### PR TITLE
Document how to configure `n-ui` to support `x-engine` .jsx files on the client side

### DIFF
--- a/packages/x-engine/readme.md
+++ b/packages/x-engine/readme.md
@@ -119,6 +119,26 @@ export default const TeaserList = (props) => (
 );
 ```
 
+#### Client-side through n-ui
+In order to configure n-ui to compile x-dash based `.jsx` files you will also need to add the following to `n-ui-build.config.js`.
+
+```js
+// n-ui-build.config.js
+const xEngine = require('@financial-times/x-engine/src/webpack');
+
+module.exports = {
+	plugins: [
+		xEngine()
+	],
+	pragma: 'h'
+};
+```
+
+You will also need to import `h` from `x-engine` at the top of each `.jsx` file.
+```javascript
+import {h} from '@financial-times/x-engine'
+```
+
 ## FAQ
 
 ### This sounds complicated… is it a magic black box?


### PR DESCRIPTION
# Document how to configure n-ui to support x-engine .jsx files on the client side

## What
_**This is a documentation change.**_
This adds documentation describing how to configure [n-ui](https://github.com/Financial-Times/n-ui) to compile `x-engine` based `.jsx` files for use on the client side.

## Why
Because [n-ui](https://github.com/Financial-Times/n-ui) means that consuming projects webpack configs are a step removed from them, it means that these project require a slightly different configuration.

## Actual process for supporting on n-ui
In order to configure n-ui to compile x-dash based `.jsx` files you will also need to add the following to `n-ui-build.config.js`.
 ```js
// n-ui-build.config.js
const xEngine = require('@financial-times/x-engine/src/webpack');
 module.exports = {
	plugins: [
		xEngine()
	],
	pragma: 'h'
};
```
 You will also need to import `h` from `x-engine` at the top of each `.jsx` file.
```javascript
import {h} from '@financial-times/x-engine'
```