### PR TITLE
Also set state to loaded when playing

### DIFF
--- a/components/x-audio/src/redux/__tests__/player-logic.test.js
+++ b/components/x-audio/src/redux/__tests__/player-logic.test.js
@@ -256,9 +256,16 @@ describe('middleware', () => {
 		});
 	});
 
-	test('HTML canplay event dispatches loaded action', () => {
+	test('HTML canplaythrough event dispatches loaded action', () => {
 		const { store, audio } = create();
 		audio.dispatchEvent(new Event('canplaythrough'));
+
+		expect(store.dispatch).toHaveBeenCalledWith(actions.loaded());
+	});
+
+	test('HTML playing event dispatches loaded action', () => {
+		const { store, audio } = create();
+		audio.dispatchEvent(new Event('playing'));
 
 		expect(store.dispatch).toHaveBeenCalledWith(actions.loaded());
 	});

--- a/components/x-audio/src/redux/player-logic.js
+++ b/components/x-audio/src/redux/player-logic.js
@@ -184,6 +184,7 @@ export const middleware = (store, audio = new Audio()) => {
 	audio.addEventListener('loadstart', () => store.dispatch(actions.loading()));
 	audio.addEventListener('loadeddata', () => store.dispatch(actions.loading()));
 	audio.addEventListener('canplaythrough', () => store.dispatch(actions.loaded()));
+	audio.addEventListener('playing', () => store.dispatch(actions.loaded()));
 
 	audio.addEventListener('durationchange', () => {
 		store.dispatch(actions.updateDuration({ duration: audio.duration }));


### PR DESCRIPTION
Set x-audio state to loaded when we get the playing event from the audio object, as when events fire can happen in a different order to what you might expect when you fast forward

https://docs.google.com/spreadsheets/d/1lYdCJv74oyVhyHyoyZIR_Lh5TnuyNQ_cifOsvAnrGdU/edit#gid=747106634