### PR TITLE
Podcast link fixes

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -570,7 +570,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       <a
         className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcast-app-link__16Wuo"
         data-trackable="apple-podcasts"
-        href="podcast://https%3A%2F%2Faccess.acast.cloud%2Frss%2Fft-test%2Fabc-123"
+        href="podcast://access.acast.cloud/rss/ft-test/abc-123"
       >
         Apple Podcasts
       </a>
@@ -579,7 +579,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       <a
         className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcast-app-link__16Wuo"
         data-trackable="overcast"
-        href="overcast://x-callback-url/add?url=https%3A%2F%2Faccess.acast.cloud%2Frss%2Fft-test%2Fabc-123"
+        href="overcast://x-callback-url/add?url=access.acast.cloud/rss/ft-test/abc-123"
       >
         Overcast
       </a>
@@ -588,7 +588,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       <a
         className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcast-app-link__16Wuo"
         data-trackable="pocket-casts"
-        href="pktc://subscribe/https%3A%2F%2Faccess.acast.cloud%2Frss%2Fft-test%2Fabc-123"
+        href="pktc://subscribe/access.acast.cloud/rss/ft-test/abc-123"
       >
         Pocket Casts
       </a>
@@ -597,7 +597,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       <a
         className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcast-app-link__16Wuo"
         data-trackable="podcast-addict"
-        href="podcastaddict://https%3A%2F%2Faccess.acast.cloud%2Frss%2Fft-test%2Fabc-123"
+        href="podcastaddict://access.acast.cloud/rss/ft-test/abc-123"
       >
         Podcast Addict
       </a>
@@ -606,7 +606,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       <a
         className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcast-app-link__16Wuo"
         data-trackable="acast"
-        href="acast://subscribe/https%3A%2F%2Faccess.acast.cloud%2Frss%2Fft-test%2Fabc-123"
+        href="acast://subscribe/https://access.acast.cloud/rss/ft-test/abc-123"
       >
         Acast
       </a>
@@ -619,14 +619,14 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       className="o-forms__text PodcastLaunchers_rss-url__input__2Nm4J"
       readOnly={true}
       type="text"
-      value="https://access.acast.cloud/rss/ft-test/abc-123"
+      value="access.acast.cloud/rss/ft-test/abc-123"
     />
     <div
       className="o-forms__suffix PodcastLaunchers_rss-url__copy-button__1aSjC"
     >
       <button
         className="o-buttons o-buttons--primary o-buttons--big"
-        data-url="https://access.acast.cloud/rss/ft-test/abc-123"
+        data-url="access.acast.cloud/rss/ft-test/abc-123"
         onClick={[Function]}
       >
         Copy RSS

--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -579,7 +579,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       <a
         className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcast-app-link__16Wuo"
         data-trackable="overcast"
-        href="overcast://x-callback-url/add?url=access.acast.cloud/rss/ft-test/abc-123"
+        href="overcast://x-callback-url/add?url=http://access.acast.cloud/rss/ft-test/abc-123"
       >
         Overcast
       </a>
@@ -606,7 +606,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       <a
         className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcast-app-link__16Wuo"
         data-trackable="acast"
-        href="acast://subscribe/https://access.acast.cloud/rss/ft-test/abc-123"
+        href="acast://subscribe/http://access.acast.cloud/rss/ft-test/abc-123"
       >
         Acast
       </a>

--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -579,7 +579,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       <a
         className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcast-app-link__16Wuo"
         data-trackable="overcast"
-        href="overcast://x-callback-url/add?url=http://access.acast.cloud/rss/ft-test/abc-123"
+        href="overcast://x-callback-url/add?url=https://access.acast.cloud/rss/ft-test/abc-123"
       >
         Overcast
       </a>
@@ -606,7 +606,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       <a
         className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcast-app-link__16Wuo"
         data-trackable="acast"
-        href="acast://subscribe/http://access.acast.cloud/rss/ft-test/abc-123"
+        href="acast://subscribe/https://access.acast.cloud/rss/ft-test/abc-123"
       >
         Acast
       </a>
@@ -619,14 +619,14 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       className="o-forms__text PodcastLaunchers_rss-url__input__2Nm4J"
       readOnly={true}
       type="text"
-      value="access.acast.cloud/rss/ft-test/abc-123"
+      value="https://access.acast.cloud/rss/ft-test/abc-123"
     />
     <div
       className="o-forms__suffix PodcastLaunchers_rss-url__copy-button__1aSjC"
     >
       <button
         className="o-buttons o-buttons--primary o-buttons--big"
-        data-url="access.acast.cloud/rss/ft-test/abc-123"
+        data-url="https://access.acast.cloud/rss/ft-test/abc-123"
         onClick={[Function]}
       >
         Copy RSS

--- a/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
+++ b/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
@@ -12,7 +12,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="apple-podcasts"
-        href="podcast://https://acast.access/rss/ft-test/123-abc"
+        href="podcast://acast.access/rss/ft-test/123-abc"
       >
         Apple Podcasts
       </a>
@@ -21,7 +21,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="overcast"
-        href="overcast://x-callback-url/add?url=http://https://acast.access/rss/ft-test/123-abc"
+        href="overcast://x-callback-url/add?url=https://acast.access/rss/ft-test/123-abc"
       >
         Overcast
       </a>
@@ -30,7 +30,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="pocket-casts"
-        href="pktc://subscribe/https://acast.access/rss/ft-test/123-abc"
+        href="pktc://subscribe/acast.access/rss/ft-test/123-abc"
       >
         Pocket Casts
       </a>
@@ -39,7 +39,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="podcast-addict"
-        href="podcastaddict://https://acast.access/rss/ft-test/123-abc"
+        href="podcastaddict://acast.access/rss/ft-test/123-abc"
       >
         Podcast Addict
       </a>
@@ -48,7 +48,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="acast"
-        href="acast://subscribe/http://https://acast.access/rss/ft-test/123-abc"
+        href="acast://subscribe/https://acast.access/rss/ft-test/123-abc"
       >
         Acast
       </a>

--- a/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
+++ b/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
@@ -12,7 +12,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="apple-podcasts"
-        href="podcast://https%3A%2F%2Facast.access%2Frss%2Fft-test%2F123-abc"
+        href="podcast://https://acast.access/rss/ft-test/123-abc"
       >
         Apple Podcasts
       </a>
@@ -21,7 +21,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="overcast"
-        href="overcast://x-callback-url/add?url=https%3A%2F%2Facast.access%2Frss%2Fft-test%2F123-abc"
+        href="overcast://x-callback-url/add?url=https://acast.access/rss/ft-test/123-abc"
       >
         Overcast
       </a>
@@ -30,7 +30,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="pocket-casts"
-        href="pktc://subscribe/https%3A%2F%2Facast.access%2Frss%2Fft-test%2F123-abc"
+        href="pktc://subscribe/https://acast.access/rss/ft-test/123-abc"
       >
         Pocket Casts
       </a>
@@ -39,7 +39,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="podcast-addict"
-        href="podcastaddict://https%3A%2F%2Facast.access%2Frss%2Fft-test%2F123-abc"
+        href="podcastaddict://https://acast.access/rss/ft-test/123-abc"
       >
         Podcast Addict
       </a>
@@ -48,7 +48,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="acast"
-        href="acast://subscribe/https%3A%2F%2Facast.access%2Frss%2Fft-test%2F123-abc"
+        href="acast://subscribe/https://https://acast.access/rss/ft-test/123-abc"
       >
         Acast
       </a>

--- a/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
+++ b/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="overcast"
-        href="overcast://x-callback-url/add?url=https://acast.access/rss/ft-test/123-abc"
+        href="overcast://x-callback-url/add?url=http://https://acast.access/rss/ft-test/123-abc"
       >
         Overcast
       </a>
@@ -48,7 +48,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
       <a
         className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="acast"
-        href="acast://subscribe/https://https://acast.access/rss/ft-test/123-abc"
+        href="acast://subscribe/http://https://acast.access/rss/ft-test/123-abc"
       >
         Acast
       </a>

--- a/components/x-podcast-launchers/src/__tests__/__snapshots__/generate-app-links.test.js.snap
+++ b/components/x-podcast-launchers/src/__tests__/__snapshots__/generate-app-links.test.js.snap
@@ -6,31 +6,31 @@ Array [
     "name": "Apple Podcasts",
     "template": "podcast://{url}",
     "trackingId": "apple-podcasts",
-    "url": "podcast://http%3A%2F%2Facast.access%2Frss%2Fft-news%2F%26%C2%A3%401234",
+    "url": "podcast://http://acast.access/rss/ft-news/&£@1234",
   },
   Object {
     "name": "Overcast",
     "template": "overcast://x-callback-url/add?url={url}",
     "trackingId": "overcast",
-    "url": "overcast://x-callback-url/add?url=http%3A%2F%2Facast.access%2Frss%2Fft-news%2F%26%C2%A3%401234",
+    "url": "overcast://x-callback-url/add?url=http://acast.access/rss/ft-news/&£@1234",
   },
   Object {
     "name": "Pocket Casts",
     "template": "pktc://subscribe/{url}",
     "trackingId": "pocket-casts",
-    "url": "pktc://subscribe/http%3A%2F%2Facast.access%2Frss%2Fft-news%2F%26%C2%A3%401234",
+    "url": "pktc://subscribe/http://acast.access/rss/ft-news/&£@1234",
   },
   Object {
     "name": "Podcast Addict",
     "template": "podcastaddict://{url}",
     "trackingId": "podcast-addict",
-    "url": "podcastaddict://http%3A%2F%2Facast.access%2Frss%2Fft-news%2F%26%C2%A3%401234",
+    "url": "podcastaddict://http://acast.access/rss/ft-news/&£@1234",
   },
   Object {
     "name": "Acast",
-    "template": "acast://subscribe/{url}",
+    "template": "acast://subscribe/https://{url}",
     "trackingId": "acast",
-    "url": "acast://subscribe/http%3A%2F%2Facast.access%2Frss%2Fft-news%2F%26%C2%A3%401234",
+    "url": "acast://subscribe/https://http://acast.access/rss/ft-news/&£@1234",
   },
 ]
 `;

--- a/components/x-podcast-launchers/src/__tests__/__snapshots__/generate-app-links.test.js.snap
+++ b/components/x-podcast-launchers/src/__tests__/__snapshots__/generate-app-links.test.js.snap
@@ -6,11 +6,11 @@ Array [
     "name": "Apple Podcasts",
     "template": "podcast://{url}",
     "trackingId": "apple-podcasts",
-    "url": "podcast://http://acast.access/rss/ft-news/&£@1234",
+    "url": "podcast://acast.access/rss/ft-news/&£@1234",
   },
   Object {
     "name": "Overcast",
-    "template": "overcast://x-callback-url/add?url={url}",
+    "template": "overcast://x-callback-url/add?url=http://{url}",
     "trackingId": "overcast",
     "url": "overcast://x-callback-url/add?url=http://acast.access/rss/ft-news/&£@1234",
   },
@@ -18,19 +18,19 @@ Array [
     "name": "Pocket Casts",
     "template": "pktc://subscribe/{url}",
     "trackingId": "pocket-casts",
-    "url": "pktc://subscribe/http://acast.access/rss/ft-news/&£@1234",
+    "url": "pktc://subscribe/acast.access/rss/ft-news/&£@1234",
   },
   Object {
     "name": "Podcast Addict",
     "template": "podcastaddict://{url}",
     "trackingId": "podcast-addict",
-    "url": "podcastaddict://http://acast.access/rss/ft-news/&£@1234",
+    "url": "podcastaddict://acast.access/rss/ft-news/&£@1234",
   },
   Object {
     "name": "Acast",
-    "template": "acast://subscribe/https://{url}",
+    "template": "acast://subscribe/http://{url}",
     "trackingId": "acast",
-    "url": "acast://subscribe/https://http://acast.access/rss/ft-news/&£@1234",
+    "url": "acast://subscribe/http://acast.access/rss/ft-news/&£@1234",
   },
 ]
 `;

--- a/components/x-podcast-launchers/src/__tests__/__snapshots__/generate-app-links.test.js.snap
+++ b/components/x-podcast-launchers/src/__tests__/__snapshots__/generate-app-links.test.js.snap
@@ -3,34 +3,39 @@
 exports[`generate-app-links should generate each app link with the urlencoded RSS url 1`] = `
 Array [
   Object {
+    "includeProtocol": false,
     "name": "Apple Podcasts",
     "template": "podcast://{url}",
     "trackingId": "apple-podcasts",
     "url": "podcast://acast.access/rss/ft-news/&£@1234",
   },
   Object {
+    "includeProtocol": true,
     "name": "Overcast",
-    "template": "overcast://x-callback-url/add?url=http://{url}",
+    "template": "overcast://x-callback-url/add?url={url}",
     "trackingId": "overcast",
-    "url": "overcast://x-callback-url/add?url=http://acast.access/rss/ft-news/&£@1234",
+    "url": "overcast://x-callback-url/add?url=https://acast.access/rss/ft-news/&£@1234",
   },
   Object {
+    "includeProtocol": false,
     "name": "Pocket Casts",
     "template": "pktc://subscribe/{url}",
     "trackingId": "pocket-casts",
     "url": "pktc://subscribe/acast.access/rss/ft-news/&£@1234",
   },
   Object {
+    "includeProtocol": false,
     "name": "Podcast Addict",
     "template": "podcastaddict://{url}",
     "trackingId": "podcast-addict",
     "url": "podcastaddict://acast.access/rss/ft-news/&£@1234",
   },
   Object {
+    "includeProtocol": true,
     "name": "Acast",
-    "template": "acast://subscribe/http://{url}",
+    "template": "acast://subscribe/{url}",
     "trackingId": "acast",
-    "url": "acast://subscribe/http://acast.access/rss/ft-news/&£@1234",
+    "url": "acast://subscribe/https://acast.access/rss/ft-news/&£@1234",
   },
 ]
 `;

--- a/components/x-podcast-launchers/src/__tests__/generate-app-links.test.js
+++ b/components/x-podcast-launchers/src/__tests__/generate-app-links.test.js
@@ -3,7 +3,7 @@ import generateAppLinks from '../generate-app-links';
 
 describe('generate-app-links', () => {
 	it('should generate each app link with the urlencoded RSS url', () => {
-		const rssUrl = 'http://acast.access/rss/ft-news/&£@1234';
+		const rssUrl = 'acast.access/rss/ft-news/&£@1234';
 		expect(
 			generateAppLinks(rssUrl)
 		).toMatchSnapshot();

--- a/components/x-podcast-launchers/src/__tests__/generate-app-links.test.js
+++ b/components/x-podcast-launchers/src/__tests__/generate-app-links.test.js
@@ -3,7 +3,7 @@ import generateAppLinks from '../generate-app-links';
 
 describe('generate-app-links', () => {
 	it('should generate each app link with the urlencoded RSS url', () => {
-		const rssUrl = 'acast.access/rss/ft-news/&£@1234';
+		const rssUrl = 'https://acast.access/rss/ft-news/&£@1234';
 		expect(
 			generateAppLinks(rssUrl)
 		).toMatchSnapshot();

--- a/components/x-podcast-launchers/src/app-links.js
+++ b/components/x-podcast-launchers/src/app-links.js
@@ -7,7 +7,7 @@ export default
 	},
 	{
 		"name": "Overcast",
-		"template": "overcast://x-callback-url/add?url={url}",
+		"template": "overcast://x-callback-url/add?url=http://{url}",
 		"trackingId": "overcast",
 	},
 	{
@@ -22,7 +22,7 @@ export default
 	},
 	{
 		"name": "Acast",
-		"template" : "acast://subscribe/https://{url}",
+		"template" : "acast://subscribe/http://{url}",
 		"trackingId": "acast",
 	}
 ]

--- a/components/x-podcast-launchers/src/app-links.js
+++ b/components/x-podcast-launchers/src/app-links.js
@@ -3,26 +3,31 @@ export default
 	{
 		"name": "Apple Podcasts",
 		"template" : "podcast://{url}",
+		"includeProtocol": false,
 		"trackingId": "apple-podcasts",
 	},
 	{
 		"name": "Overcast",
-		"template": "overcast://x-callback-url/add?url=http://{url}",
+		"template": "overcast://x-callback-url/add?url={url}",
+		"includeProtocol": true,
 		"trackingId": "overcast",
 	},
 	{
 		"name": "Pocket Casts",
 		"template": "pktc://subscribe/{url}",
+		"includeProtocol": false,
 		"trackingId": "pocket-casts",
 	},
 	{
 		"name": "Podcast Addict",
 		"template": "podcastaddict://{url}",
+		"includeProtocol": false,
 		"trackingId": "podcast-addict",
 	},
 	{
 		"name": "Acast",
-		"template" : "acast://subscribe/http://{url}",
+		"template" : "acast://subscribe/{url}",
+		"includeProtocol": true,
 		"trackingId": "acast",
 	}
 ]

--- a/components/x-podcast-launchers/src/app-links.js
+++ b/components/x-podcast-launchers/src/app-links.js
@@ -22,7 +22,7 @@ export default
 	},
 	{
 		"name": "Acast",
-		"template" : "acast://subscribe/{url}",
+		"template" : "acast://subscribe/https://{url}",
 		"trackingId": "acast",
 	}
 ]

--- a/components/x-podcast-launchers/src/generate-app-links.js
+++ b/components/x-podcast-launchers/src/generate-app-links.js
@@ -2,8 +2,12 @@ import appLinksConfig from './app-links';
 
 export default function generateAppLinks(rssUrl) {
 	return appLinksConfig.map(data => {
+		const url = data.includeProtocol
+					? rssUrl
+					: rssUrl.replace(/^https?:\/\//, '');
+
 		return Object.assign({}, data , {
-			url: data.template.replace(/{url}/, rssUrl)
+			url: data.template.replace(/{url}/, url)
 		})
 	});
 }

--- a/components/x-podcast-launchers/src/generate-app-links.js
+++ b/components/x-podcast-launchers/src/generate-app-links.js
@@ -1,10 +1,9 @@
 import appLinksConfig from './app-links';
 
 export default function generateAppLinks(rssUrl) {
-	const encodedRSSUrl = encodeURIComponent(rssUrl);
 	return appLinksConfig.map(data => {
 		return Object.assign({}, data , {
-			url: data.template.replace(/{url}/, encodedRSSUrl)
+			url: data.template.replace(/{url}/, rssUrl)
 		})
 	});
 }

--- a/components/x-podcast-launchers/src/generate-rss-url.js
+++ b/components/x-podcast-launchers/src/generate-rss-url.js
@@ -1,6 +1,6 @@
 import nanoid from 'nanoid';
 
 export default function generateRSSUrl(acastHost, seriesId, token) {
-	// ie. http://access.acast.cloud/rss/ft-test/tYPWWHla
+	// ie. https://access.acast.cloud/rss/ft-test/tYPWWHla
 	return `${acastHost}/rss/${seriesId}/${token || nanoid(10)}`;
 }

--- a/components/x-podcast-launchers/stories/example.js
+++ b/components/x-podcast-launchers/stories/example.js
@@ -7,7 +7,7 @@ exports.data = {
 	conceptName: 'Rachman Review',
 	isFollowed: false,
 	csrfToken: 'token',
-	acastRSSHost: 'access.acast.cloud',
+	acastRSSHost: 'https://access.acast.cloud',
 	acastAccessToken: 'abc-123'
 };
 

--- a/components/x-podcast-launchers/stories/example.js
+++ b/components/x-podcast-launchers/stories/example.js
@@ -7,7 +7,7 @@ exports.data = {
 	conceptName: 'Rachman Review',
 	isFollowed: false,
 	csrfToken: 'token',
-	acastRSSHost: 'https://access.acast.cloud',
+	acastRSSHost: 'access.acast.cloud',
 	acastAccessToken: 'abc-123'
 };
 


### PR DESCRIPTION
- The RSS URL should not be urlencoded when injected into the app links
- We should use `https` in the RSS URL, which will be set in the VAULT env var passed to the component, e.g. `https://acast.access.cloud`
- Pocketcasts, podcast addict + apple podcasts require the protocol to be stripped from the RSS URL
