### PR TITLE
Modify mins remaining => min remaining

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -22,7 +22,7 @@ exports[`@financial-times/x-audio renders a default App player x-audio 1`] = `
   <div
     className="styles_audio-player__info__remaining__2uHGl"
   >
-    1 mins remaining
+    1 min remaining
   </div>
   <button
     aria-label="play"

--- a/components/x-audio/src/components/TimeRemaining.jsx
+++ b/components/x-audio/src/components/TimeRemaining.jsx
@@ -5,7 +5,7 @@ import formatToHMMSS from './format-seconds-to-hmmss';
 
 const formatToMinsRemaining = (targetSeconds) => {
 	const minutes = Math.round((targetSeconds / 60));
-	return `${ minutes > 1 ? minutes : 1 } mins remaining`;
+	return `${ minutes > 1 ? minutes : 1 } min remaining`;
 }
 
 export const TimeRemaining = ({


### PR DESCRIPTION
To keep consistency with other place,
- the time next to play button on podcast pages on APP(min)
- in teasers(min)
- homepage podcast slice on ft.com(min)

**BEFORE**
![Screenshot 2019-05-31 at 11 22 13](https://user-images.githubusercontent.com/21194161/58700573-55d80980-8398-11e9-835b-66cb53ee1c3b.png)

**AFTER**
![Screenshot 2019-05-31 at 11 37 04](https://user-images.githubusercontent.com/21194161/58700604-7011e780-8398-11e9-8bb7-681c45e6cdd2.png)

