### PR TITLE
expose source files in packages

### DIFF
--- a/components/x-increment/package.json
+++ b/components/x-increment/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "",
+  "source": "src/Increment.jsx",
   "main": "dist/Increment.cjs.js",
   "module": "dist/Increment.esm.js",
   "browser": "dist/Increment.es5.js",

--- a/components/x-interaction/package.json
+++ b/components/x-interaction/package.json
@@ -2,6 +2,7 @@
   "name": "@financial-times/x-interaction",
   "version": "0.0.0",
   "description": "This module enables you to write x-dash components that respond to events and change their own data.",
+  "source": "src/Interaction.jsx",
   "main": "dist/Interaction.cjs.js",
   "module": "dist/Interaction.esm.js",
   "browser": "dist/Interaction.es5.js",

--- a/components/x-styling-demo/package.json
+++ b/components/x-styling-demo/package.json
@@ -2,6 +2,7 @@
   "name": "@financial-times/x-styling-demo",
   "version": "0.0.0",
   "description": "",
+  "source": "src/Button.jsx",
   "main": "dist/Button.cjs.js",
   "browser": "dist/Button.es5.js",
   "module": "dist/Button.esm.js",

--- a/components/x-teaser/.npmignore
+++ b/components/x-teaser/.npmignore
@@ -1,3 +1,2 @@
-src/
 stories/
 rollup.config.js

--- a/components/x-teaser/package.json
+++ b/components/x-teaser/package.json
@@ -2,6 +2,7 @@
   "name": "@financial-times/x-teaser",
   "version": "0.0.0",
   "description": "This module provides templates for use with o-teaser. Teasers are used to present content.",
+  "source": "src/Teaser.jsx",
   "main": "dist/Teaser.cjs.js",
   "module": "dist/Teaser.esm.js",
   "browser": "dist/Teaser.es5.js",


### PR DESCRIPTION
from conversation with @pavelpichrt: Apps Team would like to be able to use their own webpack configuration for x-dash components, to interoperate with their CSS modules configuration and other tooling. Previously, x-teaser'ds source files were being excluded by the npmignore, preventing this.

This PR also adds the `source` field to every component, allowing tooling to pick up on it and do e.g. for webpack:

```js
{
  resolve: {mainFields: ['source', 'browser', 'module', 'main']}}
}
```

allowing `import {Teaser} from '@financial-times/x-teaser'` to load the source JSX