### PR TITLE
Update the aria label on podcast and video teasers

### DIFF
--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -28,7 +28,6 @@ exports[`x-teaser / snapshots renders a Hero teaser with article data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -93,7 +92,6 @@ exports[`x-teaser / snapshots renders a Hero teaser with contentPackage data 1`]
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -158,7 +156,6 @@ exports[`x-teaser / snapshots renders a Hero teaser with opinion data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -228,7 +225,6 @@ exports[`x-teaser / snapshots renders a Hero teaser with packageItem data 1`] = 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -298,7 +294,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with podcast data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
+        aria-label="Listen to podcast Who sets the internet standards?"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -365,7 +361,6 @@ exports[`x-teaser / snapshots renders a Hero teaser with promoted data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -430,7 +425,6 @@ exports[`x-teaser / snapshots renders a Hero teaser with topStory data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -565,7 +559,6 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with article data 1`] 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -617,7 +610,6 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with contentPackage da
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -669,7 +661,6 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with opinion data 1`] 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -726,7 +717,6 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with packageItem data 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -783,7 +773,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with podcast data 1`] 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
+        aria-label="Listen to podcast Who sets the internet standards?"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -837,7 +827,6 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with promoted data 1`]
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -889,7 +878,6 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with topStory data 1`]
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -998,7 +986,6 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with article data 1`]
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1063,7 +1050,6 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with contentPackage d
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1128,7 +1114,6 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with opinion data 1`]
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1198,7 +1183,6 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with packageItem data
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1268,7 +1252,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with podcast data 1`]
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
+        aria-label="Listen to podcast Who sets the internet standards?"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -1335,7 +1319,6 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with promoted data 1`
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1400,7 +1383,6 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with topStory data 1`
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1535,7 +1517,6 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with article data 1`] =
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1575,7 +1556,6 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with contentPackage dat
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1615,7 +1595,6 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with opinion data 1`] =
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1660,7 +1639,6 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with packageItem data 1
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1705,7 +1683,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with podcast data 1`] =
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
+        aria-label="Listen to podcast Who sets the internet standards?"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -1747,7 +1725,6 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with promoted data 1`] 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1787,7 +1764,6 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with topStory data 1`] 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1926,7 +1902,6 @@ exports[`x-teaser / snapshots renders a Large teaser with article data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2003,7 +1978,6 @@ exports[`x-teaser / snapshots renders a Large teaser with contentPackage data 1`
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2080,7 +2054,6 @@ exports[`x-teaser / snapshots renders a Large teaser with opinion data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2162,7 +2135,6 @@ exports[`x-teaser / snapshots renders a Large teaser with packageItem data 1`] =
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2244,7 +2216,7 @@ exports[`x-teaser / snapshots renders a Large teaser with podcast data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
+        aria-label="Listen to podcast Who sets the internet standards?"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -2323,7 +2295,6 @@ exports[`x-teaser / snapshots renders a Large teaser with promoted data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2400,7 +2371,6 @@ exports[`x-teaser / snapshots renders a Large teaser with topStory data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2559,7 +2529,6 @@ exports[`x-teaser / snapshots renders a Small teaser with article data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2599,7 +2568,6 @@ exports[`x-teaser / snapshots renders a Small teaser with contentPackage data 1`
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2639,7 +2607,6 @@ exports[`x-teaser / snapshots renders a Small teaser with opinion data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2684,7 +2651,6 @@ exports[`x-teaser / snapshots renders a Small teaser with packageItem data 1`] =
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2729,7 +2695,7 @@ exports[`x-teaser / snapshots renders a Small teaser with podcast data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
+        aria-label="Listen to podcast Who sets the internet standards?"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -2771,7 +2737,6 @@ exports[`x-teaser / snapshots renders a Small teaser with promoted data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2811,7 +2776,6 @@ exports[`x-teaser / snapshots renders a Small teaser with topStory data 1`] = `
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2896,7 +2860,6 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with article data 1`] 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2973,7 +2936,6 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with contentPackage da
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3050,7 +3012,6 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with opinion data 1`] 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3132,7 +3093,6 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with packageItem data 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3214,7 +3174,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with podcast data 1`] 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
+        aria-label="Listen to podcast Who sets the internet standards?"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -3293,7 +3253,6 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with promoted data 1`]
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3370,7 +3329,6 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with topStory data 1`]
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3529,7 +3487,6 @@ exports[`x-teaser / snapshots renders a TopStory teaser with article data 1`] = 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3581,7 +3538,6 @@ exports[`x-teaser / snapshots renders a TopStory teaser with contentPackage data
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3633,7 +3589,6 @@ exports[`x-teaser / snapshots renders a TopStory teaser with opinion data 1`] = 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3690,7 +3645,6 @@ exports[`x-teaser / snapshots renders a TopStory teaser with packageItem data 1`
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3747,7 +3701,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with podcast data 1`] = 
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
+        aria-label="Listen to podcast Who sets the internet standards?"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -3801,7 +3755,6 @@ exports[`x-teaser / snapshots renders a TopStory teaser with promoted data 1`] =
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3853,7 +3806,6 @@ exports[`x-teaser / snapshots renders a TopStory teaser with topStory data 1`] =
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3999,7 +3951,6 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article da
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4076,7 +4027,6 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with contentPac
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4153,7 +4103,6 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with opinion da
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4235,7 +4184,6 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with packageIte
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4317,7 +4265,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with podcast da
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
+        aria-label="Listen to podcast Who sets the internet standards?"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -4396,7 +4344,6 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with promoted d
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4473,7 +4420,6 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with topStory d
       className="o-teaser__heading"
     >
       <a
-        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -28,6 +28,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with article data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -92,6 +93,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with contentPackage data 1`]
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -156,6 +158,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with opinion data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -225,6 +228,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with packageItem data 1`] = 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -294,6 +298,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with podcast data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -360,6 +365,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with promoted data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -424,6 +430,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with topStory data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -493,6 +500,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with video data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label="Watch video FT View: Donald Trump, man of steel"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -557,6 +565,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with article data 1`] 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -608,6 +617,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with contentPackage da
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -659,6 +669,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with opinion data 1`] 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -715,6 +726,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with packageItem data 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -771,6 +783,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with podcast data 1`] 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -824,6 +837,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with promoted data 1`]
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -875,6 +889,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with topStory data 1`]
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -931,6 +946,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with video data 1`] = 
       className="o-teaser__heading"
     >
       <a
+        aria-label="Watch video FT View: Donald Trump, man of steel"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -982,6 +998,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with article data 1`]
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1046,6 +1063,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with contentPackage d
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1110,6 +1128,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with opinion data 1`]
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1179,6 +1198,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with packageItem data
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1248,6 +1268,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with podcast data 1`]
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -1314,6 +1335,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with promoted data 1`
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1378,6 +1400,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with topStory data 1`
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1447,6 +1470,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with video data 1`] =
       className="o-teaser__heading"
     >
       <a
+        aria-label="Watch video FT View: Donald Trump, man of steel"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1511,6 +1535,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with article data 1`] =
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1550,6 +1575,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with contentPackage dat
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1589,6 +1615,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with opinion data 1`] =
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1633,6 +1660,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with packageItem data 1
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1677,6 +1705,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with podcast data 1`] =
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -1718,6 +1747,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with promoted data 1`] 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1757,6 +1787,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with topStory data 1`] 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1855,6 +1886,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with video data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label="Watch video FT View: Donald Trump, man of steel"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1894,6 +1926,7 @@ exports[`x-teaser / snapshots renders a Large teaser with article data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -1970,6 +2003,7 @@ exports[`x-teaser / snapshots renders a Large teaser with contentPackage data 1`
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2046,6 +2080,7 @@ exports[`x-teaser / snapshots renders a Large teaser with opinion data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2127,6 +2162,7 @@ exports[`x-teaser / snapshots renders a Large teaser with packageItem data 1`] =
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2208,6 +2244,7 @@ exports[`x-teaser / snapshots renders a Large teaser with podcast data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -2286,6 +2323,7 @@ exports[`x-teaser / snapshots renders a Large teaser with promoted data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2362,6 +2400,7 @@ exports[`x-teaser / snapshots renders a Large teaser with topStory data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2443,6 +2482,7 @@ exports[`x-teaser / snapshots renders a Large teaser with video data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label="Watch video FT View: Donald Trump, man of steel"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2519,6 +2559,7 @@ exports[`x-teaser / snapshots renders a Small teaser with article data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2558,6 +2599,7 @@ exports[`x-teaser / snapshots renders a Small teaser with contentPackage data 1`
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2597,6 +2639,7 @@ exports[`x-teaser / snapshots renders a Small teaser with opinion data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2641,6 +2684,7 @@ exports[`x-teaser / snapshots renders a Small teaser with packageItem data 1`] =
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2685,6 +2729,7 @@ exports[`x-teaser / snapshots renders a Small teaser with podcast data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -2726,6 +2771,7 @@ exports[`x-teaser / snapshots renders a Small teaser with promoted data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2765,6 +2811,7 @@ exports[`x-teaser / snapshots renders a Small teaser with topStory data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2809,6 +2856,7 @@ exports[`x-teaser / snapshots renders a Small teaser with video data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label="Watch video FT View: Donald Trump, man of steel"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2848,6 +2896,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with article data 1`] 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -2924,6 +2973,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with contentPackage da
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3000,6 +3050,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with opinion data 1`] 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3081,6 +3132,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with packageItem data 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3162,6 +3214,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with podcast data 1`] 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -3240,6 +3293,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with promoted data 1`]
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3316,6 +3370,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with topStory data 1`]
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3397,6 +3452,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with video data 1`] = 
       className="o-teaser__heading"
     >
       <a
+        aria-label="Watch video FT View: Donald Trump, man of steel"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3473,6 +3529,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with article data 1`] = 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3524,6 +3581,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with contentPackage data
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3575,6 +3633,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with opinion data 1`] = 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3631,6 +3690,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with packageItem data 1`
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3687,6 +3747,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with podcast data 1`] = 
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -3740,6 +3801,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with promoted data 1`] =
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3791,6 +3853,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with topStory data 1`] =
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3884,6 +3947,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with video data 1`] = `
       className="o-teaser__heading"
     >
       <a
+        aria-label="Watch video FT View: Donald Trump, man of steel"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -3935,6 +3999,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article da
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4011,6 +4076,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with contentPac
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4087,6 +4153,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with opinion da
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4168,6 +4235,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with packageIte
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4249,6 +4317,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with podcast da
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
@@ -4327,6 +4396,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with promoted d
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4403,6 +4473,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with topStory d
       className="o-teaser__heading"
     >
       <a
+        aria-label={null}
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"
@@ -4521,6 +4592,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with video data
       className="o-teaser__heading"
     >
       <a
+        aria-label="Watch video FT View: Donald Trump, man of steel"
         className="js-teaser-heading-link"
         data-trackable="heading-link"
         href="#"

--- a/components/x-teaser/src/Title.jsx
+++ b/components/x-teaser/src/Title.jsx
@@ -6,13 +6,19 @@ export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators
 	const displayUrl = relativeUrl || url;
 	// o-labels--premium left for backwards compatibility for o-labels v3
 	const premiumClass = 'o-labels o-labels--premium o-labels--content-premium';
+	let ariaLabel;
+	if(props.type === 'video') {
+		ariaLabel = `Watch video ${displayTitle}`
+	} else if (props.type === 'audio') {
+		ariaLabel = `Listen to podcast ${displayTitle}`
+	}
 
 	return (
 		<div className="o-teaser__heading">
 			<Link {...props} url={displayUrl} attrs={{
 				'data-trackable': 'heading-link',
 				className: 'js-teaser-heading-link',
-				'aria-label': props.type === 'video' ? `Watch video ${displayTitle}` : null
+				'aria-label': ariaLabel
 			}}>
 				{displayTitle}
 			</Link>

--- a/components/x-teaser/src/Title.jsx
+++ b/components/x-teaser/src/Title.jsx
@@ -12,6 +12,7 @@ export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators
 			<Link {...props} url={displayUrl} attrs={{
 				'data-trackable': 'heading-link',
 				className: 'js-teaser-heading-link',
+				'aria-label': props.type === 'video' ? `Watch video ${displayTitle}` : null
 			}}>
 				{displayTitle}
 			</Link>


### PR DESCRIPTION
Adds an aria-label property to all video and podcast teasers to include the phrase "Watch video" or "Listen to podcast" before the title attribute is read out. This will not affect other teasers as any attributes with a `null` value will be ignored.

This should be released as a new beta version: `v1.0.0-beta.17`