### PR TITLE
Make `x-rollup`, `x-babel-config`, `x-test-utils` publishable

### DIFF
--- a/packages/x-babel-config/package.json
+++ b/packages/x-babel-config/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@financial-times/x-babel-config",
-  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/x-rollup/package.json
+++ b/packages/x-rollup/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@financial-times/x-rollup",
   "version": "0.0.0",
-  "private": true,
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/x-test-utils/package.json
+++ b/packages/x-test-utils/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@financial-times/x-test-utils",
-  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "enzyme.js",


### PR DESCRIPTION
# Make `x-rollup`, `x-babel-config`, `x-test-utils` publishable

## What
Removes private from `x-rollup`, `x-babel-config` and `x-test-utils` so that these can be used in non-x projects.

## Why
Will allow the publishing of these tooling libraries for use by x-like (jsx) projects elsewhere in the ft-ecosystem that might not be stable enough to be promoted to x-dash.

