### PR TITLE
Switch off click events have key events a11y rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,8 @@ module.exports = {
 		// this rule is deprecated and replaced with label-has-associated-control
 		'jsx-a11y/label-has-for': 'off',
 		'jsx-a11y/label-has-associated-control': 'error',
+		// this rule is incorrect
+		'jsx-a11y/click-events-have-key-events': 'off'
 	},
 	overrides: [
 		{


### PR DESCRIPTION
click events are triggered with a) mouse click b) pressing enter when focussed on an element c) double tapping when focussed on an element and using a screenreader

mousedown, mouseover, mouseup events need keyboard alternatives. not clicks.

very simple POC https://jsbin.com/weginoduka/edit?html,js,output