### PR TITLE
ensure 0ish time is always rendered as 00:00

### DIFF
--- a/components/x-audio/src/components/TimeRemaining.jsx
+++ b/components/x-audio/src/components/TimeRemaining.jsx
@@ -14,7 +14,7 @@ export const TimeRemaining = ({
 	duration
 }) => {
 	const remainingSeconds = duration - currentTime;
-	const remainingText = expanded ? `-${formatToHMMSS(remainingSeconds)}` : formatToMinsRemaining(remainingSeconds);
+	const remainingText = expanded ? `-${formatToHMMSS(Math.floor(remainingSeconds))}` : formatToMinsRemaining(remainingSeconds);
 
 	return(
 		<div className={classNameMap('audio-player__info__remaining')}>

--- a/components/x-audio/src/components/__tests__/TimeRemaining.test.jsx
+++ b/components/x-audio/src/components/__tests__/TimeRemaining.test.jsx
@@ -23,6 +23,16 @@ describe('TimeRemaining', () => {
 			const subject = shallow(<TimeRemaining {...props} expanded={true}/>);
 			expect(subject).toMatchSnapshot();
 		});
+		test('should display -00:00 if remaining seconds is less than 1', () => {
+			const subject = shallow(
+				<TimeRemaining {...props}
+					expanded
+					currentTime={59.2}
+					duration={60}
+				/>
+			);
+			expect(subject).toMatchSnapshot();
+		});
 	})
 
 	describe('given expanded is false', () => {

--- a/components/x-audio/src/components/__tests__/__snapshots__/TimeRemaining.test.jsx.snap
+++ b/components/x-audio/src/components/__tests__/__snapshots__/TimeRemaining.test.jsx.snap
@@ -16,6 +16,14 @@ exports[`TimeRemaining given expanded is false should return text in "XX min rem
 </div>
 `;
 
+exports[`TimeRemaining given expanded is true should display -00:00 if remaining seconds is less than 1 1`] = `
+<div
+  className="audio-player__info__remaining"
+>
+  -00:00
+</div>
+`;
+
 exports[`TimeRemaining given expanded is true should return text in HMMSS format 1`] = `
 <div
   className="audio-player__info__remaining"


### PR DESCRIPTION
iOS shows `-00:01` instead of a `-00:00` in time remaining when a show is finished. Andriod is OK.
With this solution, anything under 1 second is shown as `0:00`