### PR TITLE
Remove extra space after title text

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -68,7 +68,6 @@ exports[`@financial-times/x-teaser renders a Hero Article x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -144,7 +143,6 @@ exports[`@financial-times/x-teaser renders a Hero Content Package x-teaser 1`] =
         href="#"
       >
         The royal wedding
-         
       </a>
     </div>
   </div>
@@ -208,7 +206,6 @@ exports[`@financial-times/x-teaser renders a Hero Opinion Piece x-teaser 1`] = `
         href="#"
       >
         Anti-Semitism and the threat of identity politics
-         
       </a>
     </div>
     <p
@@ -272,7 +269,6 @@ exports[`@financial-times/x-teaser renders a Hero Package item x-teaser 1`] = `
         href="#"
       >
         Why so little has changed since the crash
-         
       </a>
     </div>
   </div>
@@ -339,7 +335,6 @@ exports[`@financial-times/x-teaser renders a Hero Paid Post x-teaser 1`] = `
         href="#"
       >
         Why eSports companies are on a winning streak
-         
       </a>
     </div>
     <p
@@ -420,7 +415,6 @@ exports[`@financial-times/x-teaser renders a Hero Podcast x-teaser 1`] = `
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
       >
         Who sets the internet standards?
-         
       </a>
     </div>
     <p
@@ -496,7 +490,6 @@ exports[`@financial-times/x-teaser renders a Hero Top Story x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -666,7 +659,6 @@ exports[`@financial-times/x-teaser renders a Hero Video x-teaser 1`] = `
         href="#"
       >
         FT View: Donald Trump, man of steel
-         
       </a>
     </div>
   </div>
@@ -705,7 +697,6 @@ exports[`@financial-times/x-teaser renders a HeroNarrow Article x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -781,7 +772,6 @@ exports[`@financial-times/x-teaser renders a HeroNarrow Content Package x-teaser
         href="#"
       >
         The royal wedding
-         
       </a>
     </div>
     <p
@@ -857,7 +847,6 @@ exports[`@financial-times/x-teaser renders a HeroNarrow Opinion Piece x-teaser 1
         href="#"
       >
         Anti-Semitism and the threat of identity politics
-         
       </a>
     </div>
     <p
@@ -921,7 +910,6 @@ exports[`@financial-times/x-teaser renders a HeroNarrow Package item x-teaser 1`
         href="#"
       >
         Why so little has changed since the crash
-         
       </a>
     </div>
     <p
@@ -1000,7 +988,6 @@ exports[`@financial-times/x-teaser renders a HeroNarrow Paid Post x-teaser 1`] =
         href="#"
       >
         Why eSports companies are on a winning streak
-         
       </a>
     </div>
     <p
@@ -1081,7 +1068,6 @@ exports[`@financial-times/x-teaser renders a HeroNarrow Podcast x-teaser 1`] = `
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
       >
         Who sets the internet standards?
-         
       </a>
     </div>
     <p
@@ -1157,7 +1143,6 @@ exports[`@financial-times/x-teaser renders a HeroNarrow Top Story x-teaser 1`] =
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -1327,7 +1312,6 @@ exports[`@financial-times/x-teaser renders a HeroNarrow Video x-teaser 1`] = `
         href="#"
       >
         FT View: Donald Trump, man of steel
-         
       </a>
     </div>
     <p
@@ -1378,7 +1362,6 @@ exports[`@financial-times/x-teaser renders a HeroOverlay Article x-teaser 1`] = 
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -1454,7 +1437,6 @@ exports[`@financial-times/x-teaser renders a HeroOverlay Content Package x-tease
         href="#"
       >
         The royal wedding
-         
       </a>
     </div>
   </div>
@@ -1518,7 +1500,6 @@ exports[`@financial-times/x-teaser renders a HeroOverlay Opinion Piece x-teaser 
         href="#"
       >
         Anti-Semitism and the threat of identity politics
-         
       </a>
     </div>
     <p
@@ -1582,7 +1563,6 @@ exports[`@financial-times/x-teaser renders a HeroOverlay Package item x-teaser 1
         href="#"
       >
         Why so little has changed since the crash
-         
       </a>
     </div>
   </div>
@@ -1649,7 +1629,6 @@ exports[`@financial-times/x-teaser renders a HeroOverlay Paid Post x-teaser 1`] 
         href="#"
       >
         Why eSports companies are on a winning streak
-         
       </a>
     </div>
     <p
@@ -1730,7 +1709,6 @@ exports[`@financial-times/x-teaser renders a HeroOverlay Podcast x-teaser 1`] = 
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
       >
         Who sets the internet standards?
-         
       </a>
     </div>
     <p
@@ -1806,7 +1784,6 @@ exports[`@financial-times/x-teaser renders a HeroOverlay Top Story x-teaser 1`] 
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -1976,7 +1953,6 @@ exports[`@financial-times/x-teaser renders a HeroOverlay Video x-teaser 1`] = `
         href="#"
       >
         FT View: Donald Trump, man of steel
-         
       </a>
     </div>
   </div>
@@ -2015,7 +1991,6 @@ exports[`@financial-times/x-teaser renders a HeroVideo Article x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -2091,7 +2066,6 @@ exports[`@financial-times/x-teaser renders a HeroVideo Content Package x-teaser 
         href="#"
       >
         The royal wedding
-         
       </a>
     </div>
   </div>
@@ -2155,7 +2129,6 @@ exports[`@financial-times/x-teaser renders a HeroVideo Opinion Piece x-teaser 1`
         href="#"
       >
         Anti-Semitism and the threat of identity politics
-         
       </a>
     </div>
     <p
@@ -2219,7 +2192,6 @@ exports[`@financial-times/x-teaser renders a HeroVideo Package item x-teaser 1`]
         href="#"
       >
         Why so little has changed since the crash
-         
       </a>
     </div>
   </div>
@@ -2286,7 +2258,6 @@ exports[`@financial-times/x-teaser renders a HeroVideo Paid Post x-teaser 1`] = 
         href="#"
       >
         Why eSports companies are on a winning streak
-         
       </a>
     </div>
     <p
@@ -2367,7 +2338,6 @@ exports[`@financial-times/x-teaser renders a HeroVideo Podcast x-teaser 1`] = `
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
       >
         Who sets the internet standards?
-         
       </a>
     </div>
     <p
@@ -2443,7 +2413,6 @@ exports[`@financial-times/x-teaser renders a HeroVideo Top Story x-teaser 1`] = 
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -2613,7 +2582,6 @@ exports[`@financial-times/x-teaser renders a HeroVideo Video x-teaser 1`] = `
         href="#"
       >
         FT View: Donald Trump, man of steel
-         
       </a>
     </div>
   </div>
@@ -2652,7 +2620,6 @@ exports[`@financial-times/x-teaser renders a Large Article x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -2728,7 +2695,6 @@ exports[`@financial-times/x-teaser renders a Large Content Package x-teaser 1`] 
         href="#"
       >
         The royal wedding
-         
       </a>
     </div>
     <p
@@ -2804,7 +2770,6 @@ exports[`@financial-times/x-teaser renders a Large Opinion Piece x-teaser 1`] = 
         href="#"
       >
         Anti-Semitism and the threat of identity politics
-         
       </a>
     </div>
     <p
@@ -2868,7 +2833,6 @@ exports[`@financial-times/x-teaser renders a Large Package item x-teaser 1`] = `
         href="#"
       >
         Why so little has changed since the crash
-         
       </a>
     </div>
     <p
@@ -2947,7 +2911,6 @@ exports[`@financial-times/x-teaser renders a Large Paid Post x-teaser 1`] = `
         href="#"
       >
         Why eSports companies are on a winning streak
-         
       </a>
     </div>
     <p
@@ -3028,7 +2991,6 @@ exports[`@financial-times/x-teaser renders a Large Podcast x-teaser 1`] = `
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
       >
         Who sets the internet standards?
-         
       </a>
     </div>
     <p
@@ -3104,7 +3066,6 @@ exports[`@financial-times/x-teaser renders a Large Top Story x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -3274,7 +3235,6 @@ exports[`@financial-times/x-teaser renders a Large Video x-teaser 1`] = `
         href="#"
       >
         FT View: Donald Trump, man of steel
-         
       </a>
     </div>
     <p
@@ -3325,7 +3285,6 @@ exports[`@financial-times/x-teaser renders a Small Article x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -3401,7 +3360,6 @@ exports[`@financial-times/x-teaser renders a Small Content Package x-teaser 1`] 
         href="#"
       >
         The royal wedding
-         
       </a>
     </div>
   </div>
@@ -3465,7 +3423,6 @@ exports[`@financial-times/x-teaser renders a Small Opinion Piece x-teaser 1`] = 
         href="#"
       >
         Anti-Semitism and the threat of identity politics
-         
       </a>
     </div>
     <p
@@ -3529,7 +3486,6 @@ exports[`@financial-times/x-teaser renders a Small Package item x-teaser 1`] = `
         href="#"
       >
         Why so little has changed since the crash
-         
       </a>
     </div>
   </div>
@@ -3596,7 +3552,6 @@ exports[`@financial-times/x-teaser renders a Small Paid Post x-teaser 1`] = `
         href="#"
       >
         Why eSports companies are on a winning streak
-         
       </a>
     </div>
     <p
@@ -3677,7 +3632,6 @@ exports[`@financial-times/x-teaser renders a Small Podcast x-teaser 1`] = `
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
       >
         Who sets the internet standards?
-         
       </a>
     </div>
     <p
@@ -3753,7 +3707,6 @@ exports[`@financial-times/x-teaser renders a Small Top Story x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -3923,7 +3876,6 @@ exports[`@financial-times/x-teaser renders a Small Video x-teaser 1`] = `
         href="#"
       >
         FT View: Donald Trump, man of steel
-         
       </a>
     </div>
   </div>
@@ -3962,7 +3914,6 @@ exports[`@financial-times/x-teaser renders a SmallHeavy Article x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -4038,7 +3989,6 @@ exports[`@financial-times/x-teaser renders a SmallHeavy Content Package x-teaser
         href="#"
       >
         The royal wedding
-         
       </a>
     </div>
     <p
@@ -4114,7 +4064,6 @@ exports[`@financial-times/x-teaser renders a SmallHeavy Opinion Piece x-teaser 1
         href="#"
       >
         Anti-Semitism and the threat of identity politics
-         
       </a>
     </div>
     <p
@@ -4178,7 +4127,6 @@ exports[`@financial-times/x-teaser renders a SmallHeavy Package item x-teaser 1`
         href="#"
       >
         Why so little has changed since the crash
-         
       </a>
     </div>
     <p
@@ -4257,7 +4205,6 @@ exports[`@financial-times/x-teaser renders a SmallHeavy Paid Post x-teaser 1`] =
         href="#"
       >
         Why eSports companies are on a winning streak
-         
       </a>
     </div>
     <p
@@ -4338,7 +4285,6 @@ exports[`@financial-times/x-teaser renders a SmallHeavy Podcast x-teaser 1`] = `
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
       >
         Who sets the internet standards?
-         
       </a>
     </div>
     <p
@@ -4414,7 +4360,6 @@ exports[`@financial-times/x-teaser renders a SmallHeavy Top Story x-teaser 1`] =
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -4584,7 +4529,6 @@ exports[`@financial-times/x-teaser renders a SmallHeavy Video x-teaser 1`] = `
         href="#"
       >
         FT View: Donald Trump, man of steel
-         
       </a>
     </div>
     <p
@@ -4635,7 +4579,6 @@ exports[`@financial-times/x-teaser renders a TopStory Article x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -4711,7 +4654,6 @@ exports[`@financial-times/x-teaser renders a TopStory Content Package x-teaser 1
         href="#"
       >
         The royal wedding
-         
       </a>
     </div>
     <p
@@ -4787,7 +4729,6 @@ exports[`@financial-times/x-teaser renders a TopStory Opinion Piece x-teaser 1`]
         href="#"
       >
         Anti-Semitism and the threat of identity politics
-         
       </a>
     </div>
     <p
@@ -4851,7 +4792,6 @@ exports[`@financial-times/x-teaser renders a TopStory Package item x-teaser 1`] 
         href="#"
       >
         Why so little has changed since the crash
-         
       </a>
     </div>
     <p
@@ -4930,7 +4870,6 @@ exports[`@financial-times/x-teaser renders a TopStory Paid Post x-teaser 1`] = `
         href="#"
       >
         Why eSports companies are on a winning streak
-         
       </a>
     </div>
     <p
@@ -5011,7 +4950,6 @@ exports[`@financial-times/x-teaser renders a TopStory Podcast x-teaser 1`] = `
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
       >
         Who sets the internet standards?
-         
       </a>
     </div>
     <p
@@ -5087,7 +5025,6 @@ exports[`@financial-times/x-teaser renders a TopStory Top Story x-teaser 1`] = `
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -5257,7 +5194,6 @@ exports[`@financial-times/x-teaser renders a TopStory Video x-teaser 1`] = `
         href="#"
       >
         FT View: Donald Trump, man of steel
-         
       </a>
     </div>
     <p
@@ -5308,7 +5244,6 @@ exports[`@financial-times/x-teaser renders a TopStoryLandscape Article x-teaser 
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -5384,7 +5319,6 @@ exports[`@financial-times/x-teaser renders a TopStoryLandscape Content Package x
         href="#"
       >
         The royal wedding
-         
       </a>
     </div>
     <p
@@ -5460,7 +5394,6 @@ exports[`@financial-times/x-teaser renders a TopStoryLandscape Opinion Piece x-t
         href="#"
       >
         Anti-Semitism and the threat of identity politics
-         
       </a>
     </div>
     <p
@@ -5524,7 +5457,6 @@ exports[`@financial-times/x-teaser renders a TopStoryLandscape Package item x-te
         href="#"
       >
         Why so little has changed since the crash
-         
       </a>
     </div>
     <p
@@ -5603,7 +5535,6 @@ exports[`@financial-times/x-teaser renders a TopStoryLandscape Paid Post x-tease
         href="#"
       >
         Why eSports companies are on a winning streak
-         
       </a>
     </div>
     <p
@@ -5684,7 +5615,6 @@ exports[`@financial-times/x-teaser renders a TopStoryLandscape Podcast x-teaser 
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
       >
         Who sets the internet standards?
-         
       </a>
     </div>
     <p
@@ -5760,7 +5690,6 @@ exports[`@financial-times/x-teaser renders a TopStoryLandscape Top Story x-tease
         href="#"
       >
         Inside charity fundraiser where hostesses are put on show
-         
       </a>
     </div>
     <p
@@ -5930,7 +5859,6 @@ exports[`@financial-times/x-teaser renders a TopStoryLandscape Video x-teaser 1`
         href="#"
       >
         FT View: Donald Trump, man of steel
-         
       </a>
     </div>
     <p

--- a/components/x-teaser/src/Title.jsx
+++ b/components/x-teaser/src/Title.jsx
@@ -14,7 +14,6 @@ export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators
 				className: 'js-teaser-heading-link',
 			}}>
 				{displayTitle}
-				{' '}
 			</Link>
 			{indicators && indicators.accessLevel === 'premium' ? (
 				<span className={premiumClass} aria-label="Premium content">


### PR DESCRIPTION
After discussing it with @chee 

An extra space is inserted after the title text on teaser titles, it is apparently serving as a workaround to an issue where the labels weren't displayed correctly. 

This is now causing issue with the "external link" icon on promoted content teasers. Where the icon overlaps the text, and this weird behaviour seems to be linked to this extra space.

I ran x-teaser with premium labels and without the space, it doesn't change anything visually, it seems safe to remove this workaround now

