### PR TITLE
Set input height to keep result container's position consistently

### DIFF
--- a/components/x-topic-search/src/TopicSearch.scss
+++ b/components/x-topic-search/src/TopicSearch.scss
@@ -38,6 +38,7 @@
 	max-width: none;
 	color: oColorsGetPaletteColor('white');
 	background: transparent;
+	height: 40px;
 
 	&::placeholder {
 		color: oColorsGetPaletteColor('white');


### PR DESCRIPTION
**The bug**
-----
Only on Safari, the input box's height is set differently.
Chrome, Firefox, IE11 => 40px
Safari => 46px
![wrong-top-position](https://user-images.githubusercontent.com/21194161/52209080-a6bc7300-287a-11e9-9924-2836a2e575fc.png)

**The reason**
-----

It seems Safari includes the height of search cancel button as the input height and Chrome doesn't.

![css-difference](https://user-images.githubusercontent.com/21194161/52208833-d919a080-2879-11e9-8d6a-f96835a138f0.png)

```css
input {
    min-height: 40px;
    padding: 9px 9px 9px;
    font-size: 16px;
    line-height: 20px;
    margin: 0;
    border-bottom: 2px solid #ffffff;
    padding-left: 24px;

    &::-webkit-search-cancel-button {
	@include oIconsGetIcon('cross', oColorsGetPaletteColor('white'), 26);
	-webkit-appearance: none;
    }
}
```

**The solution**
-----
Adding `position: absolute` or `z-index` doesn't solve the problem. Overwrite padding top/bottom 0 and keep the input height the min-height(40px) no matter whether the browser includes the cancel button height as the input height or not.