### PR TITLE
Update o-labels dependency and HTML template

### DIFF
--- a/components/x-teaser/src/Title.jsx
+++ b/components/x-teaser/src/Title.jsx
@@ -4,6 +4,8 @@ import Link from './Link';
 export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators, ...props }) => {
 	const displayTitle = headlineTesting && altTitle ? altTitle : title;
 	const displayUrl = relativeUrl || url;
+	// o-labels--premium left for backwards compatibility for o-labels v3
+	const premiumClass = 'o-labels o-labels--premium o-labels--content-premium';
 
 	return (
 		<div className="o-teaser__heading">
@@ -15,7 +17,7 @@ export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators
 				{' '}
 			</Link>
 			{indicators && indicators.accessLevel === 'premium' ? (
-				<span className="o-labels o-labels--premium" aria-label="Premium content">
+				<span className={premiumClass} aria-label="Premium content">
 					Premium
 				</span>
 			) : null}

--- a/components/x-teaser/stories/index.js
+++ b/components/x-teaser/stories/index.js
@@ -8,8 +8,8 @@ exports.dependencies = {
 	'o-normalise': '^1.6.0',
 	'o-date': '^2.11.0',
 	'o-typography': '^5.5.0',
-	'o-teaser': '^2.3.0',
-	'o-labels': '^3.0.0',
+	'o-teaser': '^3.2.1',
+	'o-labels': '^4.2.1',
 	'o-video': '^4.1.0',
 };
 


### PR DESCRIPTION
To update `o-teaser`, `o-labels` has to be updated. There was a breaking change where label class names were changed so the premium label in `x-teaser` was changed from `.premium` to `.content-premium`