### PR TITLE
Add a 'className' prop so consumers can add additional classes

### DIFF
--- a/components/x-follow-button/readme.md
+++ b/components/x-follow-button/readme.md
@@ -94,4 +94,5 @@ Feature                   | Type    | Required | Default value  | Description
 `isFollowed`              | Boolean | no       | `false`        | Whether the concept is followed or not.
 `csrfToken`               | String  | no       | none           | value included in a hidden form field.
 `variant`                 | String  | no       | `standard`     | One of `standard`, `inverse`, `opinion` or `monochrome`. Other values will be ignored.
+`className`               | String  | no       | none           | Additional classNames to add to the <form> element.
 `followPlusDigestEmail`   | Boolean | no       | `false`        | Whether following the topic should also subscribe to the digest.

--- a/components/x-follow-button/src/FollowButton.jsx
+++ b/components/x-follow-button/src/FollowButton.jsx
@@ -10,7 +10,8 @@ export const FollowButton = (props) => {
 		isFollowed,
 		csrfToken,
 		followPlusDigestEmail,
-		variant
+		variant,
+		className
 	} = props;
 	const VARIANTS = ['standard', 'inverse', 'opinion', 'monochrome'];
 
@@ -40,6 +41,7 @@ export const FollowButton = (props) => {
 			method="GET"
 			data-concept-id={conceptId}
 			action={getFormAction()}
+			className={className}
 			onSubmit={event => {
 				event.preventDefault();
 				const detail = {


### PR DESCRIPTION
__Please note this PR is only to merge into the component branch, not master__

This prop has been added because, for example, the app needs an 'online-only' class name for these components.