### PR TITLE
Fix wrong input height on Safari

### DIFF
--- a/components/x-topic-search/src/TopicSearch.scss
+++ b/components/x-topic-search/src/TopicSearch.scss
@@ -34,7 +34,7 @@
 	margin: 0;
 	border: none;
 	border-bottom: 2px solid oColorsGetPaletteColor('white');
-	padding-left: 24px;
+	padding: 0 9px 0 24px;
 	max-width: none;
 	color: oColorsGetPaletteColor('white');
 	background: transparent;
@@ -46,6 +46,12 @@
 	&::-webkit-search-cancel-button {
 		@include oIconsGetIcon('cross', oColorsGetPaletteColor('white'), 26);
 		-webkit-appearance: none;
+	}
+
+	&::-webkit-search-decoration,
+	&::-webkit-search-results-button,
+	&::-webkit-search-results-decoration {
+	  display: none;
 	}
 }
 


### PR DESCRIPTION
I accidentally deleted the branch and closed this PR... https://github.com/Financial-Times/x-dash/pull/245 🙈 

**The bug**
-----
Only on Safari, the input box's height is set differently.
Chrome, Firefox, IE11 => 40px
Safari => 46px
![wrong-top-position](https://user-images.githubusercontent.com/21194161/52209080-a6bc7300-287a-11e9-9924-2836a2e575fc.png)

**The reason**
-----

It seems Safari includes the height of search cancel button as the input height and Chrome doesn't.

![css-difference](https://user-images.githubusercontent.com/21194161/52208833-d919a080-2879-11e9-8d6a-f96835a138f0.png)

```css
input {
    min-height: 40px;
    padding: 9px 9px 9px;
    font-size: 16px;
    line-height: 20px;
    margin: 0;
    border-bottom: 2px solid #ffffff;
    padding-left: 24px;

    &::-webkit-search-cancel-button {
	@include oIconsGetIcon('cross', oColorsGetPaletteColor('white'), 26);
	-webkit-appearance: none;
    }
}
```

**The solution**
-----
Adding `position: absolute` or `z-index` doesn't solve the problem. Overwrite padding top/bottom 0 and keep the input height the min-height(40px) no matter whether the browser includes the cancel button height as the input height or not.