### PR TITLE
add testURL property

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	testURL: 'http://localhost/',
+	testURL: 'https://local.ft.com/',
 	testMatch: ['**/__tests__/**/*.test.js'],
 	testPathIgnorePatterns: ['/node_modules/', '/bower_components/']
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	testURL: 'http://localhost/',
 	testMatch: ['**/__tests__/**/*.test.js'],
 	testPathIgnorePatterns: ['/node_modules/', '/bower_components/']
 };


### PR DESCRIPTION
Adds the `testURL` property to the Jest config. To fix the following error with the latest version of JSDom. (Further details https://github.com/facebook/jest/issues/6766)
```
FAIL
● Test suite failed to run

SecurityError: localStorage is not available for opaque origins at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
      at Array.forEach (<anonymous>)
```