### PR TITLE
Update o-audio to v1.0.0-beta.11

### DIFF
--- a/components/x-audio/package.json
+++ b/components/x-audio/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@financial-times/o-audio": "1.0.0-beta.10",
+    "@financial-times/o-audio": "1.0.0-beta.11",
     "@financial-times/x-engine": "file:../../packages/x-engine",
     "classnames": "^2.2.6",
     "hammerjs": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   },
   "workspaces": [
     "components/*",
-    "packages/*",
-    "tools/*"
+    "packages/*"
   ],
   "dependencies": {}
 }


### PR DESCRIPTION
**o-audio@v1.0.0-beta.11**
Add error property in tracking event.detail

This PR includes **Remove `tools/*` from workspaces** because I got this error on Circle builds.
`ENOENT: no such file or directory, stat '/home/circleci/project/build/tools/x-docs/static/storybook'`
https://circleci.com/gh/Financial-Times/x-dash/2944

I removed it not to be bothered by their errors, and also speed up the process of reinstalling and building as Matt H suggested on x channel on slack.
https://financialtimes.slack.com/archives/C10AJEQKS/p1560934866022200

I will add a note on x-audio branch to tell before merging into master we need to put back `tools/*` in `package.json`