### PR TITLE
Storyboard knobs not working for x-interactive wrapped component

### DIFF
--- a/components/x-increment/stories/async.js
+++ b/components/x-increment/stories/async.js
@@ -1,10 +1,14 @@
 exports.title = 'Async';
 
-exports.data = {
+const data = {
 	count: 1,
 	timeout: 1000,
 	id: 'base-increment-static-id',
 };
+
+exports.data = data;
+
+exports.knobs = Object.keys(data);
 
 // This reference is only required for hot module loading in development
 // <https://webpack.js.org/concepts/hot-module-replacement/>

--- a/components/x-increment/stories/index.js
+++ b/components/x-increment/stories/index.js
@@ -6,3 +6,5 @@ exports.stories = [
 	require('./increment'),
 	require('./async'),
 ];
+
+exports.knobs = require('./knobs');

--- a/components/x-increment/stories/knobs.js
+++ b/components/x-increment/stories/knobs.js
@@ -1,0 +1,7 @@
+module.exports = (data, { number }) => {
+	return {
+		count() {
+			return number('Count', data.count, {});
+		}
+	};
+};


### PR DESCRIPTION
Demonstrating a problem I've run into.

When a component with knobs is made interactive, editing the knobs in Storybook no longer causes the component to be updated 'live'.

I ran into this with `x-article-save-button`, but it's more simply demonstrated with `x-increment`