### PR TITLE
Revert "Call audio.load() on LOAD_MEDIA action to trigger preloading"

### DIFF
--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -156,7 +156,6 @@ describe('middleware', () => {
 
 		audio.play = jest.fn();
 		audio.pause = jest.fn();
-		audio.load = jest.fn();
 		const middlewareWithNext = middleware(store, audio)(next);
 		const invoke = action => middlewareWithNext(action)
 		const trackingMock = Tracking.mock.instances[0];
@@ -191,11 +190,7 @@ describe('middleware', () => {
 				autoplay: true
 			}));
 			expect(store.dispatch).toHaveBeenCalledWith(actions.requestPlay({ willNotify: false }))
-		});
-
-		test('calls audio.load() to trigger preloading', () => {
-			expect(audio.load).toHaveBeenCalled();
-		});
+		})
 	});
 
 

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -157,7 +157,7 @@ export const actions = {
 // middleware
 export const middleware = (store, audio = new Audio()) => {
 
-	audio.preload = 'auto';
+	audio.preload = 'metadata';
 
 	// debuging
 	// [
@@ -216,7 +216,6 @@ export const middleware = (store, audio = new Audio()) => {
 				if (action.autoplay) {
 					store.dispatch(actions.requestPlay({ willNotify: false }));
 				}
-				audio.load();
 				break;
 			case REQUEST_PLAY:
 			// eslint-disable-next-line no-case-declarations


### PR DESCRIPTION
This reverts commit 816c3e02e240c066d75ad21bb14bb40aa2b6c1a1.

Calling `audio.load()` at this stage was making Chrome thinking we were violating the autoplay policy.
https://developers.google.com/web/updates/2017/09/autoplay-policy-changes