### PR TITLE
Add the ended notifier to notifiers class

### DIFF
--- a/components/x-audio/src/redux/middleware/notifier.js
+++ b/components/x-audio/src/redux/middleware/notifier.js
@@ -26,6 +26,9 @@ export class NotifiersProxy {
 	get pause() {
 		return this.getFunc('pause');
 	}
+	get ended() {
+		return this.getFunc('ended');
+	}
 }
 
 


### PR DESCRIPTION
This fixes the bug when the player doesn't automatically close when finished.

https://trello.com/c/wsnikIsM/451-minimised-audio-player-should-close-after-the-audio-has-ended