### PR TITLE
Do not display remaining time's decimal point

### DIFF
--- a/components/x-audio/__tests__/format-seconds-to-hmmss.test.js
+++ b/components/x-audio/__tests__/format-seconds-to-hmmss.test.js
@@ -26,4 +26,12 @@ describe('Format seconds to h:mm:ss', () => {
 			expect(subject(60 * 60)).toBe('1:00:00');
 		});
 	});
+
+	describe('target has decimal point', () => {
+		it('should return h:mm:ss with correct number', () => {
+			expect(subject(1.11111)).toBe('00:01');
+			expect(subject(1.55555)).toBe('00:02');
+			expect(subject((1 * 3600) + (59 * 60) + 59.5)).toBe('2:00:00');
+		});
+	});
 })

--- a/components/x-audio/src/components/TimeRemaining.jsx
+++ b/components/x-audio/src/components/TimeRemaining.jsx
@@ -20,7 +20,7 @@ export const TimeRemaining = ({
 		<div className={classNameMap('audio-player__info__remaining')}>
 			{remainingText}
 		</div>
-	)
+	);
 }
 
 TimeRemaining.defaultProps = {

--- a/components/x-audio/src/components/format-seconds-to-hmmss.js
+++ b/components/x-audio/src/components/format-seconds-to-hmmss.js
@@ -1,8 +1,9 @@
 //format seconds to h:mm:ss or mm:ss(when less than an hour)
 export default (targetSeconds) => {
-	let hours   = Math.floor(targetSeconds / 3600);
-	let minutes = Math.floor((targetSeconds - (hours * 3600)) / 60);
-	let seconds = targetSeconds - (hours * 3600) - (minutes * 60);
+	const roundedTargetSec =  Math.round(targetSeconds);
+	let hours   = Math.floor(roundedTargetSec / 3600);
+	let minutes = Math.floor((roundedTargetSec - (hours * 3600)) / 60);
+	let seconds = roundedTargetSec - (hours * 3600) - (minutes * 60);
 
 	const displayMin = minutes < 10 ? `0${minutes}` : minutes;
 	const displaySec = seconds < 10 ? `0${seconds}` : seconds;


### PR DESCRIPTION
**BEFORE**
![Screenshot 2019-06-06 at 09 54 13](https://user-images.githubusercontent.com/21194161/59026272-e6f22900-884d-11e9-8e5f-962e2778fed0.png)


**AFTER**
![Screenshot 2019-06-06 at 11 19 35](https://user-images.githubusercontent.com/21194161/59025991-57e51100-884d-11e9-9f4b-d71a0ad134b0.png)
