### PR TITLE
Display subheadings on the sidebar

### DIFF
--- a/tools/x-docs-2/src/components/layouts/basic.jsx
+++ b/tools/x-docs-2/src/components/layouts/basic.jsx
@@ -10,7 +10,9 @@ export default ({ title, children, sidebar }) => (
 			<Header />
 		</header>
 		<main className="site-layout__content" role="main">
-			{children}
+			<div className="site-layout__content--inner">
+				{children}
+			</div>
 		</main>
 		<div className="site-layout__sidebar" role="complementary">
 			{sidebar}

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { Link } from 'gatsby';
 
+import GithubSlugger from 'github-slugger';
+
 const createUrlFromName = (name) => {
-	return name.toLowerCase().replace(/ /g, '-').replace(/[?!:%$'.,"…:]/g, '');
+	const slugger = new GithubSlugger();
+	return slugger.slug(name)
 }
 
 const buildListItem = (item, currentNode) => {

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -29,18 +29,25 @@ const buildListItem = (item, currentNode) => {
 	);
 }
 
-const buildSubheadingsList = (menu, currentNode) => {
-	return menu.headings.map(item => {
-		if (item.depth === 2) {
-			return buildListItem(item, currentNode);
-		} else if (item.depth === 3) {
+const recursiveBulletsGenerator = (item, prevDepth, currentNode) => {
+	if (item.depth > 1) {
+		if (item.depth > prevDepth) {
 			return (
 				<ul key={item.value}>
-					{ buildListItem(item, currentNode) }
+					{ recursiveBulletsGenerator(item, prevDepth + 1, currentNode) }
 				</ul>
 			);
-		}
-		return null;
+		} else return buildListItem(item, currentNode); 
+	} else return null;
+}
+
+const buildSubheadingsList = (menu, currentNode) => {
+	return menu.headings.map(item => {
+		return (
+			<ul key={item.value}>
+				{ recursiveBulletsGenerator(item, 2, currentNode) }
+			</ul>
+		);
 	});
 }
 
@@ -52,11 +59,7 @@ const Sidebar = ({ data, title, menu, location }) => (
 				<Link to={node.path} exact activeClassName="is-active">
 					{node.context.title}
 				</Link>
-				{ menu && menu.headings.length > 0 && node.path === location ? (
-					<ul>
-						{ buildSubheadingsList(menu, node) }
-					</ul>
-				) : null }
+				{ menu && menu.headings.length > 0 && node.path === location ? buildSubheadingsList(menu, node) : null }
 			</li>
 		))}
 	</ul>

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -7,7 +7,7 @@ const createUrlFromName = (name) => {
 
 const buildListItem = (item, currentNode) => {
 	return (
-		<Link to={`${currentNode.path}#${createUrlFromName(item.value)}`}>
+		<Link to={`${currentNode.path}#${createUrlFromName(item.value)}`} key={item.value}>
 			<li>{item.value}</li>
 		</Link>
 	);
@@ -19,7 +19,7 @@ const buildSubheadingsList = (menu, currentNode) => {
 			return buildListItem(item, currentNode);
 		} else if (item.depth === 3) {
 			return (
-				<ul>
+				<ul key={item.value}>
 					{ buildListItem(item, currentNode) }
 				</ul>
 			);

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'gatsby';
 
 const createUrlFromName = (name) => {
-	return name.toLowerCase().replace(/ /g, '-');
+	return name.toLowerCase().replace(/ /g, '-').replace(/[?!:%$'.,"…:]/g, '');
 }
 
 const buildListItem = (item, currentNode) => {

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -8,7 +8,7 @@ const createUrlFromName = (name) => {
 const buildListItem = (item, currentNode) => {
 	return (
 		<Link to={`${currentNode.fields.slug}#${createUrlFromName(item.value)}`}>
-			<li>{item.value.toLowerCase()}</li>
+			<li>{item.value}</li>
 		</Link>
 	);
 }

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -13,9 +13,17 @@ const createUrlFromName = (name) => {
 	return slugger.slug(name)
 }
 
+const reactToClick = (e, link) => {
+	e.preventDefault();
+	document.querySelector(`#${link}`).scrollIntoView({
+		behavior: 'smooth'
+	});
+}
+
 const buildListItem = (item, currentNode) => {
+	const url = createUrlFromName(item.value);
 	return (
-		<Link to={`${currentNode.path}#${createUrlFromName(item.value)}`} key={item.value}>
+		<Link to={`${currentNode.path}#${url}`} key={item.value} onClick={(e) => reactToClick(e, url)}>
 			<li>{item.value}</li>
 		</Link>
 	);

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -14,8 +14,7 @@ const buildListItem = (item, currentNode) => {
 }
 
 const buildSubheadingsList = (menu, currentNode) => {
-	const currentMenu = menu.filter(item => item.node.headings.length > 0 && item.node.headings[0].value === currentNode.context.title)[0].node.headings;
-	return currentMenu.map(item => {
+	return menu.headings.map(item => {
 		if (item.depth === 2) {
 			return buildListItem(item, currentNode);
 		} else if (item.depth === 3) {
@@ -32,12 +31,12 @@ const buildSubheadingsList = (menu, currentNode) => {
 const Sidebar = ({ data, title, menu }) => (
 	<ul className="site-sidebar">
 		<li className="site-sidebar__item site-sidebar__item--title">{title}</li>
-		{data.map(({ node }, i) => (
+		{ data.map(({ node }, i) => (
 			<li key={`list-${i}`} className="site-sidebar__item site-sidebar__item--link">
 				<Link to={node.path} exact activeClassName="is-active">
 					{node.context.title}
 				</Link>
-				{ menu && node.path === document.location.pathname ? (
+				{ menu && menu.headings.length > 0 && node.path === document.location.pathname ? (
 					<ul>
 						{ buildSubheadingsList(menu, node) }
 					</ul>

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -28,15 +28,15 @@ const buildSubheadingsList = (menu, currentNode) => {
 	});
 }
 
-const Sidebar = ({ data, title, menu }) => (
+const Sidebar = ({ data, title, menu, pageContext }) => (
 	<ul className="site-sidebar">
-		<li className="site-sidebar__item site-sidebar__item--title">{title}</li>
+		<li className="site-sidebar__item site-sidebar__item--title">{title || pageContext.source}</li>
 		{ data.map(({ node }, i) => (
 			<li key={`list-${i}`} className="site-sidebar__item site-sidebar__item--link">
 				<Link to={node.path} exact activeClassName="is-active">
 					{node.context.title}
 				</Link>
-				{ menu && menu.headings.length > 0 && node.path === document.location.pathname ? (
+				{ menu && menu.headings.length > 0 && pageContext && pageContext.source && pageContext.title && node.path === `/${pageContext.source}/${pageContext.title}` ? (
 					<ul>
 						{ buildSubheadingsList(menu, node) }
 					</ul>

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -1,7 +1,35 @@
 import React from 'react';
 import { Link } from 'gatsby';
 
-const List = ({ data, title }) => (
+const createUrlFromName = (name) => {
+	return name.toLowerCase().replace(/ /g, '-');
+}
+
+const buildListItem = (item, currentNode) => {
+	return (
+		<Link to={`${currentNode.fields.slug}#${createUrlFromName(item.value)}`}>
+			<li>{item.value}</li>
+		</Link>
+	);
+}
+
+const buildSubheadingsList = (menu, currentNode) => {
+	const currentMenu = menu.filter(item => item.node.headings[0].value === currentNode.name)[0].node.headings;
+	return currentMenu.map(item => {
+		if (item.depth === 2) {
+			return buildListItem(item, currentNode);
+		} else if (item.depth === 3) {
+			return (
+				<ul>
+					{ buildListItem(item, currentNode) }
+				</ul>
+			);
+		}
+		return null;
+	});
+}
+
+const Sidebar = ({ data, title, menu }) => (
 	<ul className="site-sidebar">
 		<li className="site-sidebar__item site-sidebar__item--title">{title}</li>
 		{data.map(({ node }, i) => (
@@ -9,9 +37,14 @@ const List = ({ data, title }) => (
 				<Link to={node.fields.slug} exact activeClassName="is-active">
 					{node.name}
 				</Link>
+				{ menu && node.fields.slug === document.location.pathname ? (
+					<ul>
+						{ buildSubheadingsList(menu, node) }
+					</ul>
+				) : null }
 			</li>
 		))}
 	</ul>
 );
 
-export default List;
+export default Sidebar;

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -36,15 +36,15 @@ const buildSubheadingsList = (menu, currentNode) => {
 	});
 }
 
-const Sidebar = ({ data, title, menu, pageContext }) => (
+const Sidebar = ({ data, title, menu, location }) => (
 	<ul className="site-sidebar">
-		<li className="site-sidebar__item site-sidebar__item--title">{title || pageContext.source}</li>
+		<li className="site-sidebar__item site-sidebar__item--title">{title}</li>
 		{ data.map(({ node }, i) => (
 			<li key={`list-${i}`} className="site-sidebar__item site-sidebar__item--link">
 				<Link to={node.path} exact activeClassName="is-active">
 					{node.context.title}
 				</Link>
-				{ menu && menu.headings.length > 0 && pageContext && pageContext.source && pageContext.title && node.path === `/${pageContext.source}/${pageContext.title}` ? (
+				{ menu && menu.headings.length > 0 && node.path === location ? (
 					<ul>
 						{ buildSubheadingsList(menu, node) }
 					</ul>

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -20,10 +20,10 @@ const reactToClick = (e, link) => {
 	});
 }
 
-const buildListItem = (item, currentNode) => {
+const buildListItem = (item) => {
 	const url = createUrlFromName(item.value);
 	return (
-		<Link to={`${currentNode.path}#${url}`} key={item.value} onClick={(e) => reactToClick(e, url)}>
+		<Link to={`#${url}`} key={item.value} onClick={(e) => reactToClick(e, url)}>
 			<li>{item.value}</li>
 		</Link>
 	);

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -7,14 +7,14 @@ const createUrlFromName = (name) => {
 
 const buildListItem = (item, currentNode) => {
 	return (
-		<Link to={`${currentNode.fields.slug}#${createUrlFromName(item.value)}`}>
+		<Link to={`${currentNode.path}#${createUrlFromName(item.value)}`}>
 			<li>{item.value}</li>
 		</Link>
 	);
 }
 
 const buildSubheadingsList = (menu, currentNode) => {
-	const currentMenu = menu.filter(item => item.node.headings[0].value === currentNode.name)[0].node.headings;
+	const currentMenu = menu.filter(item => item.node.headings.length > 0 && item.node.headings[0].value === currentNode.context.title)[0].node.headings;
 	return currentMenu.map(item => {
 		if (item.depth === 2) {
 			return buildListItem(item, currentNode);
@@ -37,7 +37,7 @@ const Sidebar = ({ data, title, menu }) => (
 				<Link to={node.path} exact activeClassName="is-active">
 					{node.context.title}
 				</Link>
-				{ menu && node.fields.slug === document.location.pathname ? (
+				{ menu && node.path === document.location.pathname ? (
 					<ul>
 						{ buildSubheadingsList(menu, node) }
 					</ul>

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -8,7 +8,7 @@ const createUrlFromName = (name) => {
 const buildListItem = (item, currentNode) => {
 	return (
 		<Link to={`${currentNode.fields.slug}#${createUrlFromName(item.value)}`}>
-			<li>{item.value}</li>
+			<li>{item.value.toLowerCase()}</li>
 		</Link>
 	);
 }

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -5,6 +5,11 @@ import GithubSlugger from 'github-slugger';
 
 const createUrlFromName = (name) => {
 	const slugger = new GithubSlugger();
+	// As slugger checks if it is not duplicating created urls, like this:
+	// const slugger = new GithubSlugger();
+	// slugger.slug('url one') // url-one
+	// slugger.slug('url one') // url-one-2
+	// therefore there is a need to create a new class instance every time when the function is applied
 	return slugger.slug(name)
 }
 

--- a/tools/x-docs-2/src/components/sidebar/module-list.jsx
+++ b/tools/x-docs-2/src/components/sidebar/module-list.jsx
@@ -13,17 +13,16 @@ const createUrlFromName = (name) => {
 	return slugger.slug(name)
 }
 
-const reactToClick = (e, link) => {
+const reactToClick = (e) => {
 	e.preventDefault();
-	document.querySelector(`#${link}`).scrollIntoView({
+	document.querySelector(e.currentTarget.hash).scrollIntoView({
 		behavior: 'smooth'
 	});
 }
 
 const buildListItem = (item) => {
-	const url = createUrlFromName(item.value);
 	return (
-		<Link to={`#${url}`} key={item.value} onClick={(e) => reactToClick(e, url)}>
+		<Link to={`#${createUrlFromName(item.value)}`} key={item.value} onClick={reactToClick}>
 			<li>{item.value}</li>
 		</Link>
 	);

--- a/tools/x-docs-2/src/lib/create-npm-package-pages.js
+++ b/tools/x-docs-2/src/lib/create-npm-package-pages.js
@@ -31,6 +31,7 @@ module.exports = async (actions, graphql) => {
 			context: {
 				type: `npm-package-${node.fields.source}`,
 				title: node.name.replace('@financial-times/', ''),
+				source: node.fields.source,
 				packageName: node.manifest.name,
 				packageDescription: node.manifest.description,
 				// Associate readme and story nodes via slug

--- a/tools/x-docs-2/src/templates/npm-package.jsx
+++ b/tools/x-docs-2/src/templates/npm-package.jsx
@@ -7,7 +7,12 @@ const Template = ({ pageContext, data }) => {
 	return (
 		<Layout
 			title={pageContext.title}
-			sidebar={<Sidebar data={data.relatedContent.edges} title={pageContext.source} />}>
+			sidebar={
+				<Sidebar data={data.relatedContent.edges}
+					title={pageContext.source}
+					menu={data.menu.edges}
+				/>
+			} >
 			<div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
 		</Layout>
 	);

--- a/tools/x-docs-2/src/templates/npm-package.jsx
+++ b/tools/x-docs-2/src/templates/npm-package.jsx
@@ -16,7 +16,8 @@ const Template = ({ pageContext, data }) => {
 			sidebar={
 				<Sidebar data={data.allSitePage.edges}
 					menu={data.markdownRemark}
-					pageContext={pageContext}
+					location={`/${pageContext.source}/${pageContext.title}`}
+					title={pageContext.source}
 				/>
 			} >
 			<div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />

--- a/tools/x-docs-2/src/templates/npm-package.jsx
+++ b/tools/x-docs-2/src/templates/npm-package.jsx
@@ -35,5 +35,18 @@ export const pageQuery = graphql`
 				}
 			}
 		}
+		menu: allMarkdownRemark(
+			filter: { fields: { source: { eq: $source } } }
+		) {
+			edges {
+				node {
+					id
+					headings {
+						value
+						depth
+					}
+				}
+			}
+		}
 	}
 `;

--- a/tools/x-docs-2/src/templates/npm-package.jsx
+++ b/tools/x-docs-2/src/templates/npm-package.jsx
@@ -16,7 +16,7 @@ const Template = ({ pageContext, data }) => {
 			sidebar={
 				<Sidebar data={data.allSitePage.edges}
 					title={pageContext.source}
-					menu={data.menu.edges}
+					menu={data.markdownRemark}
 				/>
 			} >
 			<div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
@@ -35,6 +35,10 @@ export const pageQuery = graphql`
 		}
 		markdownRemark(fields: { slug: { eq: $readmePath } }) {
 			html
+			headings {
+				value
+				depth
+			}
 		}
 		stories(fields: { slug: { eq: $storiesPath } }) {
 			stories
@@ -47,19 +51,6 @@ export const pageQuery = graphql`
 					path
 					context {
 						title
-					}
-				}
-			}
-		}
-		menu: allMarkdownRemark(
-			skip: 0
-		) {
-			edges {
-				node {
-					id
-					headings {
-						value
-						depth
 					}
 				}
 			}

--- a/tools/x-docs-2/src/templates/npm-package.jsx
+++ b/tools/x-docs-2/src/templates/npm-package.jsx
@@ -15,8 +15,8 @@ const Template = ({ pageContext, data }) => {
 			title={pageContext.title}
 			sidebar={
 				<Sidebar data={data.allSitePage.edges}
-					title={pageContext.source}
 					menu={data.markdownRemark}
+					pageContext={pageContext}
 				/>
 			} >
 			<div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />

--- a/tools/x-docs-2/src/templates/npm-package.jsx
+++ b/tools/x-docs-2/src/templates/npm-package.jsx
@@ -14,12 +14,11 @@ const Template = ({ pageContext, data }) => {
 		<Layout
 			title={pageContext.title}
 			sidebar={
-				<Sidebar data={data.relatedContent.edges}
+				<Sidebar data={data.allSitePage.edges}
 					title={pageContext.source}
 					menu={data.menu.edges}
 				/>
 			} >
-			sidebar={<Sidebar data={data.allSitePage.edges} title={pageContext.source} />}>
 			<div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
 			<h2>Stories:</h2>
 			{data.stories ? <ListStories stories={data.stories.stories} /> : null}
@@ -53,7 +52,7 @@ export const pageQuery = graphql`
 			}
 		}
 		menu: allMarkdownRemark(
-			filter: { fields: { source: { eq: $source } } }
+			skip: 0
 		) {
 			edges {
 				node {

--- a/tools/x-docs-2/static/main.css
+++ b/tools/x-docs-2/static/main.css
@@ -217,8 +217,12 @@ pre code {
 
 	.site-layout__content {
 		grid-area: main;
-		max-width: var(--container-readable);
+		max-width: 100%;
 		margin: 0 auto;
+		padding: 0;
+	}
+
+	.site-layout__content--inner {
 		padding: 20px;
 	}
 

--- a/tools/x-docs-2/static/main.css
+++ b/tools/x-docs-2/static/main.css
@@ -549,6 +549,7 @@ pre code {
 	margin: 0;
 	font-size: 16px;
 	font-weight: normal;
+	line-height: 2.6em;
 }
 
 .module-list__item-link p {

--- a/tools/x-docs-2/static/main.css
+++ b/tools/x-docs-2/static/main.css
@@ -348,6 +348,7 @@ pre code {
 .site-sidebar__item ul li {
 	opacity: 0.3;
 	font-style: italic;
+	text-transform: lowercase;
 }
 
 .site-sidebar__item a:hover,

--- a/tools/x-docs-2/static/main.css
+++ b/tools/x-docs-2/static/main.css
@@ -345,6 +345,11 @@ pre code {
 	opacity: 0.65;
 }
 
+.site-sidebar__item ul li {
+	opacity: 0.3;
+	font-style: italic;
+}
+
 .site-sidebar__item a:hover,
 .site-sidebar__item a:focus,
 .site-sidebar__item a.is-active {


### PR DESCRIPTION
## What is does
Displays subheadings on the sidebar, like this:
<img width="302" alt="screen shot 2018-08-08 at 22 22 40" src="https://user-images.githubusercontent.com/10063385/43865566-d831890a-9b5a-11e8-8208-40b002f29877.png">

<img width="301" alt="screen shot 2018-08-13 at 18 47 47" src="https://user-images.githubusercontent.com/10063385/44048507-6e4121d6-9f29-11e8-83be-c9a06c45e1c3.png">

## How it works
Gets markdown information via query using `allMarkdownRemark` function, and then displays it in relevant places.
 - Any depth is displayed, let's hope if stays visually appealing
 - Every subheading is a link to corresponding part of the text (transitions are smoooooth)
 - We can see subheadings of the active heading only