### PR TITLE
Keep 1 mins remaining  when it is less than 1 mins

### DIFF
--- a/components/x-audio/src/components/TimeRemaining.jsx
+++ b/components/x-audio/src/components/TimeRemaining.jsx
@@ -4,8 +4,8 @@ import classNameMap from './classnames-helper';
 import formatToHMMSS from './format-seconds-to-hmmss';
 
 const formatToMinsRemaining = (targetSeconds) => {
-	const minutes = Math.floor((targetSeconds / 60));
-	return `${minutes} mins remaining`;
+	const minutes = Math.round((targetSeconds / 60));
+	return `${ minutes > 1 ? minutes : 1 } mins remaining`;
 }
 
 export const TimeRemaining = ({


### PR DESCRIPTION
For minimised player
![Screenshot 2019-05-13 at 11 11 22](https://user-images.githubusercontent.com/21194161/57633615-b5ae7200-759b-11e9-8edb-db210493325f.png)

I have confirmed with designer Luke, it should keep displaying "1 mins remaining" when the remaining is less than 1 mins
https://github.com/Financial-Times/x-dash/pull/289#discussion_r282922673

- Change `Math.floor()` => `Math.round()`
- Keep "1 mins remaining" when the remaining is less than 1 mins