### PR TITLE
Fetch suggestions include followed topics

### DIFF
--- a/components/x-topic-search/__tests__/__snapshots__/x-topic-search.test.jsx.snap
+++ b/components/x-topic-search/__tests__/__snapshots__/x-topic-search.test.jsx.snap
@@ -42,12 +42,18 @@ exports[`x-topic-search given all topics include search term are followed should
         <b>
           abcd
         </b>
+        , 
+      </span>
+      <span>
+        <b>
+          abcde
+        </b>
          
       </span>
       <span>
         and 
         <b>
-          abcde
+          abcdef
         </b>
       </span>
     </div>

--- a/components/x-topic-search/__tests__/__snapshots__/x-topic-search.test.jsx.snap
+++ b/components/x-topic-search/__tests__/__snapshots__/x-topic-search.test.jsx.snap
@@ -40,14 +40,14 @@ exports[`x-topic-search given all topics include search term are followed should
       You already follow 
       <span>
         <b>
-          abcc
+          abcd
         </b>
          
       </span>
       <span>
         and 
         <b>
-          abccd
+          abcde
         </b>
       </span>
     </div>
@@ -103,7 +103,7 @@ exports[`x-topic-search given there are unfollowed topics include search term sh
           data-trackable="topic-link"
           href="TOPIC-1__url"
         >
-          TOPIC-1__name
+          abcd
         </a>
         <form
           action="/__myft/api/core/followed/concept/TOPIC-1__id?method=put"
@@ -111,12 +111,12 @@ exports[`x-topic-search given there are unfollowed topics include search term sh
           method="GET"
         >
           <button
-            aria-label="Add TOPIC-1__name to myFT"
+            aria-label="Add abcd to myFT"
             aria-pressed="false"
             class="main_button__3Mk67"
             data-concept-id="TOPIC-1__id"
             data-trackable="follow"
-            title="Add TOPIC-1__name to myFT"
+            title="Add abcd to myFT"
             type="submit"
           >
             Add to myFT
@@ -134,7 +134,7 @@ exports[`x-topic-search given there are unfollowed topics include search term sh
           data-trackable="topic-link"
           href="TOPIC-2__url"
         >
-          TOPIC-2__name
+          abcde
         </a>
         <form
           action="/__myft/api/core/followed/concept/TOPIC-2__id?method=put"
@@ -142,12 +142,12 @@ exports[`x-topic-search given there are unfollowed topics include search term sh
           method="GET"
         >
           <button
-            aria-label="Add TOPIC-2__name to myFT"
+            aria-label="Add abcde to myFT"
             aria-pressed="false"
             class="main_button__3Mk67"
             data-concept-id="TOPIC-2__id"
             data-trackable="follow"
-            title="Add TOPIC-2__name to myFT"
+            title="Add abcde to myFT"
             type="submit"
           >
             Add to myFT

--- a/components/x-topic-search/__tests__/x-topic-search.test.jsx
+++ b/components/x-topic-search/__tests__/x-topic-search.test.jsx
@@ -27,7 +27,7 @@ describe('x-topic-search', () => {
 
 	describe('given there are unfollowed topics include search term', () => {
 		it('should render the unfollowed topics list with x-follow-button', async () => {
-			fetchMock.get(fetchUrl, [ topicOne, topicTwo]);
+			fetchMock.get(fetchUrl, [ topicOne, topicTwo ]);
 
 			const subject = mount(<TopicSearch {...props}/>);
 			const input = subject.find('input');
@@ -53,7 +53,7 @@ describe('x-topic-search', () => {
 		it('should render followed topics name list', async () => {
 			props.followedTopicIds = [ topicOne.id, topicTwo.id, topicThree.id ];
 
-			fetchMock.get(fetchUrl, [ topicOne, topicTwo, topicThree]);
+			fetchMock.get(fetchUrl, [ topicOne, topicTwo, topicThree ]);
 
 			const subject = mount(<TopicSearch {...props}/>);
 			const input = subject.find('input');

--- a/components/x-topic-search/__tests__/x-topic-search.test.jsx
+++ b/components/x-topic-search/__tests__/x-topic-search.test.jsx
@@ -9,6 +9,10 @@ const apiUrl = 'api-url';
 const apiUrlWithQueries = `${ apiUrl }?count=${ maxSuggestions }&partial=${ searchTerm }`;
 const props = { apiUrl, maxSuggestions };
 
+const topicOne = { id: 'TOPIC-1__id', prefLabel: `${searchTerm}d`, url:'TOPIC-1__url' };
+const topicTwo = { id: 'TOPIC-2__id', prefLabel: `${searchTerm}de`, url:'TOPIC-2__url' };
+const apiResponse = [ topicOne, topicTwo];
+
 describe('x-topic-search', () => {
 
 	let fetchUrl;
@@ -23,10 +27,6 @@ describe('x-topic-search', () => {
 
 	describe('given there are unfollowed topics include search term', () => {
 		it('should render the unfollowed topics list with x-follow-button', async () => {
-			const apiResponse = [
-				{ id: 'TOPIC-1__id', prefLabel: 'TOPIC-1__name', url:'TOPIC-1__url' },
-				{ id: 'TOPIC-2__id', prefLabel: 'TOPIC-2__name', url:'TOPIC-2__url' }
-			];
 			fetchMock.get(fetchUrl, apiResponse);
 
 			const subject = mount(<TopicSearch {...props}/>);
@@ -51,12 +51,9 @@ describe('x-topic-search', () => {
 
 	describe('given all topics include search term are followed', () => {
 		it('should render followed topics name list', async () => {
-			const followedTopicOne = { name: `${searchTerm}c`, uuid: 'FOLLOWED-TOPIC-1__id' };
-			const followedTopicTwo = { name: `${searchTerm}cd`, uuid: 'FOLLOWED-TOPIC-2__id' };
-			props.followedTopics = [ followedTopicOne, followedTopicTwo ];
+			props.followedTopicIds = [ topicOne.id, topicTwo.id ];
 
-			fetchUrl = `${ apiUrlWithQueries }&tagged=${ followedTopicOne.uuid },${ followedTopicTwo.uuid }`;
-			fetchMock.get(fetchUrl, []);
+			fetchMock.get(fetchUrl, apiResponse);
 
 			const subject = mount(<TopicSearch {...props}/>);
 			const input = subject.find('input');

--- a/components/x-topic-search/__tests__/x-topic-search.test.jsx
+++ b/components/x-topic-search/__tests__/x-topic-search.test.jsx
@@ -11,7 +11,7 @@ const props = { apiUrl, maxSuggestions };
 
 const topicOne = { id: 'TOPIC-1__id', prefLabel: `${searchTerm}d`, url:'TOPIC-1__url' };
 const topicTwo = { id: 'TOPIC-2__id', prefLabel: `${searchTerm}de`, url:'TOPIC-2__url' };
-const apiResponse = [ topicOne, topicTwo];
+const topicThree = { id: 'TOPIC-3__id', prefLabel: `${searchTerm}def`, url:'TOPIC-3__url' };
 
 describe('x-topic-search', () => {
 
@@ -27,7 +27,7 @@ describe('x-topic-search', () => {
 
 	describe('given there are unfollowed topics include search term', () => {
 		it('should render the unfollowed topics list with x-follow-button', async () => {
-			fetchMock.get(fetchUrl, apiResponse);
+			fetchMock.get(fetchUrl, [ topicOne, topicTwo]);
 
 			const subject = mount(<TopicSearch {...props}/>);
 			const input = subject.find('input');
@@ -51,9 +51,9 @@ describe('x-topic-search', () => {
 
 	describe('given all topics include search term are followed', () => {
 		it('should render followed topics name list', async () => {
-			props.followedTopicIds = [ topicOne.id, topicTwo.id ];
+			props.followedTopicIds = [ topicOne.id, topicTwo.id, topicThree.id ];
 
-			fetchMock.get(fetchUrl, apiResponse);
+			fetchMock.get(fetchUrl, [ topicOne, topicTwo, topicThree]);
 
 			const subject = mount(<TopicSearch {...props}/>);
 			const input = subject.find('input');

--- a/components/x-topic-search/readme.md
+++ b/components/x-topic-search/readme.md
@@ -36,10 +36,10 @@ All `x-` components are designed to be compatible with a variety of runtimes, no
 
 ### Properties
 
-Property         | Type   | Required | Note
------------------|--------|----------|------------------
-`minSearchLength`| Number | No       | Minimum chars to start search. Default is 2
-`maxSuggestions` | Number | No       | Maximum number to display suggestions. Default is 5
-`apiUrl`         | String | Yes      | The url to use when making requests to get topics
-`followedTopics` | Array  | Yes      | Each item should have `name` and `uuid` properties. Default is `[]`
-`csrfToken`      | String | Yes      | Value included in a hidden form field for x-follow-button
+Property          | Type   | Required | Note
+------------------|--------|----------|------------------
+`minSearchLength` | Number | No       | Minimum chars to start search. Default is 2
+`maxSuggestions`  | Number | No       | Maximum number to display suggestions. Default is 5
+`apiUrl`          | String | Yes      | The url to use when making requests to get topics
+`followedTopicIds`| Array  | Yes      | Array of followed topic `id`s. Default is `[]`
+`csrfToken`       | String | Yes      | Value included in a hidden form field for x-follow-button

--- a/components/x-topic-search/readme.md
+++ b/components/x-topic-search/readme.md
@@ -41,5 +41,5 @@ Property          | Type   | Required | Note
 `minSearchLength` | Number | No       | Minimum chars to start search. Default is 2
 `maxSuggestions`  | Number | No       | Maximum number to display suggestions. Default is 5
 `apiUrl`          | String | Yes      | The url to use when making requests to get topics
-`followedTopicIds`| Array  | Yes      | Array of followed topic `id`s. Default is `[]`
+`followedTopicIds`| Array  | Yes      | Array of followed topic `id`s.
 `csrfToken`       | String | Yes      | Value included in a hidden form field for x-follow-button

--- a/components/x-topic-search/src/AllFollowed.jsx
+++ b/components/x-topic-search/src/AllFollowed.jsx
@@ -10,19 +10,17 @@ const arrayToSentence = followedSuggestions => {
 		return <b>{ followedSuggestions[0].prefLabel }</b>;
 	} else {
 		return followedSuggestions
-		.map((topic, index) => {
-			if (index + 1 === topicsLength) {
-				// the last topic
-				return  <span key={ topic.id }>and <b>{ topic.prefLabel }</b></span>
-			} else {
-				if ((topicsLength - 2) === index) {
+			.map((topic, index) => {
+				if (index === topicsLength - 1) {
+					// the last topic
+					return  <span key={ topic.id }>and <b>{ topic.prefLabel }</b></span>
+				} else if (index === topicsLength - 2) {
 					// one before the last topic
 					return <span key={ topic.id }><b>{ topic.prefLabel }</b> </span>;
 				} else {
 					return <span key={ topic.id }><b>{ topic.prefLabel }</b>, </span>;
 				}
-			}
-		})
+			})
 	}
 
 };

--- a/components/x-topic-search/src/AllFollowed.jsx
+++ b/components/x-topic-search/src/AllFollowed.jsx
@@ -13,13 +13,13 @@ const arrayToSentence = followedSuggestions => {
 		.map((topic, index) => {
 			if (index + 1 === topicsLength) {
 				// the last topic
-				return  <span key={ index }>and <b>{ topic.prefLabel }</b></span>
+				return  <span key={ topic.id }>and <b>{ topic.prefLabel }</b></span>
 			} else {
 				if ((topicsLength - 2) === index) {
 					// one before the last topic
-					return <span key={ index }><b>{ topic.prefLabel }</b> </span>;
+					return <span key={ topic.id }><b>{ topic.prefLabel }</b> </span>;
 				} else {
-					return <span key={ index }><b>{ topic.prefLabel }</b>, </span>;
+					return <span key={ topic.id }><b>{ topic.prefLabel }</b>, </span>;
 				}
 			}
 		})

--- a/components/x-topic-search/src/AllFollowed.jsx
+++ b/components/x-topic-search/src/AllFollowed.jsx
@@ -3,13 +3,13 @@ import styles from './TopicSearch.scss';
 import classNames from 'classnames';
 
 // transform like this => topic1, topic2 and topic3
-const arrayToSentence = matchingFollowedTopics => {
-	const topicsLength = matchingFollowedTopics.length;
+const arrayToSentence = followedSuggestions => {
+	const topicsLength = followedSuggestions.length;
 
 	if (topicsLength === 1) {
-		return <b>{ matchingFollowedTopics[0].prefLabel }</b>;
+		return <b>{ followedSuggestions[0].prefLabel }</b>;
 	} else {
-		return matchingFollowedTopics
+		return followedSuggestions
 		.map((topic, index) => {
 			if (index + 1 === topicsLength) {
 				// the last topic
@@ -27,8 +27,8 @@ const arrayToSentence = matchingFollowedTopics => {
 
 };
 
-export default ({ matchingFollowedTopics }) => (
+export default ({ followedSuggestions }) => (
 	<div className={ classNames(styles["all-followed"]) } aria-live="polite">
-		You already follow { arrayToSentence(matchingFollowedTopics) }
+		You already follow { arrayToSentence(followedSuggestions) }
 	</div>
 );

--- a/components/x-topic-search/src/AllFollowed.jsx
+++ b/components/x-topic-search/src/AllFollowed.jsx
@@ -7,19 +7,19 @@ const arrayToSentence = matchingFollowedTopics => {
 	const topicsLength = matchingFollowedTopics.length;
 
 	if (topicsLength === 1) {
-		return <b>{ matchingFollowedTopics[0].name }</b>;
+		return <b>{ matchingFollowedTopics[0].prefLabel }</b>;
 	} else {
 		return matchingFollowedTopics
 		.map((topic, index) => {
 			if (index + 1 === topicsLength) {
 				// the last topic
-				return  <span key={ index }>and <b>{ topic.name }</b></span>
+				return  <span key={ index }>and <b>{ topic.prefLabel }</b></span>
 			} else {
 				if ((topicsLength - 2) === index) {
 					// one before the last topic
-					return <span key={ index }><b>{ topic.name }</b> </span>;
+					return <span key={ index }><b>{ topic.prefLabel }</b> </span>;
 				} else {
-					return <span key={ index }><b>{ topic.name }</b>, </span>;
+					return <span key={ index }><b>{ topic.prefLabel }</b>, </span>;
 				}
 			}
 		})

--- a/components/x-topic-search/src/SuggestionList.jsx
+++ b/components/x-topic-search/src/SuggestionList.jsx
@@ -13,7 +13,9 @@ export default ({ suggestions, searchTerm, csrfToken }) => {
 				data-concept-id={ suggestion.id }
 				data-trackable-meta={ '{"search-term":"' + searchTerm + '"}' }>
 
-				<a data-trackable="topic-link" className={ classNames(styles["suggestion__name"]) } href={ suggestion.url }>
+				<a data-trackable="topic-link"
+					className={ classNames(styles["suggestion__name"]) }
+					href={ suggestion.url || `/stream/${suggestion.id}` }>
 					{ suggestion.prefLabel }
 				</a>
 

--- a/components/x-topic-search/src/TopicSearch.jsx
+++ b/components/x-topic-search/src/TopicSearch.jsx
@@ -92,13 +92,13 @@ const TopicSearch = topicSearchActions(({ searchTerm, showResult, result, action
 		{ showResult && !isLoading &&
 			<div className={ classNames(styles['result-container']) } data-component="topic-search">
 
-					{ result.matchingUnfollowedTopics.length > 0 &&
-						<SuggestionList suggestions={ result.matchingUnfollowedTopics } searchTerm={ searchTerm } csrfToken={ csrfToken }/> }
+					{ result.unfollowedSuggestions.length > 0 &&
+						<SuggestionList suggestions={ result.unfollowedSuggestions } searchTerm={ searchTerm } csrfToken={ csrfToken }/> }
 
-					{ !result.matchingUnfollowedTopics.length && result.matchingFollowedTopics.length > 0 &&
-						<AllFollowed matchingFollowedTopics={ result.matchingFollowedTopics }/> }
+					{ !result.unfollowedSuggestions.length && result.followedSuggestions.length > 0 &&
+						<AllFollowed followedSuggestions={ result.followedSuggestions }/> }
 
-					{ !result.matchingUnfollowedTopics.length && !result.matchingFollowedTopics.length &&
+					{ !result.unfollowedSuggestions.length && !result.followedSuggestions.length &&
 						<NoSuggestions searchTerm={ searchTerm }/> }
 			</div> }
 

--- a/components/x-topic-search/src/TopicSearch.jsx
+++ b/components/x-topic-search/src/TopicSearch.jsx
@@ -91,14 +91,15 @@ const TopicSearch = topicSearchActions(({ searchTerm, showResult, result, action
 
 		{ showResult && !isLoading &&
 			<div className={ classNames(styles['result-container']) } data-component="topic-search">
-					{ result.status === 'suggestions'&&
-						<SuggestionList suggestions={ result.suggestions } searchTerm={ searchTerm } csrfToken={ csrfToken }/> }
 
-					{ result.status === 'no-suggestions' &&
-						<NoSuggestions searchTerm={ searchTerm }/> }
+					{ result.matchingUnfollowedTopics.length > 0 &&
+						<SuggestionList suggestions={ result.matchingUnfollowedTopics } searchTerm={ searchTerm } csrfToken={ csrfToken }/> }
 
-					{ result.status === 'all-followed' &&
+					{ !result.matchingUnfollowedTopics.length && result.matchingFollowedTopics.length > 0 &&
 						<AllFollowed matchingFollowedTopics={ result.matchingFollowedTopics }/> }
+
+					{ !result.matchingUnfollowedTopics.length && !result.matchingFollowedTopics.length &&
+						<NoSuggestions searchTerm={ searchTerm }/> }
 			</div> }
 
 	</div>

--- a/components/x-topic-search/src/TopicSearch.jsx
+++ b/components/x-topic-search/src/TopicSearch.jsx
@@ -10,18 +10,15 @@ import NoSuggestions from './NoSuggestions';
 import AllFollowed from './AllFollowed';
 
 const debounceGetSuggestions = debounce(getSuggestions, 150);
-const getFollowedTopicIndex = (followedTopics, targetTopicId) => (
-	followedTopics.findIndex(topic => topic && topic.conceptId || topic.uuid === targetTopicId)
-);
 
 let resultExist = false;
 
-const topicSearchActions = withActions(({ minSearchLength = 2, maxSuggestions = 5, apiUrl, followedTopics = [] }) => ({
+const topicSearchActions = withActions(({ minSearchLength = 2, maxSuggestions = 5, apiUrl, followedTopicIds = [] }) => ({
 	async checkInput(event) {
 		const searchTerm = event.target.value && event.target.value.trim();
 
 		if (searchTerm.length >= minSearchLength) {
-			return debounceGetSuggestions(searchTerm, maxSuggestions, apiUrl, followedTopics)
+			return debounceGetSuggestions(searchTerm, maxSuggestions, apiUrl, followedTopicIds)
 				.then(result => {
 					resultExist = true;
 					return { showResult: true, result, searchTerm };
@@ -37,23 +34,21 @@ const topicSearchActions = withActions(({ minSearchLength = 2, maxSuggestions = 
 	},
 
 	topicFollowed (subjectId) {
-		const followedTopicIndex = getFollowedTopicIndex(followedTopics, subjectId);
-
-		if (followedTopicIndex === -1) {
-			followedTopics.push({ uuid: subjectId })
+		if (!followedTopicIds.includes(subjectId)) {
+			followedTopicIds.push(subjectId);
 		}
 
-		return { followedTopics };
+		return { followedTopicIds };
 	},
 
 	topicUnfollowed (subjectId) {
-		const unfollowedTopicIndex = getFollowedTopicIndex(followedTopics, subjectId);
+		const targetIdIndex = followedTopicIds.indexOf(subjectId);
 
-		if (unfollowedTopicIndex > -1) {
-			followedTopics.splice(unfollowedTopicIndex, 1);
+		if (targetIdIndex > -1) {
+			followedTopicIds.splice(targetIdIndex, 1);
 		}
 
-		return { followedTopics };
+		return { followedTopicIds };
 	},
 
 	selectInput (event) {

--- a/components/x-topic-search/src/TopicSearch.jsx
+++ b/components/x-topic-search/src/TopicSearch.jsx
@@ -11,7 +11,7 @@ import AllFollowed from './AllFollowed';
 
 const debounceGetSuggestions = debounce(getSuggestions, 150);
 
-let resultExist = false;
+let resultExists = false;
 
 const topicSearchActions = withActions(({ minSearchLength = 2, maxSuggestions = 5, apiUrl, followedTopicIds = [] }) => ({
 	async checkInput(event) {
@@ -20,15 +20,15 @@ const topicSearchActions = withActions(({ minSearchLength = 2, maxSuggestions = 
 		if (searchTerm.length >= minSearchLength) {
 			return debounceGetSuggestions(searchTerm, maxSuggestions, apiUrl, followedTopicIds)
 				.then(result => {
-					resultExist = true;
+					resultExists = true;
 					return { showResult: true, result, searchTerm };
 				})
 				.catch(() => {
-					resultExist = false;
+					resultExists = false;
 					return { showResult: false };
 				});
 		} else {
-			resultExist = false;
+			resultExists = false;
 			return Promise.resolve({ showResult: false });
 		}
 	},
@@ -53,7 +53,7 @@ const topicSearchActions = withActions(({ minSearchLength = 2, maxSuggestions = 
 
 	selectInput (event) {
 		event.target.select();
-		return { showResult: resultExist };
+		return { showResult: resultExists };
 	},
 
 	hideResult() {

--- a/components/x-topic-search/src/lib/get-suggestions.js
+++ b/components/x-topic-search/src/lib/get-suggestions.js
@@ -3,14 +3,14 @@ const addQueryParamToUrl = (name, value, url, append = true) => {
 	return append === true ? `${url}&${queryParam}` : `${url}?${queryParam}`;
 };
 
-const separateFollowedAndUnfollowed = (suggestions = [], followedTopics) => {
-	const followedSuggestions = suggestions.filter(suggestion => followedTopics.some(topic => topic.uuid === suggestion.id));
-	const unfollowedSuggestions = suggestions.filter(suggestion => !followedTopics.some(topic => topic.uuid === suggestion.id));
+const separateFollowedAndUnfollowed = (suggestions = [], followedTopicIds) => {
+	const followedSuggestions = suggestions.filter(suggestion => followedTopicIds.includes(suggestion.id));
+	const unfollowedSuggestions = suggestions.filter(suggestion => !followedTopicIds.includes(suggestion.id));
 
 	return { followedSuggestions, unfollowedSuggestions };
 }
 
-export default (searchTerm, maxSuggestions, apiUrl, followedTopics) => {
+export default (searchTerm, maxSuggestions, apiUrl, followedTopicIds) => {
 
 	const dataSrc = addQueryParamToUrl('count', maxSuggestions, apiUrl, false);
 	const url = addQueryParamToUrl('partial', searchTerm.replace(' ', '+'), dataSrc);
@@ -23,7 +23,7 @@ export default (searchTerm, maxSuggestions, apiUrl, followedTopics) => {
 			return response.json();
 		})
 		.then(suggestions => {
-			return separateFollowedAndUnfollowed(suggestions, followedTopics)
+			return separateFollowedAndUnfollowed(suggestions, followedTopicIds)
 		})
 		.catch(() => {
 			throw new Error();

--- a/components/x-topic-search/src/lib/get-suggestions.js
+++ b/components/x-topic-search/src/lib/get-suggestions.js
@@ -30,13 +30,6 @@ export default (searchTerm, maxSuggestions, apiUrl, followedTopics) => {
 	const dataSrc = addQueryParamToUrl('count', maxSuggestions, apiUrl, false);
 	let url = addQueryParamToUrl('partial', searchTerm.replace(' ', '+'), dataSrc);
 
-	if (followedTopics.length > 0) {
-		const tagged = followedTopics
-		.map(topic => topic.uuid)
-		.join(',');
-		url = addQueryParamToUrl('tagged', tagged, url);
-	}
-
 	return fetch(url)
 		.then(response => {
 			if (!response.ok) {

--- a/components/x-topic-search/src/lib/get-suggestions.js
+++ b/components/x-topic-search/src/lib/get-suggestions.js
@@ -3,7 +3,23 @@ const addQueryParamToUrl = (name, value, url, append = true) => {
 	return append === true ? `${url}&${queryParam}` : `${url}?${queryParam}`;
 };
 
+const separateFollowedAndNot = (suggestions, followedTopics) => {
+	const matchingFollowedTopics = [];
+	const matchingNotFollowedTopics = [];
+
+	followedTopics.forEach(followedTopic => suggestions.forEach(suggestion => {
+		if (suggestion.id === followedTopic.uuid) {
+			matchingFollowedTopics.push(suggestion);
+		} else {
+			matchingNotFollowedTopics.push(suggestion)
+		}
+	}));
+
+	return { matchingFollowedTopics, matchingNotFollowedTopics };
+}
+
 const suggest = function (suggestions, followedTopics, searchTerm) {
+
 	if (suggestions.length) {
 		suggestions.forEach((suggestion) => {
 			if (suggestion && !suggestion.url){
@@ -11,15 +27,19 @@ const suggest = function (suggestions, followedTopics, searchTerm) {
 				suggestion.url = '/stream/' + suggestion.id;
 			}
 		});
-		return { status: 'suggestions', suggestions };
-	} else {
-		const matchingFollowedTopics = followedTopics
-			.filter(topic => topic.name.toLowerCase().includes(searchTerm.toLowerCase()));
 
-		if(matchingFollowedTopics.length > 0) {
+		const {
+			matchingFollowedTopics,
+			matchingNotFollowedTopics
+		} = separateFollowedAndNot(suggestions, followedTopics);
+
+		if (matchingNotFollowedTopics.length) {
+			return { status: 'suggestions', suggestions: matchingNotFollowedTopics };
+		} else {
 			return { status: 'all-followed', matchingFollowedTopics };
 		}
 
+	} else {
 		return { status: 'no-suggestions' };
 	}
 };

--- a/components/x-topic-search/src/lib/get-suggestions.js
+++ b/components/x-topic-search/src/lib/get-suggestions.js
@@ -3,24 +3,12 @@ const addQueryParamToUrl = (name, value, url, append = true) => {
 	return append === true ? `${url}&${queryParam}` : `${url}?${queryParam}`;
 };
 
-const separateFollowedAndUnfollowed = (suggestions, followedTopics) => {
+const separateFollowedAndUnfollowed = (suggestions = [], followedTopics) => {
 	const followedSuggestions = suggestions.filter(suggestion => followedTopics.some(topic => topic.uuid === suggestion.id));
 	const unfollowedSuggestions = suggestions.filter(suggestion => !followedTopics.some(topic => topic.uuid === suggestion.id));
 
 	return { followedSuggestions, unfollowedSuggestions };
 }
-
-const suggest = (suggestions = [], followedTopics) => {
-	suggestions.forEach((suggestion) => {
-		if (suggestion && !suggestion.url){
-			// TODO App needs different url?
-			suggestion.url = '/stream/' + suggestion.id;
-		}
-	});
-
-	return separateFollowedAndUnfollowed(suggestions, followedTopics);
-};
-
 
 export default (searchTerm, maxSuggestions, apiUrl, followedTopics) => {
 
@@ -35,7 +23,7 @@ export default (searchTerm, maxSuggestions, apiUrl, followedTopics) => {
 			return response.json();
 		})
 		.then(suggestions => {
-			return suggest(suggestions, followedTopics)
+			return separateFollowedAndUnfollowed(suggestions, followedTopics)
 		})
 		.catch(() => {
 			throw new Error();

--- a/components/x-topic-search/src/lib/get-suggestions.js
+++ b/components/x-topic-search/src/lib/get-suggestions.js
@@ -5,17 +5,17 @@ const addQueryParamToUrl = (name, value, url, append = true) => {
 
 const separateFollowedAndNot = (suggestions, followedTopics) => {
 	const matchingFollowedTopics = [];
-	const matchingNotFollowedTopics = [];
+	const matchingUnfollowedTopics = [];
 
 	followedTopics.forEach(followedTopic => suggestions.forEach(suggestion => {
 		if (suggestion.id === followedTopic.uuid) {
 			matchingFollowedTopics.push(suggestion);
 		} else {
-			matchingNotFollowedTopics.push(suggestion)
+			matchingUnfollowedTopics.push(suggestion)
 		}
 	}));
 
-	return { matchingFollowedTopics, matchingNotFollowedTopics };
+	return { matchingFollowedTopics, matchingUnfollowedTopics };
 }
 
 const suggest = function (suggestions, followedTopics) {
@@ -28,19 +28,10 @@ const suggest = function (suggestions, followedTopics) {
 			}
 		});
 
-		const {
-			matchingFollowedTopics,
-			matchingNotFollowedTopics
-		} = separateFollowedAndNot(suggestions, followedTopics);
-
-		if (matchingNotFollowedTopics.length) {
-			return { status: 'suggestions', suggestions: matchingNotFollowedTopics };
-		} else {
-			return { status: 'all-followed', matchingFollowedTopics };
-		}
+		return separateFollowedAndNot(suggestions, followedTopics);
 
 	} else {
-		return { status: 'no-suggestions' };
+		return { matchingFollowedTopics: [], matchingUnfollowedTopics: [] };
 	}
 };
 
@@ -48,7 +39,7 @@ const suggest = function (suggestions, followedTopics) {
 export default (searchTerm, maxSuggestions, apiUrl, followedTopics) => {
 
 	const dataSrc = addQueryParamToUrl('count', maxSuggestions, apiUrl, false);
-	let url = addQueryParamToUrl('partial', searchTerm.replace(' ', '+'), dataSrc);
+	const url = addQueryParamToUrl('partial', searchTerm.replace(' ', '+'), dataSrc);
 
 	return fetch(url)
 		.then(response => {

--- a/components/x-topic-search/src/lib/get-suggestions.js
+++ b/components/x-topic-search/src/lib/get-suggestions.js
@@ -3,40 +3,22 @@ const addQueryParamToUrl = (name, value, url, append = true) => {
 	return append === true ? `${url}&${queryParam}` : `${url}?${queryParam}`;
 };
 
-const separateFollowedAndNot = (suggestions, followedTopics) => {
-	const matchingFollowedTopics = [];
-	const matchingUnfollowedTopics = [];
+const separateFollowedAndUnfollowed = (suggestions, followedTopics) => {
+	const followedSuggestions = suggestions.filter(suggestion => followedTopics.some(topic => topic.uuid === suggestion.id));
+	const unfollowedSuggestions = suggestions.filter(suggestion => !followedTopics.some(topic => topic.uuid === suggestion.id));
 
-	if (!followedTopic.length) {
-		return { matchingFollowedTopics, matchingUnfollowedTopics: suggestions }
-	}
-
-	followedTopics.forEach(followedTopic => suggestions.forEach(suggestion => {
-		if (suggestion.id === followedTopic.uuid) {
-			matchingFollowedTopics.push(suggestion);
-		} else {
-			matchingUnfollowedTopics.push(suggestion)
-		}
-	}));
-
-	return { matchingFollowedTopics, matchingUnfollowedTopics };
+	return { followedSuggestions, unfollowedSuggestions };
 }
 
-const suggest = function (suggestions, followedTopics) {
+const suggest = (suggestions = [], followedTopics) => {
+	suggestions.forEach((suggestion) => {
+		if (suggestion && !suggestion.url){
+			// TODO App needs different url?
+			suggestion.url = '/stream/' + suggestion.id;
+		}
+	});
 
-	if (suggestions.length) {
-		suggestions.forEach((suggestion) => {
-			if (suggestion && !suggestion.url){
-				// TODO App needs different url?
-				suggestion.url = '/stream/' + suggestion.id;
-			}
-		});
-
-		return separateFollowedAndNot(suggestions, followedTopics);
-
-	} else {
-		return { matchingFollowedTopics: [], matchingUnfollowedTopics: [] };
-	}
+	return separateFollowedAndUnfollowed(suggestions, followedTopics);
 };
 
 

--- a/components/x-topic-search/src/lib/get-suggestions.js
+++ b/components/x-topic-search/src/lib/get-suggestions.js
@@ -18,7 +18,7 @@ const separateFollowedAndNot = (suggestions, followedTopics) => {
 	return { matchingFollowedTopics, matchingNotFollowedTopics };
 }
 
-const suggest = function (suggestions, followedTopics, searchTerm) {
+const suggest = function (suggestions, followedTopics) {
 
 	if (suggestions.length) {
 		suggestions.forEach((suggestion) => {
@@ -58,7 +58,7 @@ export default (searchTerm, maxSuggestions, apiUrl, followedTopics) => {
 			return response.json();
 		})
 		.then(suggestions => {
-			return suggest(suggestions, followedTopics, searchTerm)
+			return suggest(suggestions, followedTopics)
 		})
 		.catch(() => {
 			throw new Error();

--- a/components/x-topic-search/src/lib/get-suggestions.js
+++ b/components/x-topic-search/src/lib/get-suggestions.js
@@ -7,6 +7,10 @@ const separateFollowedAndNot = (suggestions, followedTopics) => {
 	const matchingFollowedTopics = [];
 	const matchingUnfollowedTopics = [];
 
+	if (!followedTopic.length) {
+		return { matchingFollowedTopics, matchingUnfollowedTopics: suggestions }
+	}
+
 	followedTopics.forEach(followedTopic => suggestions.forEach(suggestion => {
 		if (suggestion.id === followedTopic.uuid) {
 			matchingFollowedTopics.push(suggestion);

--- a/components/x-topic-search/stories/topic-search.js
+++ b/components/x-topic-search/stories/topic-search.js
@@ -4,11 +4,8 @@ exports.data = {
 	minSearchLength: 2,
 	maxSuggestions: 10,
 	apiUrl: '//tag-facets-api.ft.com/annotations',
-	followedTopics: [
-		{
-			name: 'World Elephant Polo Association',
-			uuid: 'f95d1e16-2307-4feb-b3ff-6f224798aa49'
-		}
+	followedTopicIds: [
+		'f95d1e16-2307-4feb-b3ff-6f224798aa49'
 	],
 	csrfToken: 'csrfToken'
 };


### PR DESCRIPTION
This change is to update followedTopics properly when users click an external follow button. x-topic-search executes the topicFollowed action (which is triggered in the consumer side) when that happens. x-topic-search gets only the topic id from the event, but it needs the whole topic data to render correct info.

Changing from **Fetch suggestions except followedTopics** to **Fetch all suggestions and then pick followedTopic up by the ids** will make easier to update followedTopics with the whole topic data.