### PR TITLE
Remove initialState from actions

### DIFF
--- a/components/x-interaction/src/InteractionClass.jsx
+++ b/components/x-interaction/src/InteractionClass.jsx
@@ -23,7 +23,7 @@ export class InteractionClass extends Component {
 				});
 
 				Promise.resolve(
-					func(props.initialState, ...args)
+					func(...args)
 				).then(
 					next => {
 						this.setState(next);


### PR DESCRIPTION
it's passed in via the toplevel function. having it here is misleading