### PR TITLE
Apply custom styles to search cancel button

### DIFF
--- a/components/x-topic-search/src/TopicSearch.scss
+++ b/components/x-topic-search/src/TopicSearch.scss
@@ -42,6 +42,11 @@
 	&::placeholder {
 		color: oColorsGetPaletteColor('white');
 	}
+
+	&::-webkit-search-cancel-button {
+		@include oIconsGetIcon('cross', oColorsGetPaletteColor('white'), 26);
+		-webkit-appearance: none;
+	}
 }
 
 .result-container {


### PR DESCRIPTION
The search cancel button is supported only in WebKit and Blink, hence the vendor prefix `::-webkit-` is needed.

**BEFORE**
![screen shot 2019-01-29 at 16 08 31](https://user-images.githubusercontent.com/21194161/51922245-8e62d900-23e0-11e9-8a24-92e5316f3aa0.png)

**AFTER**
![screen shot 2019-01-29 at 16 06 29](https://user-images.githubusercontent.com/21194161/51922272-9c185e80-23e0-11e9-90d2-a77548864dfa.png)
