### PR TITLE
Add additional data trackables around podcast launchers

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -612,30 +612,30 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
         Acast
       </a>
     </li>
-  </ul>
-  <div
-    className="o-forms__affix-wrapper PodcastLaunchers_rssUrlWrapper__vc1zt"
-  >
-    <input
-      className="o-forms__text PodcastLaunchers_rssUrlInput__O7wL-"
-      readOnly={true}
-      type="text"
-      value="https://access.acast.com/rss/therachmanreview/abc-123"
-    />
-    <div
-      className="o-forms__suffix PodcastLaunchers_rssUrlCopyButton__2_4c0"
+    <li
+      className="o-forms__affix-wrapper PodcastLaunchers_rssUrlWrapper__vc1zt"
     >
-      <button
-        className="o-buttons o-buttons--primary o-buttons--big"
-        data-trackable="copy-rss"
-        data-url="https://access.acast.com/rss/therachmanreview/abc-123"
-        onClick={[Function]}
-        type="button"
+      <input
+        className="o-forms__text PodcastLaunchers_rssUrlInput__O7wL-"
+        readOnly={true}
+        type="text"
+        value="https://access.acast.com/rss/therachmanreview/abc-123"
+      />
+      <div
+        className="o-forms__suffix PodcastLaunchers_rssUrlCopyButton__2_4c0"
       >
-        Copy RSS
-      </button>
-    </div>
-  </div>
+        <button
+          className="o-buttons o-buttons--primary o-buttons--big"
+          data-trackable="copy-rss"
+          data-url="https://access.acast.com/rss/therachmanreview/abc-123"
+          onClick={[Function]}
+          type="button"
+        >
+          Copy RSS
+        </button>
+      </div>
+    </li>
+  </ul>
   <h2
     className="PodcastLaunchers_heading__1103H"
   >

--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -557,6 +557,7 @@ exports[`@financial-times/x-gift-article renders a default Without gift credits 
 exports[`@financial-times/x-podcast-launchers renders a default Example x-podcast-launchers 1`] = `
 <div
   className="PodcastLaunchers_container__1418-"
+  data-trackable="podcast-launchers"
 >
   <h2
     className="PodcastLaunchers_heading__1103H"
@@ -626,6 +627,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
     >
       <button
         className="o-buttons o-buttons--primary o-buttons--big"
+        data-trackable="copy-rss"
         data-url="https://access.acast.com/rss/therachmanreview/abc-123"
         onClick={[Function]}
         type="button"

--- a/components/x-podcast-launchers/src/PodcastLaunchers.jsx
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.jsx
@@ -71,31 +71,31 @@ class PodcastLaunchers extends Component {
 			<div className={styles.container} data-trackable='podcast-launchers'>
 				<h2 className={styles.heading}>Subscribe on a podcast app</h2>
 				<ul className={styles.podcastAppLinksWrapper}>
-				{generateAppLinks(rssUrl).map(({ name, url, trackingId }) => (
-					<li key={name}>
-						<a
-							href={url}
-							className={podcastAppLinkStyles}
-							data-trackable={trackingId}>
-							{name}
-						</a>
-					</li>
-				))}
-				</ul>
+					{generateAppLinks(rssUrl).map(({ name, url, trackingId }) => (
+						<li key={name}>
+							<a
+								href={url}
+								className={podcastAppLinkStyles}
+								data-trackable={trackingId}>
+								{name}
+							</a>
+						</li>
+					))}
 
-				<div className={rssUrlWrapperStyles}>
-					<input className={rssUrlInputStyles} value={rssUrl} type='text' readOnly/>
-					<div className={rssUrlCopyButtonWrapperStyles}>
-						<button
-							className={basicButtonStyles}
-							onClick={copyToClipboard}
-							data-url={rssUrl}
-							data-trackable='copy-rss'
-							type='button'>
-							Copy RSS
-						</button>
-					</div>
-				</div>
+					<li key='Rss Url' className={rssUrlWrapperStyles}>
+						<input className={rssUrlInputStyles} value={rssUrl} type='text' readOnly/>
+						<div className={rssUrlCopyButtonWrapperStyles}>
+							<button
+								className={basicButtonStyles}
+								onClick={copyToClipboard}
+								data-url={rssUrl}
+								data-trackable='copy-rss'
+								type='button'>
+								Copy RSS
+							</button>
+						</div>
+					</li>
+				</ul>
 
 				<h2 className={styles.heading}>Can’t see your podcast app?</h2>
 				{followButton(conceptId, conceptName, csrfToken, isFollowed)}

--- a/components/x-podcast-launchers/src/PodcastLaunchers.jsx
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.jsx
@@ -68,7 +68,7 @@ class PodcastLaunchers extends Component {
 		const followButton = typeof renderFollowButton === 'function' ? renderFollowButton : defaultFollowButtonRender;
 
 		return rssUrl && (
-			<div className={styles.container}>
+			<div className={styles.container} data-trackable='podcast-launchers'>
 				<h2 className={styles.heading}>Subscribe on a podcast app</h2>
 				<ul className={styles.podcastAppLinksWrapper}>
 				{generateAppLinks(rssUrl).map(({ name, url, trackingId }) => (
@@ -90,6 +90,7 @@ class PodcastLaunchers extends Component {
 							className={basicButtonStyles}
 							onClick={copyToClipboard}
 							data-url={rssUrl}
+							data-trackable='copy-rss'
 							type='button'>
 							Copy RSS
 						</button>

--- a/components/x-podcast-launchers/src/PodcastLaunchers.scss
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.scss
@@ -17,7 +17,7 @@ $o-typography-is-silent: true;
 .podcastAppLinksWrapper {
 	list-style: none;
 	padding: 8px 0 0;
-	margin: 0;
+	margin: 0 0 24px;
 }
 
 .podcastAppLink {
@@ -27,7 +27,6 @@ $o-typography-is-silent: true;
 
 .rssUrlWrapper {
 	margin-top: 0px;
-	margin-bottom: 24px;
 }
 
 .rssUrlInput {

--- a/components/x-podcast-launchers/src/PodcastLaunchers.scss
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.scss
@@ -16,17 +16,17 @@ $o-typography-is-silent: true;
 
 .podcastAppLinksWrapper {
 	list-style: none;
-	padding: 8px 0 0;
+	padding: 0;
 	margin: 0 0 24px;
 }
 
 .podcastAppLink {
 	width: 100%;
-	margin-bottom: 8px;
+	margin-top: 8px;
 }
 
 .rssUrlWrapper {
-	margin-top: 0px;
+	margin-top: 8px;
 }
 
 .rssUrlInput {

--- a/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
+++ b/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
@@ -3,7 +3,9 @@
 exports[`PodcastLaunchers should hide itself if an RSS URL could not be generated 1`] = `""`;
 
 exports[`PodcastLaunchers should render the app links based on concept Id 1`] = `
-<div>
+<div
+  data-trackable="podcast-launchers"
+>
   <h2>
     Subscribe on a podcast app
   </h2>
@@ -68,6 +70,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
     >
       <button
         className="o-buttons o-buttons--primary o-buttons--big"
+        data-trackable="copy-rss"
         data-url="https://acast.access/rss/therachmanreview/123-abc"
         onClick={[Function]}
         type="button"

--- a/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
+++ b/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
@@ -55,30 +55,30 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
         Acast
       </a>
     </li>
-  </ul>
-  <div
-    className="o-forms__affix-wrapper "
-  >
-    <input
-      className="o-forms__text "
-      readOnly={true}
-      type="text"
-      value="https://acast.access/rss/therachmanreview/123-abc"
-    />
-    <div
-      className="o-forms__suffix "
+    <li
+      className="o-forms__affix-wrapper "
     >
-      <button
-        className="o-buttons o-buttons--primary o-buttons--big"
-        data-trackable="copy-rss"
-        data-url="https://acast.access/rss/therachmanreview/123-abc"
-        onClick={[Function]}
-        type="button"
+      <input
+        className="o-forms__text "
+        readOnly={true}
+        type="text"
+        value="https://acast.access/rss/therachmanreview/123-abc"
+      />
+      <div
+        className="o-forms__suffix "
       >
-        Copy RSS
-      </button>
-    </div>
-  </div>
+        <button
+          className="o-buttons o-buttons--primary o-buttons--big"
+          data-trackable="copy-rss"
+          data-url="https://acast.access/rss/therachmanreview/123-abc"
+          onClick={[Function]}
+          type="button"
+        >
+          Copy RSS
+        </button>
+      </div>
+    </li>
+  </ul>
   <h2>
     Can’t see your podcast app?
   </h2>


### PR DESCRIPTION
To make it easier to locate the buttons in spoor.

![image](https://user-images.githubusercontent.com/295469/63871234-732a6d00-c9b3-11e9-91a6-b4dddffac32a.png)
