### PR TITLE
update related links url property to relativeUrl

### DIFF
--- a/components/x-teaser/__fixtures__/top-story.json
+++ b/components/x-teaser/__fixtures__/top-story.json
@@ -26,19 +26,19 @@
   "relatedLinks": [
     {
       "id": "",
-      "url": "#",
+      "relativeUrl": "#",
       "type": "article",
       "title": "Removing the fig leaf of charity"
     },
     {
       "id": "",
-      "url": "#",
+      "relativeUrl": "#",
       "type": "article",
       "title": "A dinner that demeaned both women and men"
     },
     {
       "id": "",
-      "url": "#",
+      "relativeUrl": "#",
       "type": "video",
       "title": "PM speaks out after Presidents Club dinner"
     }

--- a/components/x-teaser/src/RelatedLinks.jsx
+++ b/components/x-teaser/src/RelatedLinks.jsx
@@ -1,11 +1,11 @@
 import { h } from '@financial-times/x-engine';
 
-const renderLink = ({ id, url, type, title }, i) => (
+const renderLink = ({ id, relativeUrl, type, title }, i) => (
 	<li
 		key={`related-${i}`}
 		data-content-id={id}
 		className={`o-teaser__related-item o-teaser__related-item--${type}`}>
-		<a data-trackable="related" href={url}>
+		<a data-trackable="related" href={relativeUrl}>
 			{title}
 		</a>
 	</li>


### PR DESCRIPTION
Replaces `url` with `relatedUrl` in the relatedLinks x-teaser component to more accurately match the data being passed in.

This change will affect the relatedLinks component only. 