### PR TITLE
Set up podcast story and add isPodcast indicator (added to es interfa…

### DIFF
--- a/components/x-teaser/Props.d.ts
+++ b/components/x-teaser/Props.d.ts
@@ -133,6 +133,7 @@ export interface Indicators {
 	accessLevel: 'premium' | 'subscribed' | 'registered' | 'free';
 	isOpinion?: boolean;
 	isColumn?: boolean;
+	isPodcast?: boolean;
 	/** Methode packaging options */
 	isEditorsChoice?: boolean;
 	isExclusive?: boolean;

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -247,6 +247,7 @@ Property           | Type    | Notes
 `accessLevel`      | String  | "premium", "subscribed", "registered", or "free"
 `isOpinion`        | Boolean |
 `isColumn`         | Boolean |
+`isPodcast`        | Boolean |
 `isEditorsChoice`  | Boolean |
 `isExclusive`      | Boolean |
 `isScoop`          | Boolean |

--- a/components/x-teaser/stories/index.js
+++ b/components/x-teaser/stories/index.js
@@ -15,6 +15,7 @@ exports.dependencies = {
 
 exports.stories = [
 	require('./article'),
+	require('./podcast'),
 	require('./opinion'),
 	require('./package'),
 	require('./package-item'),

--- a/components/x-teaser/stories/knobs.js
+++ b/components/x-teaser/stories/knobs.js
@@ -158,6 +158,7 @@ module.exports = (data, { object, text, number, boolean, date, selectV2 }) => {
 				accessLevel: selectV2('Access level', ['free', 'registered', 'subscribed', 'premium'], data.indicators.accessLevel || 'free', Groups.Indicators),
 				isOpinion: boolean('Is opinion', data.indicators.isOpinion, Groups.Indicators),
 				isColumn: boolean('Is column', data.indicators.isColumn, Groups.Indicators),
+				isPodcast: boolean('Is podcast', data.indicators.isPodcast, Groups.Indicators),
 				isEditorsChoice: boolean('Is editor\'s choice', data.indicators.isEditorsChoice, Groups.Indicators),
 				isExclusive: boolean('Is exclusive', data.indicators.isExclusive, Groups.Indicators),
 				isScoop: boolean('Is scoop', data.indicators.isScoop, Groups.Indicators)

--- a/components/x-teaser/stories/podcast.js
+++ b/components/x-teaser/stories/podcast.js
@@ -1,0 +1,73 @@
+const { presets } = require('../');
+
+exports.title = 'Podcast';
+
+// This data will provide defaults for the Knobs defined below and used
+// to render examples in the documentation site.
+exports.data = Object.assign({
+	type: 'audio',
+	id: 'd1246074-f7d3-4aaf-951c-80a6db495765',
+	url: 'https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765',
+	title: 'Who sets the internet standards?',
+	standfirst: '',
+	altStandfirst: '',
+	publishedDate: '2018-10-24T04:00:00.000Z',
+	firstPublishedDate: '2018-10-24T04:00:00.000Z',
+	metaPrefixText: 'Podcast',
+	metaSuffixText: '',
+	metaLink: {
+		url: '#',
+		prefLabel: 'Tech Tonic podcast'
+	},
+	metaAltLink: null,
+	image: {
+		url: 'https://thumborcdn.acast.com/pKDW6uGdnSFB0lH8iZYb8LAumyk=/1500x1500/https://mediacdn.acast.com/assets/d1246074-f7d3-4aaf-951c-80a6db495765/cover-image-jnm16b8a-tt_limbago_1400.jpg',
+		width: 1500,
+		height: 1500
+	},
+	indicators: {
+		"isPodcast":true
+	}
+}, presets.SmallHeavy);
+
+// A list of properties to pass to the component when rendered in Storybook. If a Knob
+// exists for the property then it will be editable with the default as defined above.
+exports.knobs = [
+	'id',
+	'url',
+	'type',
+	// Meta
+	'showMeta',
+	'metaPrefixText',
+	'metaSuffixText',
+	'metaLink',
+	// Title
+	'showTitle',
+	'title',
+	'altTitle',
+	// Standfirst
+	'showStandfirst',
+	'standfirst',
+	'altStandfirst',
+	// Status
+	'showStatus',
+	'publishedDate',
+	'firstPublishedDate',
+	'useRelativeTime',
+	'status',
+	// Image
+	'showImage',
+	'image',
+	'imageSize',
+	// Indicators
+	'indicators',
+	// Context
+	'headlineTesting',
+	// Variants
+	'layout',
+	'modifiers',
+];
+
+// This reference is only required for hot module loading in development
+// <https://webpack.js.org/concepts/hot-module-replacement/>
+exports.m = module;


### PR DESCRIPTION
Add the story data that we would get for a podcast / audio article

ES Interface isPodcast indicator:
https://github.com/Financial-Times/next-es-interface/blob/8982c96c901dd9e95df5846e27297defc7211395/server/transformers/plugins/audio/teaser.js#L15