### PR TITLE
x-audio: Respond to external changes to expanded props

### DIFF
--- a/components/x-audio/src/redux/__tests__/middleware/notifier.test.js
+++ b/components/x-audio/src/redux/__tests__/middleware/notifier.test.js
@@ -134,7 +134,7 @@ describe('Notifier middleware', () => {
 		});
 
 
-		test(`MINIMISE action does not trigger tracking notification`, () => {
+		test(`MINIMISE action triggers notifier, but no tracking`, () => {
 			const { invoke, notifier, next } = create(state);
 			const action = actions.minimise()
 			invoke(action);

--- a/components/x-audio/src/redux/__tests__/middleware/notifier.test.js
+++ b/components/x-audio/src/redux/__tests__/middleware/notifier.test.js
@@ -125,6 +125,15 @@ describe('Notifier middleware', () => {
 			expect(next).toHaveBeenCalledWith(action);
 		});
 
+		test('EXPAND with willNotify=false does not trigger tracking notification', () => {
+			const { invoke, notifier } = create();
+			const action = actions.expand({ willNotify: false });
+			invoke(action);
+			expect(notifier.expand).not.toHaveBeenCalled();
+			expect(notifier.tracking).not.toHaveBeenCalled();
+		});
+
+
 		test(`MINIMISE action triggers tracking notification`, () => {
 			const { invoke, notifier, next } = create(state);
 			const action = actions.minimise()

--- a/components/x-audio/src/redux/__tests__/middleware/notifier.test.js
+++ b/components/x-audio/src/redux/__tests__/middleware/notifier.test.js
@@ -125,7 +125,7 @@ describe('Notifier middleware', () => {
 			expect(next).toHaveBeenCalledWith(action);
 		});
 
-		test('EXPAND with willNotify=false does not trigger tracking notification', () => {
+		test('EXPAND with willNotify=false does not trigger notifier', () => {
 			const { invoke, notifier } = create();
 			const action = actions.expand({ willNotify: false });
 			invoke(action);
@@ -134,12 +134,12 @@ describe('Notifier middleware', () => {
 		});
 
 
-		test(`MINIMISE action triggers tracking notification`, () => {
+		test(`MINIMISE action does not trigger tracking notification`, () => {
 			const { invoke, notifier, next } = create(state);
 			const action = actions.minimise()
 			invoke(action);
 			expect(notifier.minimise).toHaveBeenCalled();
-			expect(notifier.tracking).toHaveBeenCalledWith('minimise', state)
+			expect(notifier.tracking).not.toHaveBeenCalled();
 			expect(next).toHaveBeenCalledWith(action);
 		});
 

--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -68,7 +68,7 @@ export default function connectPlayer (Player) {
 		}
 
 		componentDidUpdate(prevProps) {
-			const { url, trackingContext, notifiers } = this.props;
+			const { url, trackingContext, notifiers, expanded } = this.props;
 			if (prevProps.url !== url) {
 				playerActions.loadMedia({ url, trackingContext, autoplay: true });
 				return;
@@ -80,6 +80,14 @@ export default function connectPlayer (Player) {
 
 			if (this.playingStateAndPropsNeedSync()) {
 				this.updatePlayingStateFromProps(prevProps);
+			}
+
+			if (prevProps.expanded !== expanded) {
+				if (expanded) {
+					playerActions.onExpand();
+				} else {
+					playerActions.onMinimise();
+				}
 			}
 
 			if (this.expandedPlayerRef && this.expandedPlayerRef !== this.expandedPlayerListensSwipe) {

--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -84,9 +84,9 @@ export default function connectPlayer (Player) {
 
 			if (this.state.expanded !== expanded) {
 				if (!prevProps.expanded && expanded) {
-					playerActions.onExpand();
+					playerActions.onExpand({ willNotify: false });
 				} else if (prevProps.expanded && !expanded) {
-					playerActions.onMinimise();
+					playerActions.onMinimise({ willNotify: false });
 				}
 			}
 

--- a/components/x-audio/src/redux/index.jsx
+++ b/components/x-audio/src/redux/index.jsx
@@ -82,10 +82,10 @@ export default function connectPlayer (Player) {
 				this.updatePlayingStateFromProps(prevProps);
 			}
 
-			if (prevProps.expanded !== expanded) {
-				if (expanded) {
+			if (this.state.expanded !== expanded) {
+				if (!prevProps.expanded && expanded) {
 					playerActions.onExpand();
-				} else {
+				} else if (prevProps.expanded && !expanded) {
 					playerActions.onMinimise();
 				}
 			}

--- a/components/x-audio/src/redux/middleware/notifier.js
+++ b/components/x-audio/src/redux/middleware/notifier.js
@@ -84,8 +84,10 @@ const notificationsMiddleware = notifiers => store => {
 				break;
 
 			case EXPAND:
-				notifiers.expand();
-				track('expand');
+				if (action.willNotify) {
+					notifiers.expand();
+					track('expand');
+				}
 				break;
 
 			case MINIMISE:

--- a/components/x-audio/src/redux/middleware/notifier.js
+++ b/components/x-audio/src/redux/middleware/notifier.js
@@ -93,7 +93,6 @@ const notificationsMiddleware = notifiers => store => {
 			case MINIMISE:
 				if (action.willNotify) {
 					notifiers.minimise();
-					track('minimise');
 				}
 				break;
 

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -123,8 +123,9 @@ export const actions = {
 	willClose: () => ({
 		type: WILL_CLOSE
 	}),
-	expand: () => ({
-		type: EXPAND
+	expand: ({ willNotify = true } = {}) => ({
+		type: EXPAND,
+		willNotify
 	}),
 	minimise: ({ willNotify = true } = {}) => ({
 		type: MINIMISE,


### PR DESCRIPTION
Example use case:

The app displays the expanded player in an overlay, which when clicked, should minimise the player.