### PR TITLE
Need to set error to false for load for recovery mid-stream

### DIFF
--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -19,7 +19,7 @@ export function reducer (state = initialState, action) {
 		case 'PAUSE':
 			return { ...state, playing: false };
 		case 'LOADING':
-			return { ...state, loading: true };
+			return { ...state, loading: true, error: false };
 		case 'LOADED':
 			return { ...state, loading: false };
 		case 'UPDATE_DURATION':


### PR DESCRIPTION
ensure text is always reset from error to loading regardless of when it was thrown