### PR TITLE
Fix expanded player not set swipe down

### DIFF
--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -6,6 +6,8 @@ import createStore from './store';
 import { NotifiersProxy } from './middleware/notifier';
 import handleSwipeDown from '../components/handle-swipe-down';
 
+const swipeDownClass = 'added-swipe-down';
+
 function wrapWithDispatch ({ dispatch }, actionsMap) {
 	return Object.keys(actionsMap).reduce((acc, actionName) => ({
 		...acc,
@@ -35,7 +37,6 @@ export default function connectPlayer (Player) {
 			this.setExpandedPlayerRef = element => {
 				this.expandedPlayerRef = element;
 			};
-			this.hasSwipeDownListener = false;
 			this.state = initialState;
 			this.hammer = undefined;
 		}
@@ -44,7 +45,7 @@ export default function connectPlayer (Player) {
 			const { playing, url, trackingContext } = this.props;
 			playerActions.loadMedia({ url, trackingContext, autoplay: playing });
 
-			if (this.expandedPlayerRef && !this.hasSwipeDownListener) {
+			if (this.expandedPlayerRef) {
 				this.listenForSwipeDown(this.expandedPlayerRef);
 			}
 		}
@@ -81,7 +82,7 @@ export default function connectPlayer (Player) {
 				this.updatePlayingStateFromProps(prevProps);
 			}
 
-			if (this.expandedPlayerRef && !this.hasSwipeDownListener) {
+			if (this.expandedPlayerRef && !this.expandedPlayerRef.classList.contains(swipeDownClass)) {
 				this.listenForSwipeDown(this.expandedPlayerRef);
 			}
 		}
@@ -97,7 +98,7 @@ export default function connectPlayer (Player) {
 				handleSwipeDown(ev, onSwipeEnd, expandedPlayerRef);
 			});
 
-			this.hasSwipeDownListener = true;
+			expandedPlayerRef.classList.add(swipeDownClass);
 		}
 
 		playingStateAndPropsNeedSync() {

--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -6,8 +6,6 @@ import createStore from './store';
 import { NotifiersProxy } from './middleware/notifier';
 import handleSwipeDown from '../components/handle-swipe-down';
 
-const swipeDownClass = 'added-swipe-down';
-
 function wrapWithDispatch ({ dispatch }, actionsMap) {
 	return Object.keys(actionsMap).reduce((acc, actionName) => ({
 		...acc,
@@ -82,7 +80,7 @@ export default function connectPlayer (Player) {
 				this.updatePlayingStateFromProps(prevProps);
 			}
 
-			if (this.expandedPlayerRef && !this.expandedPlayerRef.classList.contains(swipeDownClass)) {
+			if (this.expandedPlayerRef && this.expandedPlayerRef !== this.expandedPlayerListensSwipe) {
 				this.listenForSwipeDown(this.expandedPlayerRef);
 			}
 		}
@@ -98,7 +96,7 @@ export default function connectPlayer (Player) {
 				handleSwipeDown(ev, onSwipeEnd, expandedPlayerRef);
 			});
 
-			expandedPlayerRef.classList.add(swipeDownClass);
+			this.expandedPlayerListensSwipe = expandedPlayerRef;
 		}
 
 		playingStateAndPropsNeedSync() {


### PR DESCRIPTION
`this.hasSwipeDownListener` was not working as what it should be. It's never reset the value once it was set. 

I missed this bug because expanded player behaves differently between ft-app and storybook. On ft-app it works fine(the detail below). However the ft-app behaviour is incorrect and also the `hasSwipeDownListener` value is incorrect anyway.

------
 :confused: Weird behaviour on ft-app

When I change the player like the below, the player works differently between storybook and ft-app.
`minimised player` => `expanded player`1️⃣  => `minimised player` => `expanded player`2️⃣ 

**Storybook**
The expanded player 1️⃣  do swipe action.
The expanded player 2️⃣  doesn't do swipe action.

**ft-app**
The expanded player 1️⃣  do swipe action.
The expanded player 2️⃣  do swipe action.

I'm not sure the reason but it looks like the player on ft-app opens the cached expanded player every time once it was created.