### PR TITLE
chore(deps): upgrade to babel-jest v24

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "eslint-plugin-react": "^7.10.0",
     "espree": "^4.1.0",
     "fetch-mock": "^6.5.2",
-    "jest": "^22.4.3",
     "react": "^16.3.1",
     "react-test-renderer": "^16.3.1"
   },
@@ -39,5 +38,8 @@
     "components/*",
     "packages/*",
     "tools/*"
-  ]
+  ],
+  "devDependencies": {
+    "jest": "^24.7.1"
+  }
 }

--- a/packages/x-babel-config/index.js
+++ b/packages/x-babel-config/index.js
@@ -2,17 +2,9 @@ module.exports = (targets = []) => ({
 	plugins: [
 		// this plugin is not React specific! It includes a general JSX parser and helper 🙄
 		[
-			require.resolve('babel-plugin-transform-react-jsx'),
+			require.resolve('@babel/plugin-transform-react-jsx'),
 			{
 				pragma: 'h',
-				useBuiltIns: true
-			}
-		],
-		// Although this feature is at stage 4, we'd have to use babel 7 to get the version
-		// of preset-env that actually supports it 😖
-		[
-			require.resolve('babel-plugin-transform-object-rest-spread'),
-			{
 				useBuiltIns: true
 			}
 		],
@@ -29,7 +21,7 @@ module.exports = (targets = []) => ({
 	],
 	presets: [
 		[
-			require.resolve('babel-preset-env'),
+			require.resolve('@babel/preset-env'),
 			{
 				targets,
 				modules: false,

--- a/packages/x-babel-config/package.json
+++ b/packages/x-babel-config/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "babel-jest": "^23.6.0",
+    "babel-jest": "^24.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.7.0",

--- a/packages/x-babel-config/package.json
+++ b/packages/x-babel-config/package.json
@@ -11,10 +11,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@babel/plugin-transform-react-jsx": "^7.3.0",
+    "@babel/preset-env": "^7.4.3",
     "babel-jest": "^24.0.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-preset-env": "^1.7.0",
-    "fast-async": "^6.3.7"
+    "fast-async": "^7.0.6"
   }
 }

--- a/packages/x-rollup/package.json
+++ b/packages/x-rollup/package.json
@@ -11,13 +11,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@babel/core": "^7.4.3",
+    "@babel/plugin-external-helpers": "^7.2.0",
     "@financial-times/x-babel-config": "file:../x-babel-config",
-    "babel-core": "^6.26.3",
-    "babel-plugin-external-helpers": "^6.22.0",
     "chalk": "^2.4.1",
     "log-symbols": "^2.2.0",
     "rollup": "^0.63.0",
-    "rollup-plugin-babel": "^3.0.7",
+    "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-postcss": "^1.6.2"
   }

--- a/packages/x-rollup/src/babel-config.js
+++ b/packages/x-rollup/src/babel-config.js
@@ -5,7 +5,7 @@ module.exports = (...args) => {
 
 	base.plugins.push(
 		// Instruct Babel to not include any internal helper declarations in the output
-		require.resolve('babel-plugin-external-helpers'),
+		require.resolve('@babel/plugin-external-helpers'),
 	);
 
 	// rollup-specific option not included in base config

--- a/tools/x-ssr-demo/package.json
+++ b/tools/x-ssr-demo/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@babel/core": "^7.4.3",
     "@financial-times/n-handlebars": "^1.21.0",
     "@financial-times/x-babel-config": "file:../../packages/x-babel-config",
     "@financial-times/x-engine": "file:../../packages/x-engine",
@@ -18,7 +19,7 @@
     "@financial-times/x-increment": "file:../../components/x-increment",
     "@financial-times/x-interaction": "file:../../components/x-interaction",
     "babel-core": "^6.0.0",
-    "babel-loader": "^7.0.0",
+    "babel-loader": "^8.0.5",
     "express": "^4.16.3",
     "hyperons": "^0.5.0",
     "preact": "^8.2.9",


### PR DESCRIPTION
The current version includes a vulnerable version of the `braces` dependency.

https://app.snyk.io/vuln/npm:braces:20180219