### PR TITLE
Fix broken link from Getting Started to Setup by making it relative

### DIFF
--- a/tools/x-docs/src/docs/guides/apps/getting-started.md
+++ b/tools/x-docs/src/docs/guides/apps/getting-started.md
@@ -26,4 +26,4 @@
 
 ## Slightly slower start
 
-Read the [Full Setup](/tools/x-docs/src/docs/guides/apps/setup.md) guide next.
+Read the [Full Setup](/setup.md) guide next.


### PR DESCRIPTION
 🐿 v2.8.0