### PR TITLE
Add copyToClipboard function

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -596,9 +596,13 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
     </li>
     <li>
       <input
+        readOnly={true}
+        type="text"
         value="https://access.acast.cloud/rss/ft-test/abc-123"
       />
-      <button>
+      <button
+        onClick={[Function]}
+      >
         Copy RSS
       </button>
     </li>

--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -616,6 +616,8 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
     >
       <button
         className="o-buttons o-buttons--primary o-buttons--big"
+        data-url="https://access.acast.cloud/rss/ft-test/abc-123"
+        onClick={[Function]}
       >
         Copy RSS
       </button>

--- a/components/x-podcast-launchers/readme.md
+++ b/components/x-podcast-launchers/readme.md
@@ -40,7 +40,7 @@ const c = React.createElement(PodcastLaunchers, props);
 // within your app's sass file
 @import "x-podcast-launchers/dist/PodcastLaunchers";
 ```
-:warning: This component depends on styles provided by o-forms, and therefore o-forms needs to be imported before x-podcast-launchers.
+:warning: This component depends on styles provided by o-forms and o-buttons, and therefore o-forms and o-buttons needs to be imported before x-podcast-launchers.
 
 All `x-` components are designed to be compatible with a variety of runtimes, not just React. Check out the [`x-engine`][engine] documentation for a list of recommended libraries and frameworks.
 

--- a/components/x-podcast-launchers/src/PodcastLaunchers.css
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.css
@@ -26,13 +26,7 @@
 }
 
 .rss-url__copy-span {
-	-webkit-user-select: text;
-	-khtml-user-select: text;
-	-moz-user-select: text;
-	-ms-user-select: text;
-	-o-user-select: text;
 	user-select: text;
-
 	position: absolute;
 	clip: rect(0 0 0 0);
 	margin: -1px;

--- a/components/x-podcast-launchers/src/PodcastLaunchers.css
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.css
@@ -1,0 +1,45 @@
+.container {
+	width: 100%;
+}
+
+.podcast-app-links__wrapper {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.podcast-app-link {
+	width: 100%;
+	margin-bottom: 8px;
+}
+
+.rss-url__wrapper {
+	margin-top: 0px;
+}
+
+.rss-url__input {
+	max-width: none;
+}
+
+.rss-url__copy-button {
+	padding-left: 0px;
+}
+
+.rss-url__copy-span {
+	-webkit-user-select: text;
+	-khtml-user-select: text;
+	-moz-user-select: text;
+	-ms-user-select: text;
+	-o-user-select: text;
+	user-select: text;
+
+	position: absolute;
+	clip: rect(0 0 0 0);
+	margin: -1px;
+	border: 0;
+	overflow: hidden;
+	padding: 0;
+	width: 1px;
+	height: 1px;
+	white-space: nowrap;
+}

--- a/components/x-podcast-launchers/src/PodcastLaunchers.jsx
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.jsx
@@ -1,7 +1,34 @@
 import { h, Component } from '@financial-times/x-engine';
 import generateAppLinks from './generate-app-links';
 import generateRSSUrl from './generate-rss-url';
+import styles from './PodcastLaunchers.css';
 import copyToClipboard from './copy-to-clipboard';
+
+const basicButtonStyles = [
+	'o-buttons',
+	'o-buttons--primary',
+	'o-buttons--big'
+].join(' ');
+
+const podcastAppLinkStyles = [
+	basicButtonStyles,
+	styles['podcast-app-link']
+].join(' ');
+
+const rssUrlWrapperStyles = [
+	'o-forms__affix-wrapper',
+	styles['rss-url__wrapper']
+].join(' ');
+
+const rssUrlInputStyles = [
+	'o-forms__text',
+	styles['rss-url__input']
+].join(' ');
+
+const rssUrlCopyButtonWrapperStyles = [
+	'o-forms__suffix',
+	styles['rss-url__copy-button']
+].join(' ');
 
 function mapConceptToAcastSeries (/** concept */) {
 	return 'ft-test';
@@ -11,7 +38,7 @@ class PodcastLaunchers extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			rssUrl: null
+			rssUrl: ''
 		}
 	}
 
@@ -29,20 +56,22 @@ class PodcastLaunchers extends Component {
 	render() {
 		const { rssUrl } = this.state;
 		return (
-			<div className='x-podcast-launchers'>
+			<div className={styles['container']}>
 				{rssUrl && (
-					<ul>
+					<ul className={styles['podcast-app-links__wrapper']}>
 					{generateAppLinks(rssUrl).map(({ name, url }) => (
 						<li key={name}>
-							<a href={url}>{name}</a>
+							<a href={url} className={podcastAppLinkStyles}>{name}</a>
 						</li>
 					))}
-					<li>
-						<input type="text" value={rssUrl} readOnly/>
-						<button onClick={copyToClipboard}>Copy RSS</button>
-					</li>
 					</ul>
 				)}
+				<div className={rssUrlWrapperStyles}>
+					<input className={rssUrlInputStyles} value={rssUrl} type='text' readOnly/>
+					<div className={rssUrlCopyButtonWrapperStyles}>
+						<button className={basicButtonStyles} onClick={copyToClipboard}>Copy RSS</button>
+					</div>
+				</div>
 			</div>
 		)
 	}

--- a/components/x-podcast-launchers/src/PodcastLaunchers.jsx
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.jsx
@@ -69,7 +69,7 @@ class PodcastLaunchers extends Component {
 				<div className={rssUrlWrapperStyles}>
 					<input className={rssUrlInputStyles} value={rssUrl} type='text' readOnly/>
 					<div className={rssUrlCopyButtonWrapperStyles}>
-						<button className={basicButtonStyles} onClick={copyToClipboard}>Copy RSS</button>
+						<button className={basicButtonStyles} onClick={copyToClipboard} data-url={rssUrl}>Copy RSS</button>
 					</div>
 				</div>
 			</div>

--- a/components/x-podcast-launchers/src/PodcastLaunchers.jsx
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.jsx
@@ -1,6 +1,7 @@
 import { h, Component } from '@financial-times/x-engine';
 import generateAppLinks from './generate-app-links';
 import generateRSSUrl from './generate-rss-url';
+import copyToClipboard from './copy-to-clipboard';
 
 function mapConceptToAcastSeries (/** concept */) {
 	return 'ft-test';
@@ -37,8 +38,8 @@ class PodcastLaunchers extends Component {
 						</li>
 					))}
 					<li>
-						<input value={rssUrl}/>
-						<button>Copy RSS</button>
+						<input type="text" value={rssUrl} readOnly/>
+						<button onClick={copyToClipboard}>Copy RSS</button>
 					</li>
 					</ul>
 				)}

--- a/components/x-podcast-launchers/src/copy-to-clipboard.js
+++ b/components/x-podcast-launchers/src/copy-to-clipboard.js
@@ -1,0 +1,25 @@
+export default function  copyToClipboard (event) {
+	const inputEl = event.target.parentElement.querySelector('input');
+	const oldContentEditable = inputEl.contentEditable;
+	const oldReadOnly = inputEl.readOnly;
+	const range = document.createRange();
+
+	inputEl.contenteditable = true;
+	inputEl.readonly = false;
+	inputEl.focus();
+	range.selectNodeContents(inputEl);
+
+	const selection = window.getSelection();
+
+	try {
+		selection.removeAllRanges();
+		selection.addRange(range);
+		inputEl.setSelectionRange(0, 999999);
+	} catch (err) {
+		inputEl.select(); // IE11 etc.
+	}
+	inputEl.contentEditable = oldContentEditable;
+	inputEl.readOnly = oldReadOnly;
+	document.execCommand('copy');
+	inputEl.blur();
+}

--- a/components/x-podcast-launchers/src/copy-to-clipboard.js
+++ b/components/x-podcast-launchers/src/copy-to-clipboard.js
@@ -1,5 +1,5 @@
 export default function  copyToClipboard (event) {
-	const inputEl = event.target.parentElement.querySelector('input');
+	const inputEl = event.target.parentElement.parentElement.querySelector('input');
 	const oldContentEditable = inputEl.contentEditable;
 	const oldReadOnly = inputEl.readOnly;
 	const range = document.createRange();

--- a/components/x-podcast-launchers/src/copy-to-clipboard.js
+++ b/components/x-podcast-launchers/src/copy-to-clipboard.js
@@ -1,25 +1,21 @@
+import styles from './PodcastLaunchers.css';
+
 export default function  copyToClipboard (event) {
-	const inputEl = event.target.parentElement.parentElement.querySelector('input');
-	const oldContentEditable = inputEl.contentEditable;
-	const oldReadOnly = inputEl.readOnly;
+	const url = event.target.dataset.url;
+	const containerEl = event.target.parentElement;
+	const rssLink = document.createElement('span');
+
+	rssLink.classList.add(styles['rss-url__copy-span']);
+	rssLink.appendChild(document.createTextNode(url));
+	containerEl.appendChild(rssLink);
+
 	const range = document.createRange();
 
-	inputEl.contenteditable = true;
-	inputEl.readonly = false;
-	inputEl.focus();
-	range.selectNodeContents(inputEl);
-
-	const selection = window.getSelection();
-
-	try {
-		selection.removeAllRanges();
-		selection.addRange(range);
-		inputEl.setSelectionRange(0, 999999);
-	} catch (err) {
-		inputEl.select(); // IE11 etc.
-	}
-	inputEl.contentEditable = oldContentEditable;
-	inputEl.readOnly = oldReadOnly;
+	window.getSelection().removeAllRanges();
+	range.selectNode(rssLink);
+	window.getSelection().addRange(range);
 	document.execCommand('copy');
-	inputEl.blur();
+
+	window.getSelection().removeAllRanges();
+	containerEl.removeChild(rssLink);
 }


### PR DESCRIPTION
`user-select: none;` is set in ft-app's body. Therefore `span` needs to be set `user-select: text;` otherwise it won't select the text to copy.

I have checked that this copy function works on Chrome, Safari, firefox and IE11.