### PR TITLE
x-audio loading component

### DIFF
--- a/components/x-audio/.bowerrc
+++ b/components/x-audio/.bowerrc
@@ -1,8 +1,8 @@
 {
-  "registry": {
-  "search": [
-      "https://origami-bower-registry.ft.com",
-      "https://registry.bower.io"
-    ]
-  }
+	"registry": {
+		"search": [
+			"https://origami-bower-registry.ft.com",
+			"https://registry.bower.io"
+		]
+	}
 }

--- a/components/x-audio/__tests__/x-audio.test.jsx
+++ b/components/x-audio/__tests__/x-audio.test.jsx
@@ -1,0 +1,28 @@
+const { h } = require('@financial-times/x-engine');
+const { mount } = require('@financial-times/x-test-utils/enzyme');
+const { Audio } = require('../');
+
+describe('x-audio', () => {
+	describe('loader', () => {
+		const props = {
+			onPlayClick: jest.fn(),
+			onPauseClick: jest.fn(),
+			onCloseClick: jest.fn(),
+			expanded: false,
+			loading: false,
+			playing: false,
+			title: 'lorem',
+			seriesName: 'ipsum'
+		}
+		it('should show the loader when loading is true', () => {
+			const subject = mount(<Audio {...props} loading={true} />);
+			expect(subject.exists('Loading')).toEqual(true);
+		});
+
+		it('should not show the loader when loaded event occurs', () => {
+			const subject = mount(<Audio {...props} />);
+			expect(subject.exists('Loading')).toEqual(false);
+		});
+	});
+
+});

--- a/components/x-audio/bower.json
+++ b/components/x-audio/bower.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "o-icons": "^5.11.0",
+    "o-loading": "^3.1.1",
     "o-typography": "^5.11.0",
     "o-colors": "^4.8.5"
   }

--- a/components/x-audio/package.json
+++ b/components/x-audio/package.json
@@ -12,7 +12,8 @@
     "start": "node rollup.js --watch"
   },
   "keywords": [
-    "x-dash"
+    "x-dash",
+    "x-audio"
   ],
   "author": "",
   "license": "ISC",
@@ -24,7 +25,8 @@
   },
   "devDependencies": {
     "@financial-times/x-rollup": "file:../../packages/x-rollup",
-    "bower": "^1.7.9",
+    "@financial-times/x-test-utils": "file:../../packages/x-test-utils",
+    "bower": "^1.8.8",
     "node-sass": "^4.11.0"
   },
   "repository": {

--- a/components/x-audio/readme.md
+++ b/components/x-audio/readme.md
@@ -2,6 +2,11 @@
 
 This module has these features and scope.
 
+## Requirements
+
+Origami components:
+* `o-loading`
+* `o-typography`
 
 ## Installation
 
@@ -28,6 +33,11 @@ import { Audio } from '@financial-times/x-audio';
 const a = Audio(props);
 const b = <Audio {...props} />;
 const c = React.createElement(Audio, props);
+```
+
+```scss
+// within your app's sass file
+@import "x-audio/dist/Audio";
 ```
 
 All `x-` components are designed to be compatible with a variety of runtimes, not just React. Check out the [`x-engine`][engine] documentation for a list of recommended libraries and frameworks.

--- a/components/x-audio/src/components/Loading.jsx
+++ b/components/x-audio/src/components/Loading.jsx
@@ -1,0 +1,12 @@
+import { h } from '@financial-times/x-engine';
+import classNameMap from './classnames-helper';
+
+export default ({expanded}) => {
+	const foregroundColor = (expanded) ? 'dark' : 'light';
+	return (
+		<div role="status" aria-live="polite" className={classNameMap('audio-player__status',  `audio-player__status--${expanded ? 'expanded' : 'minimised'}`)}>
+			<div className={`o-loading o-loading--${foregroundColor} o-loading--mini ${classNameMap('audio-player__loader')}`}></div>
+			Loading
+		</div>
+	);
+};

--- a/components/x-audio/src/components/classnames-helper.js
+++ b/components/x-audio/src/components/classnames-helper.js
@@ -1,3 +1,3 @@
 import classNames from 'classnames';
 import styles from './styles.scss'
-export default (...classes) => classNames(classes.map(className => styles[className]))
+export default (...classes) => classNames(classes.map(className => styles[className]));

--- a/components/x-audio/src/components/index.jsx
+++ b/components/x-audio/src/components/index.jsx
@@ -1,12 +1,14 @@
 import { h } from '@financial-times/x-engine';
 import * as PropTypes from 'prop-types';
 import classNameMap from './classnames-helper';
+import Loading from './Loading';
 import {
 	Close,
 	PlayPause
 } from './Buttons'
 
 export const Audio = ({
+	loading,
 	expanded,
 	playing,
 	onPlayClick,
@@ -31,8 +33,9 @@ export const Audio = ({
 			{!expanded && <div className={classNameMap('audio-player__info__remaining')}>12 mins remaining</div>}
 		</div>
 		<PlayPause onPlayClick={onPlayClick} onPauseClick={onPauseClick} playing={playing}/>
-
+		{loading && <Loading expanded={expanded} />}
 	</div>
+
 );
 
 Audio.propTypes = {

--- a/components/x-audio/src/components/styles.scss
+++ b/components/x-audio/src/components/styles.scss
@@ -1,6 +1,9 @@
 @import 'o-icons/main';
 @import 'o-colors/main';
+
+$o-typography-load-fonts: false;
 @import 'o-typography/main';
+@include oTypography();
 
 $height--minimised: 48px;
 $info-height--expanded: 72px;
@@ -40,6 +43,7 @@ $info-height--expanded: 72px;
 	grid-template-columns: 1fr 1fr 1fr;
 	grid-template-areas: ". minimise-button ."
 	"info info info"
+	". status ."
 	"control-timeline control-timeline control-timeline"
 	"rewind play-pause forward"
 	". control-speed .";
@@ -52,7 +56,8 @@ $info-height--expanded: 72px;
 
 .audio-player--minimised {
 	grid-template-columns: $height--minimised auto $height--minimised;
-	grid-template-areas: "play-pause info close-button";
+	grid-template-areas: "play-pause info close-button"
+	"status . .";
 	height: $height--minimised;
 	border-radius: 24px;
 	background-color: oColorsGetPaletteColor('slate');
@@ -217,4 +222,21 @@ $info-height--expanded: 72px;
 	grid-area: remaining;
 	align-self: center;
 	margin-left: 8px;
+}
+
+.audio-player__status {
+  grid-area: status;
+  @include oTypographySans();
+  display: flex;
+  align-items: center;
+  /* make the mini spinner smaller*/
+  .audio-player__loader {
+    width: 8px;
+    height: 8px;
+    margin-right: 4px;
+  }
+}
+
+.audio-player__status--minimised {
+  @include oTypographySize($scale: -2);
 }

--- a/components/x-audio/src/components/styles.scss
+++ b/components/x-audio/src/components/styles.scss
@@ -225,18 +225,18 @@ $info-height--expanded: 72px;
 }
 
 .audio-player__status {
-  grid-area: status;
-  @include oTypographySans();
-  display: flex;
-  align-items: center;
-  /* make the mini spinner smaller*/
-  .audio-player__loader {
-    width: 8px;
-    height: 8px;
-    margin-right: 4px;
-  }
+	grid-area: status;
+	@include oTypographySans();
+	display: flex;
+	align-items: center;
+	/* make the mini spinner smaller*/
+	.audio-player__loader {
+		width: 8px;
+		height: 8px;
+		margin-right: 4px;
+	}
 }
 
 .audio-player__status--minimised {
-  @include oTypographySize($scale: -2);
+	@include oTypographySize($scale: -2);
 }

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -11,6 +11,12 @@ export function reducer (state = initialState, action) {
 			return {...state, playing: true }
 		case 'PAUSE':
 			return {...state, playing: false }
+		case 'LOADING': {
+			return {...state, loading: true}
+		}
+		case 'LOADED': {
+			return {...state, loading: false}
+		}
 		default:
 			return state;
 
@@ -33,6 +39,12 @@ export const actions = {
 	requestPause: () => ({
 		type: 'REQUEST_PAUSE'
 	}),
+	loading: () => ({
+		type: 'LOADING'
+	}),
+	loaded: () => ({
+		type: 'LOADED'
+	}),
 }
 
 
@@ -40,6 +52,8 @@ export const actions = {
 export const middleware = store => {
 
 	const audio = new Audio();
+	audio.preload = 'none';
+
 	// debuging
 	[
 		'loadeddata',
@@ -57,6 +71,14 @@ export const middleware = store => {
 	audio.addEventListener('play', () => store.dispatch(actions.play()));
 
 	audio.addEventListener('pause', () => store.dispatch(actions.pause()));
+
+	// loading / loaded events
+	audio.addEventListener('waiting', () => store.dispatch(actions.loading()));
+	audio.addEventListener('stalled', () => store.dispatch(actions.loading()));
+	audio.addEventListener('loadstart', () => store.dispatch(actions.loading()));
+	audio.addEventListener('loadedmetadata', () => store.dispatch(actions.loading()));
+	audio.addEventListener('loadeddata', () => store.dispatch(actions.loading()));
+	audio.addEventListener('canplay', () => store.dispatch(actions.loaded()));
 
 	return next => action => {
 		switch (action.type) {

--- a/components/x-audio/stories/index.js
+++ b/components/x-audio/stories/index.js
@@ -6,6 +6,7 @@ exports.package = require('../package.json');
 
 // Set up basic document styling using the Origami build service
 exports.dependencies = {
+	'o-loading': '^3.1.1',
 	'o-normalise': '^1.6.0',
 	'o-icons': "^5.11.0",
 	'o-typography': '^5.11.0',


### PR DESCRIPTION
***this PR supersedes https://github.com/Financial-Times/x-dash/pull/280 (I have done on a separate branch as it was written by @debugwand, I wanted to make sure the original changes were still in tact)***

x-audio load component

* shows under the various loading events, waiting and stalled
* removed when canplay event fires
* dark when expanded mode, light when minimised
* expecting to inherit colours and background colours from containers

also:
* bower added so we can use typography mixins
* `x-audio` added as a keyword in package json so we can build locally with `athloi run build --filter 'keywords:"x-audio"'` instead of building everything
* `x-test-utils` and our first test file