### PR TITLE
Remove onBlur which hides result

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -5554,7 +5554,6 @@ exports[`@financial-times/x-topic-search renders a default Topic Search Bar x-to
       className="TopicSearch_input__1Iq7K"
       data-trackable="topic-search"
       id="topic-search-input"
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
       onInput={[Function]}

--- a/components/x-topic-search/readme.md
+++ b/components/x-topic-search/readme.md
@@ -34,6 +34,30 @@ All `x-` components are designed to be compatible with a variety of runtimes, no
 
 [jsx-wtf]: https://jasonformat.com/wtf-is-jsx/
 
+### Hide Result
+
+Your x-topic-search could hide the result container, which displays search result or messages, by external triggers.
+
+[x-interaction triggering-actions-externally](https://github.com/Financial-Times/x-dash/tree/master/components/x-interaction#triggering-actions-externally)
+
+```
+const container = ...
+let topicSearchActions;
+
+['focusout', 'focusin', 'click'].forEach(action => {
+	document.body.addEventListener(action, event => {
+		if(!container.contains(event.target)) {
+			topicSearchActions.hideResult();
+		}
+	});
+});
+
+render <TopicSearch
+			...
+			actionsRef={actions => topicSearchActions = actions}
+		/>
+```
+
 ### Properties
 
 Property          | Type   | Required | Note

--- a/components/x-topic-search/src/TopicSearch.jsx
+++ b/components/x-topic-search/src/TopicSearch.jsx
@@ -80,8 +80,7 @@ const TopicSearch = topicSearchActions(({ searchTerm, showResult, result, action
 				data-trackable="topic-search"
 				onInput={ actions.checkInput }
 				onClick={ actions.selectInput }
-				onFocus={ actions.selectInput }
-				onBlur={ actions.hideResult }/>
+				onFocus={ actions.selectInput }/>
 		</div>
 
 		{ showResult && !isLoading &&


### PR DESCRIPTION
Can't click follow button in topic search result because the result disappears (this happens because of `onBlur` on `<input>`). Hiding the result container need to be controled by external triggers.