### PR TITLE
O audio integration

### DIFF
--- a/components/x-audio/package.json
+++ b/components/x-audio/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@financial-times/x-engine": "file:../../packages/x-engine",
-    "@financial-times/o-audio": "1.0.0-beta.7",
+    "@financial-times/o-audio": "1.0.0-beta.9",
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",
     "redux": "^4.0.1"

--- a/components/x-audio/package.json
+++ b/components/x-audio/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@financial-times/x-engine": "file:../../packages/x-engine",
+    "@financial-times/o-audio": "1.0.0-beta.7",
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",
     "redux": "^4.0.1"

--- a/components/x-audio/src/redux/__mocks__/@financial-times/o-audio.js
+++ b/components/x-audio/src/redux/__mocks__/@financial-times/o-audio.js
@@ -1,0 +1,1 @@
+export const Tracking = function () {}

--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -211,11 +211,11 @@ describe('middleware', () => {
 	});
 
 	describe('willClose', () => {
-		const { invoke, audio, trackingMock } = create();
+		const { invoke, store, trackingMock } = create();
 		invoke(actions.willClose());
 
 		test('pauses audio', () => {
-			expect(audio.pause).toHaveBeenCalled();
+			expect(store.dispatch).toHaveBeenCalledWith(actions.requestPause());
 		});
 
 		test('finishes tracking', () => {

--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -100,9 +100,9 @@ describe('middleware', () => {
 			expect(audio.src).toBe('https://local.ft.com/url');
 		});
 
-		test('configures tracking context', () => {
+		test('starts tracking with context', () => {
 			expect(
-				trackingMock.setContext
+				trackingMock.start
 			).toHaveBeenCalledWith({contentId: 'abc-123' });
 		});
 
@@ -168,17 +168,6 @@ describe('middleware', () => {
 			expect(store.dispatch).toHaveBeenCalledWith(actions.loading());
 		});
 	});
-
-	describe('HTML loadedmetadata event', () => {
-		const { store, audio, trackingMock } = create();
-		audio.dispatchEvent(new Event('loadedmetadata'));
-		test('dispatches loading action', () => {
-			expect(store.dispatch).toHaveBeenCalledWith(actions.loading());
-		});
-		test('starts tracking', () => {
-			expect(trackingMock.start).toHaveBeenCalled();
-		});
-	})
 
 	test('HTML canplay event dispatches loaded action', () => {
 		const { store, audio } = create();

--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -106,7 +106,7 @@ describe('middleware', () => {
 				trackingMock.setContext
 			).toHaveBeenCalledWith({contentId: 'abc-123' });
 		});
-	})
+	});
 
 
 	test('requestPlay plays', () => {
@@ -196,6 +196,19 @@ describe('middleware', () => {
 		audio.dispatchEvent(new Event('timeupdate'));
 
 		expect(store.dispatch).not.toHaveBeenCalled();
+	});
+
+	describe('willClose', () => {
+		const { invoke, audio, trackingMock } = create();
+		invoke(actions.willClose());
+
+		test('pauses audio', () => {
+			expect(audio.pause).toHaveBeenCalled();
+		});
+
+		test('finishes tracking', () => {
+			expect(trackingMock.finish).toHaveBeenCalled();
+		});
 	});
 
 });

--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -110,7 +110,7 @@ describe('middleware', () => {
 			expect(store.dispatch).not.toHaveBeenCalled();
 		});
 
-		test('starting playing when autoplay is true', () => {
+		test('starts playing when autoplay is true', () => {
 			const { invoke, store } = create();
 			invoke(actions.loadMedia({
 				url: 'https://local.ft.com/url',

--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -90,8 +90,7 @@ describe('middleware', () => {
 	}
 
 	describe('loadMedia', () => {
-		const { invoke, audio, trackingMock } = create();
-
+		const { invoke, audio, trackingMock, store } = create();
 		invoke(actions.loadMedia({
 			url: 'https://local.ft.com/url',
 			trackingContext: { contentId: 'abc-123' }
@@ -106,6 +105,19 @@ describe('middleware', () => {
 				trackingMock.setContext
 			).toHaveBeenCalledWith({contentId: 'abc-123' });
 		});
+
+		test('by default does not autoplay', () => {
+			expect(store.dispatch).not.toHaveBeenCalled();
+		});
+
+		test('starting playing when autoplay is true', () => {
+			const { invoke, store } = create();
+			invoke(actions.loadMedia({
+				url: 'https://local.ft.com/url',
+				autoplay: true
+			}));
+			expect(store.dispatch).toHaveBeenCalledWith(actions.requestPlay())
+		})
 	});
 
 

--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -1,4 +1,7 @@
 import { middleware, actions, initialState, reducer } from '../player-logic';
+import Tracking from '../tracking';
+jest.mock('../tracking');
+
 const runActions = (initialState, ...actions) => actions.reduce(reducer, initialState);
 
 describe('actions and reducer', () => {
@@ -76,19 +79,35 @@ describe('middleware', () => {
 		}
 		const next = jest.fn();
 		const audio = new Audio();
+		Tracking.mockClear();
+
 		audio.play = jest.fn();
 		audio.pause = jest.fn();
 		const middlewareWithNext = middleware(store, audio)(next);
 		const invoke = action => middlewareWithNext(action)
-
-		return { store, next, invoke, audio };
+		const trackingMock = Tracking.mock.instances[0];
+		return { store, next, invoke, audio, trackingMock };
 	}
 
-	test('loadMedia set the URL', () => {
-		const { invoke, audio } = create();
-		invoke(actions.loadMedia({ url: 'https://local.ft.com/url' }));
-		expect(audio.src).toBe('https://local.ft.com/url');
-	});
+	describe('loadMedia', () => {
+		const { invoke, audio, trackingMock } = create();
+
+		invoke(actions.loadMedia({
+			url: 'https://local.ft.com/url',
+			trackingContext: { contentId: 'abc-123' }
+		}));
+
+		test('sets the URL', () => {
+			expect(audio.src).toBe('https://local.ft.com/url');
+		});
+
+		test('configures tracking context', () => {
+			expect(
+				trackingMock.setContext
+			).toHaveBeenCalledWith({contentId: 'abc-123' });
+		});
+	})
+
 
 	test('requestPlay plays', () => {
 		const { invoke, audio } = create();
@@ -128,7 +147,6 @@ describe('middleware', () => {
 		'waiting',
 		'stalled',
 		'loadstart',
-		'loadedmetadata',
 		'loadeddata'
 	].forEach(action => {
 		test(`HTML ${action} event dispatches loading action`, () => {
@@ -136,6 +154,17 @@ describe('middleware', () => {
 			audio.dispatchEvent(new Event(action));
 
 			expect(store.dispatch).toHaveBeenCalledWith(actions.loading());
+		});
+	});
+
+	describe('HTML loadedmetadata event', () => {
+		const { store, audio, trackingMock } = create();
+		audio.dispatchEvent(new Event('loadedmetadata'));
+		test('dispatches loading action', () => {
+			expect(store.dispatch).toHaveBeenCalledWith(actions.loading());
+		});
+		test('starts tracking', () => {
+			expect(trackingMock.start).toHaveBeenCalled();
 		});
 	})
 

--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -16,13 +16,15 @@ export default function connectPlayer (Player) {
 	const playerActions = wrapWithDispatch(store, {
 		onPlayClick: actions.requestPlay,
 		onPauseClick: actions.requestPause,
-		loadMedia: actions.loadMedia
+		loadMedia: actions.loadMedia,
+		willClose: actions.willClose
 	});
 
 	class ConnectedPlayer extends Component {
 		constructor(props) {
 			super(props);
 			this.unsubscribe = store.subscribe(this.storeUpdated.bind(this));
+			this.onCloseClick = this.onCloseClick.bind(this);
 			this.state = initialState;
 		}
 
@@ -37,8 +39,12 @@ export default function connectPlayer (Player) {
 		}
 
 		componentWillUnmount() {
-			playerActions.onPauseClick();
 			this.unsubscribe();
+		}
+
+		onCloseClick() {
+			playerActions.willClose();
+			this.props.onCloseClick();
 		}
 
 		storeUpdated() {

--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -30,12 +30,7 @@ export default function connectPlayer (Player) {
 
 		componentDidMount() {
 			const { playing, url, trackingContext } = this.props;
-
-			playerActions.loadMedia({ url, trackingContext });
-
-			if (playing) 	{
-				playerActions.onPlayClick();
-			}
+			playerActions.loadMedia({ url, trackingContext, autoplay: playing });
 		}
 
 		componentWillUnmount() {
@@ -59,8 +54,7 @@ export default function connectPlayer (Player) {
 		componentDidUpdate(prevProps, prevState) {
 			const { url, trackingContext } = this.props;
 			if (prevProps.url !== url) {
-				playerActions.loadMedia({ url, trackingContext });
-				playerActions.onPlayClick();
+				playerActions.loadMedia({ url, trackingContext, autoplay: true });
 				return;
 			}
 

--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -24,7 +24,6 @@ export default function connectPlayer (Player) {
 		constructor(props) {
 			super(props);
 			this.unsubscribe = store.subscribe(this.storeUpdated.bind(this));
-			this.onCloseClick = this.onCloseClick.bind(this);
 			this.state = initialState;
 		}
 
@@ -34,12 +33,8 @@ export default function connectPlayer (Player) {
 		}
 
 		componentWillUnmount() {
-			this.unsubscribe();
-		}
-
-		onCloseClick() {
 			playerActions.willClose();
-			this.props.onCloseClick();
+			this.unsubscribe();
 		}
 
 		storeUpdated() {

--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -57,9 +57,9 @@ export default function connectPlayer (Player) {
 		}
 
 		componentDidUpdate(prevProps, prevState) {
-			const { url, metadata } = this.props;
+			const { url, trackingContext } = this.props;
 			if (prevProps.url !== url) {
-				playerActions.loadMedia({ url, metadata });
+				playerActions.loadMedia({ url, trackingContext });
 				playerActions.onPlayClick();
 				return;
 			}
@@ -123,14 +123,19 @@ export default function connectPlayer (Player) {
 			play: () => {},
 			ended: () => {}
 		},
-		onCloseClick: () => {}
+		onCloseClick: () => {},
 	}
 	ConnectedPlayer.propTypes = {
 		notifiers: PropTypes.shape({
 			play: PropTypes.func,
 			pause: PropTypes.func
 		}),
-		onCloseClick: PropTypes.func
+		onCloseClick: PropTypes.func,
+		trackingContext: PropTypes.shape({
+			contentId: PropTypes.string,
+			playerType: PropTypes.string,
+			audioSubtype: PropTypes.string
+		}).isRequired
 	}
 
 	return ConnectedPlayer;

--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -27,9 +27,9 @@ export default function connectPlayer (Player) {
 		}
 
 		componentDidMount() {
-			const { playing, url, metadata } = this.props;
+			const { playing, url, trackingContext } = this.props;
 
-			playerActions.loadMedia({ url, metadata });
+			playerActions.loadMedia({ url, trackingContext });
 
 			if (playing) 	{
 				playerActions.onPlayClick();

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -68,6 +68,9 @@ export const actions = {
 	}),
 	ended: () => ({
 		type: 'ENDED'
+	}),
+	willClose: () => ({
+		type: 'WILL_CLOSE'
 	})
 }
 
@@ -135,6 +138,10 @@ export const middleware = (store, audio = new Audio()) => {
 				break;
 			case 'REQUEST_PAUSE':
 				audio.pause();
+				break;
+			case 'WILL_CLOSE':
+				audio.pause();
+				tracking.finish();
 				break;
 		}
 		next(action);

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -103,10 +103,6 @@ export const middleware = (store, audio = new Audio()) => {
 	audio.addEventListener('waiting', () => store.dispatch(actions.loading()));
 	audio.addEventListener('stalled', () => store.dispatch(actions.loading()));
 	audio.addEventListener('loadstart', () => store.dispatch(actions.loading()));
-	audio.addEventListener('loadedmetadata', () => {
-		tracking.start();
-		store.dispatch(actions.loading());
-	});
 	audio.addEventListener('loadeddata', () => store.dispatch(actions.loading()));
 	audio.addEventListener('canplay', () => store.dispatch(actions.loaded()));
 
@@ -132,7 +128,7 @@ export const middleware = (store, audio = new Audio()) => {
 		switch (action.type) {
 			case 'LOAD_MEDIA':
 				audio.src = action.url;
-				tracking.setContext(action.trackingContext);
+				tracking.start(action.trackingContext);
 				if (action.autoplay) {
 					store.dispatch(actions.requestPlay());
 				}

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -1,3 +1,4 @@
+import Tracking from './tracking'
 // intial state
 export const initialState = {
 	playing: false,
@@ -34,10 +35,10 @@ export function reducer (state = initialState, action) {
 
 // actions
 export const actions = {
-	loadMedia: ({ url, metadata }) => ({
+	loadMedia: ({ url, trackingContext = {} }) => ({
 		type: 'LOAD_MEDIA',
 		url,
-		metadata
+		trackingContext
 	}),
 	play: () => ({
 		type: 'PLAY'
@@ -98,7 +99,10 @@ export const middleware = (store, audio = new Audio()) => {
 	audio.addEventListener('waiting', () => store.dispatch(actions.loading()));
 	audio.addEventListener('stalled', () => store.dispatch(actions.loading()));
 	audio.addEventListener('loadstart', () => store.dispatch(actions.loading()));
-	audio.addEventListener('loadedmetadata', () => store.dispatch(actions.loading()));
+	audio.addEventListener('loadedmetadata', () => {
+		tracking.start();
+		store.dispatch(actions.loading());
+	});
 	audio.addEventListener('loadeddata', () => store.dispatch(actions.loading()));
 	audio.addEventListener('canplay', () => store.dispatch(actions.loaded()));
 
@@ -117,11 +121,14 @@ export const middleware = (store, audio = new Audio()) => {
 
 	audio.addEventListener('ended', () => store.dispatch(actions.ended()));
 
+
+	const tracking = new Tracking(audio);
+
 	return next => action => {
 		switch (action.type) {
 			case 'LOAD_MEDIA':
 				audio.src = action.url;
-				// setup tracking
+				tracking.setContext(action.trackingContext);
 				break;
 			case 'REQUEST_PLAY':
 				audio.play();

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -35,10 +35,11 @@ export function reducer (state = initialState, action) {
 
 // actions
 export const actions = {
-	loadMedia: ({ url, trackingContext = {} }) => ({
+	loadMedia: ({ url, trackingContext = {}, autoplay = false }) => ({
 		type: 'LOAD_MEDIA',
 		url,
-		trackingContext
+		trackingContext,
+		autoplay
 	}),
 	play: () => ({
 		type: 'PLAY'
@@ -132,6 +133,9 @@ export const middleware = (store, audio = new Audio()) => {
 			case 'LOAD_MEDIA':
 				audio.src = action.url;
 				tracking.setContext(action.trackingContext);
+				if (action.autoplay) {
+					store.dispatch(actions.requestPlay());
+				}
 				break;
 			case 'REQUEST_PLAY':
 				audio.play();

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -144,7 +144,7 @@ export const middleware = (store, audio = new Audio()) => {
 				audio.pause();
 				break;
 			case 'WILL_CLOSE':
-				audio.pause();
+				store.dispatch(actions.requestPause());
 				tracking.finish();
 				break;
 		}

--- a/components/x-audio/src/redux/tracking.js
+++ b/components/x-audio/src/redux/tracking.js
@@ -1,4 +1,4 @@
-import OAudioTracking from '@financial-times/o-audio/dist/js/tracking';
+import { Tracking as OAudioTracking } from '@financial-times/o-audio';
 
 export default class Tracking {
 	constructor(audio) {

--- a/components/x-audio/src/redux/tracking.js
+++ b/components/x-audio/src/redux/tracking.js
@@ -4,18 +4,13 @@ export default class Tracking {
 	constructor(audio) {
 		this.audio = audio;
 		this.oAudioTracking = null;
-		this.context = null;
 	}
 
-	setContext(context) {
-		this.context = context;
-	}
-
-	start() {
+	start(context) {
 		if (this.oAudioTracking) {
-			this.finish()
+			this.finish();
 		}
-		this.oAudioTracking = new OAudioTracking(this.audio, this.context);
+		this.oAudioTracking = new OAudioTracking(this.audio, context);
 	}
 
 	finish() {

--- a/components/x-audio/src/redux/tracking.js
+++ b/components/x-audio/src/redux/tracking.js
@@ -1,0 +1,25 @@
+import OAudioTracking from '@financial-times/o-audio/dist/js/tracking';
+
+export default class Tracking {
+	constructor(audio) {
+		this.audio = audio;
+		this.oAudioTracking = null;
+		this.context = null;
+	}
+
+	setContext(context) {
+		this.context = context;
+	}
+
+	start() {
+		if (this.oAudioTracking) {
+			this.finish()
+		}
+		this.oAudioTracking = new OAudioTracking(this.audio, this.context);
+	}
+
+	finish() {
+		this.oAudioTracking.dispatchListenedEvent();
+		this.oAudioTracking.destroy();
+	}
+}

--- a/components/x-audio/stories/knobs.js
+++ b/components/x-audio/stories/knobs.js
@@ -1,6 +1,6 @@
 /*eslint-disable no-console */
 
-module.exports = (data, { boolean, text, number }) => {
+module.exports = (data, { boolean, text, number, object }) => {
 	// Public props can be set externally and their values
 	// with be used by the component, e.g `playing`
 	const PUBLIC = 'Public';
@@ -12,10 +12,9 @@ module.exports = (data, { boolean, text, number }) => {
 		playing: boolean('Playing', data.playing, PUBLIC),
 		expanded: boolean('Expanded', data.expanded, PUBLIC),
 		url: text('Audio url', data.url, PUBLIC),
-
 		currentTime: number('Current time', data.currentTime, {}, PRIVATE),
 		loading: boolean('Loading', data.loading, PRIVATE),
-
+		trackingContext: object('Tracking Context', data.trackingContext, PUBLIC),
 		onPlayClick: () => console.log('Pressed play'),
 		onPauseClick: () => console.log('Pressed pause'),
 		onCloseClick: () => console.log('Pressed close'),

--- a/components/x-audio/stories/redux-player.js
+++ b/components/x-audio/stories/redux-player.js
@@ -6,6 +6,9 @@ exports.data = {
 	title: 'Notre-Dame fire, Goldman slips, Netflix spend',
 	seriesName: 'FT News Briefing',
 	url: 'https://media.acast.com/ftnewsbriefing/tuesday-may7/media.mp3',
+	trackingContext: {
+		contentId: 'abc-123'
+	}
 };
 
 // This reference is only required for hot module loading in development


### PR DESCRIPTION
So we maintain the same audio tracking events as the current audio player has, we need to hook up the o-audio library.

This adds a new prop `trackingContext` which looks like:
```
trackingContext: PropTypes.shape({
  contentId: PropTypes.string,
  playerType: PropTypes.string,
  audioSubtype: PropTypes.string
}).isRequired
```

The [Tracking](https://github.com/Financial-Times/o-audio/blob/master/src/js/tracking.js) class within o-audio is being pulled in explicitly.
