### PR TITLE
Add isPodcast indicator

### DIFF
--- a/components/x-teaser/Props.d.ts
+++ b/components/x-teaser/Props.d.ts
@@ -133,6 +133,7 @@ export interface Indicators {
 	accessLevel: 'premium' | 'subscribed' | 'registered' | 'free';
 	isOpinion?: boolean;
 	isColumn?: boolean;
+	isPodcast?: boolean;
 	/** Methode packaging options */
 	isEditorsChoice?: boolean;
 	isExclusive?: boolean;

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -247,6 +247,7 @@ Property           | Type    | Notes
 `accessLevel`      | String  | "premium", "subscribed", "registered", or "free"
 `isOpinion`        | Boolean |
 `isColumn`         | Boolean |
+`isPodcast`        | Boolean |
 `isEditorsChoice`  | Boolean |
 `isExclusive`      | Boolean |
 `isScoop`          | Boolean |

--- a/components/x-teaser/stories/knobs.js
+++ b/components/x-teaser/stories/knobs.js
@@ -158,6 +158,7 @@ module.exports = (data, { object, text, number, boolean, date, selectV2 }) => {
 				accessLevel: selectV2('Access level', ['free', 'registered', 'subscribed', 'premium'], data.indicators.accessLevel || 'free', Groups.Indicators),
 				isOpinion: boolean('Is opinion', data.indicators.isOpinion, Groups.Indicators),
 				isColumn: boolean('Is column', data.indicators.isColumn, Groups.Indicators),
+				isPodcast: boolean('Is podcast', data.indicators.isPodcast, Groups.Indicators),
 				isEditorsChoice: boolean('Is editor\'s choice', data.indicators.isEditorsChoice, Groups.Indicators),
 				isExclusive: boolean('Is exclusive', data.indicators.isExclusive, Groups.Indicators),
 				isScoop: boolean('Is scoop', data.indicators.isScoop, Groups.Indicators)


### PR DESCRIPTION
ES Interface isPodcast indicator:
https://github.com/Financial-Times/next-es-interface/blob/8982c96c901dd9e95df5846e27297defc7211395/server/transformers/plugins/audio/teaser.js#L15