### PR TITLE
Add XXL as an image size

### DIFF
--- a/components/x-teaser/Props.d.ts
+++ b/components/x-teaser/Props.d.ts
@@ -9,7 +9,7 @@ export type Theme = 'extra-article';
 
 export type Modifier = 'stacked' | 'centre' | 'stretched' | 'opinion-background' | 'landscape' | 'big-story' | string;
 
-export type ImageSize = 'XS' | 'Small' | 'Medium' | 'Large' | 'XL';
+export type ImageSize = 'XS' | 'Small' | 'Medium' | 'Large' | 'XL' | 'XXL';
 
 export interface Features {
 	showMeta: boolean;

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -156,7 +156,7 @@ Property             | Type                 | Notes
 Property        | Type                  | Notes
 ----------------|-----------------------|--------------------------------
 `image`         | [media](#media-props) |
-`imageSize`     | String                | XS, Small, Medium, Large, or XL
+`imageSize`     | String                | XS, Small, Medium, Large, XL or XXL
 `imageLazyload` | Boolean, String       | Output image with `data-src` attribute. If this is a string it will be appended to the image as a class name.
 
 [nimg]: https://github.com/Financial-Times/n-image/

--- a/components/x-teaser/src/concerns/constants.js
+++ b/components/x-teaser/src/concerns/constants.js
@@ -4,7 +4,8 @@ export const ImageSizes = {
 	Small: 240,
 	Medium: 340,
 	Large: 420,
-	XL: 640
+	XL: 640,
+	XXL: 1180 // max width of FT.com page
 };
 
 export const Layouts = {

--- a/components/x-teaser/stories/knobs.js
+++ b/components/x-teaser/stories/knobs.js
@@ -121,7 +121,7 @@ module.exports = (data, { object, text, number, boolean, date, selectV2 }) => {
 			};
 		},
 		imageSize() {
-			return selectV2('Image size', ['XS', 'Small', 'Medium', 'Large', 'XL'], data.imageSize, Groups.Image);
+			return selectV2('Image size', ['XS', 'Small', 'Medium', 'Large', 'XL', 'XXL'], data.imageSize, Groups.Image);
 		}
 	};
 


### PR DESCRIPTION
 🐿 v2.10.2

Adds a new image size of width 1180px (which is the max width the content goes on www.ft.com).
The large hero image on https://www.ft.com/life-arts is full width, and looks bad with a 640px image.

Not making XXL the preset size for HeroOverlay because it's also used in smaller contexts.