### PR TITLE
Add space after relative time prefix

### DIFF
--- a/components/x-teaser/src/RelativeTime.jsx
+++ b/components/x-teaser/src/RelativeTime.jsx
@@ -21,7 +21,7 @@ export default ({ publishedDate, firstPublishedDate }) => {
 
 	return isRecent(relativeDate) ? (
 		<div className={`o-teaser__timestamp o-teaser__timestamp--${status}`}>
-			{status ? <span className="o-teaser__timestamp-prefix">{status} </span> : null}
+			{status ? <span className="o-teaser__timestamp-prefix">{`${status} `} </span> : null}
 			<time
 				className="o-teaser__timestamp-date o-date"
 				data-o-component="o-date"

--- a/components/x-teaser/src/RelativeTime.jsx
+++ b/components/x-teaser/src/RelativeTime.jsx
@@ -21,7 +21,7 @@ export default ({ publishedDate, firstPublishedDate }) => {
 
 	return isRecent(relativeDate) ? (
 		<div className={`o-teaser__timestamp o-teaser__timestamp--${status}`}>
-			{status ? <span className="o-teaser__timestamp-prefix">{status}</span> : null}
+			{status ? <span className="o-teaser__timestamp-prefix">{status} </span> : null}
 			<time
 				className="o-teaser__timestamp-date o-date"
 				data-o-component="o-date"


### PR DESCRIPTION
Add a space after the prefix text for relative timestamps, as they are currently bunched together.

Is currently: 

<img width="898" alt="screen shot 2018-08-21 at 14 04 54" src="https://user-images.githubusercontent.com/1978880/44403045-4f844980-a54b-11e8-9129-ea13f6ee821b.png">

