### PR TITLE
reinstate space just for premium label

### DIFF
--- a/components/x-teaser/src/Title.jsx
+++ b/components/x-teaser/src/Title.jsx
@@ -16,8 +16,11 @@ export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators
 				{displayTitle}
 			</Link>
 			{indicators && indicators.accessLevel === 'premium' ? (
-				<span className={premiumClass} aria-label="Premium content">
-					Premium
+				<span>
+					{' '}
+					<span className={premiumClass} aria-label="Premium content">
+						Premium
+					</span>
 				</span>
 			) : null}
 		</div>


### PR DESCRIPTION
Reverts the change made in https://github.com/Financial-Times/x-dash/pull/282 with as slight amend so space is only applied when a premium content label is required.

Fixes part of the bug raised here: https://trello.com/c/CkoIA7pZ/889-padding-issue-with-topic-tracker-label

![spacing_on_teaser_title](https://user-images.githubusercontent.com/6670598/57916632-25b64400-788b-11e9-9c0a-bd9a7d3b1b22.png)

Following a discussion with Lee about amending this in o-tracker it was recommened that the fix was made in x-teaser: https://financialtimes.slack.com/archives/C02FU5ARJ/p1557917172106700