### PR TITLE
Call audio.load() on LOAD_MEDIA action to trigger preloading

### DIFF
--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -130,6 +130,7 @@ describe('middleware', () => {
 
 		audio.play = jest.fn();
 		audio.pause = jest.fn();
+		audio.load = jest.fn();
 		const middlewareWithNext = middleware(store, audio)(next);
 		const invoke = action => middlewareWithNext(action)
 		const trackingMock = Tracking.mock.instances[0];
@@ -164,7 +165,11 @@ describe('middleware', () => {
 				autoplay: true
 			}));
 			expect(store.dispatch).toHaveBeenCalledWith(actions.requestPlay({ willNotify: false }))
-		})
+		});
+
+		test('calls audio.load() to trigger preloading', () => {
+			expect(audio.load).toHaveBeenCalled();
+		});
 	});
 
 

--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -263,7 +263,7 @@ describe('middleware', () => {
 
 	test('HTML canplay event dispatches loaded action', () => {
 		const { store, audio } = create();
-		audio.dispatchEvent(new Event('canplay'));
+		audio.dispatchEvent(new Event('canplaythrough'));
 
 		expect(store.dispatch).toHaveBeenCalledWith(actions.loaded());
 	});

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -183,7 +183,7 @@ export const middleware = (store, audio = new Audio()) => {
 	audio.addEventListener('stalled', () => store.dispatch(actions.loading()));
 	audio.addEventListener('loadstart', () => store.dispatch(actions.loading()));
 	audio.addEventListener('loadeddata', () => store.dispatch(actions.loading()));
-	audio.addEventListener('canplay', () => store.dispatch(actions.loaded()));
+	audio.addEventListener('canplaythrough', () => store.dispatch(actions.loaded()));
 
 	audio.addEventListener('durationchange', () => {
 		store.dispatch(actions.updateDuration({ duration: audio.duration }));

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -155,7 +155,7 @@ export const actions = {
 // middleware
 export const middleware = (store, audio = new Audio()) => {
 
-	audio.preload = 'metadata';
+	audio.preload = 'auto';
 
 	// debuging
 	// [
@@ -214,6 +214,7 @@ export const middleware = (store, audio = new Audio()) => {
 				if (action.autoplay) {
 					store.dispatch(actions.requestPlay({ willNotify: false }));
 				}
+				audio.load();
 				break;
 			case REQUEST_PLAY:
 			// eslint-disable-next-line no-case-declarations


### PR DESCRIPTION
This should deal with the delaying in audio being played seen on iOS/Safari devices.

It seems to be that Safari doesn't honour the `audio.preload` attribute until `audio.load()` is called. In other browsers, setting `audio.src` is enough.

Current use case for x-audio is that the audio player is only shown after a user has requested to play audio, so preloading is ok here. In the future we may need to make this an option.