### PR TITLE
Fire `WILL_CLOSE` action with onCloseClick, rather than on unmount

### DIFF
--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -27,6 +27,7 @@ export default function connectPlayer (Player) {
 			super(props);
 			notifiersProxy.set(props.notifiers);
 			this.unsubscribe = store.subscribe(this.storeUpdated.bind(this));
+			this.onCloseClick = this.onCloseClick.bind(this);
 			this.state = initialState;
 		}
 
@@ -36,7 +37,6 @@ export default function connectPlayer (Player) {
 		}
 
 		componentWillUnmount() {
-			playerActions.willClose();
 			this.unsubscribe();
 		}
 
@@ -77,8 +77,14 @@ export default function connectPlayer (Player) {
 			}
 		}
 
+		onCloseClick() {
+			playerActions.willClose();
+			this.props.onCloseClick();
+		}
+
 		render() {
-			const { title, seriesName, onCloseClick, expanded, showPersistentPlayerWIP } = this.props;
+			const { onCloseClick } = this;
+			const { title, seriesName, expanded, showPersistentPlayerWIP } = this.props;
 			const { playing, currentTime, loading, duration, error } = this.state;
 			return <Player
 				{...playerActions}


### PR DESCRIPTION
This is to fix a race condition where the close event is firing as soon as the close button is clicked, which results in the Redux state being cleared.

The tracking notifier is then run, which reports a `time_since_open` property. This is impossible to calculate because the time the player was opened is kept in Redux state, which has since been cleared.

So by moving the action into our own close button control, we can be sure the tracking notifier is called before we clear the state.