### PR TITLE
Column was too wide in expanded mode in safari and iOS app, fixed

### DIFF
--- a/components/x-audio/src/components/styles.scss
+++ b/components/x-audio/src/components/styles.scss
@@ -39,7 +39,7 @@ $image-size: 160px;
 }
 
 .audio-player--expanded {
-	grid-template-columns: 1fr;
+	grid-template-columns: 100%;
 	grid-template-rows: 48px repeat(4, min-content) 96px 72px;
 	grid-template-areas: "minimise-button"
 	"image"


### PR DESCRIPTION
safari and iOS rendering of x-audio expanded mode had a display problem where long text was making the expanded player push beyond the edges of the window. Changing the grid column width unit from 1fr to 100% fixes this