### PR TITLE
Fix words break issue by adding a white space

### DIFF
--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -14,6 +14,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with article data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -22,6 +24,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with article data 1`] = `
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -78,6 +82,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with contentPackage data 1`]
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: FT Magazine"
           className="o-teaser__tag"
@@ -86,6 +92,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with contentPackage data 1`]
         >
           FT Magazine
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -142,6 +150,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with opinion data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Gideon Rachman"
           className="o-teaser__tag"
@@ -150,6 +160,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with opinion data 1`] = `
         >
           Gideon Rachman
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -211,6 +223,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with packageItem data 1`] = 
         >
           FT Series
         </span>
+         
+         
         <a
           aria-label="Category: Financial crisis: Are we safer now? "
           className="o-teaser__tag"
@@ -219,6 +233,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with packageItem data 1`] = 
         >
           Financial crisis: Are we safer now? 
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -275,6 +291,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with podcast data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Tech Tonic podcast"
           className="o-teaser__tag"
@@ -283,6 +301,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with podcast data 1`] = `
         >
           Tech Tonic podcast
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -411,6 +431,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with topStory data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -419,6 +441,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with topStory data 1`] = `
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -475,6 +499,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with video data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Global Trade"
           className="o-teaser__tag"
@@ -483,6 +509,8 @@ exports[`x-teaser / snapshots renders a Hero teaser with video data 1`] = `
         >
           Global Trade
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -545,6 +573,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with article data 1`] 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -553,6 +583,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with article data 1`] 
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -596,6 +628,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with contentPackage da
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: FT Magazine"
           className="o-teaser__tag"
@@ -604,6 +638,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with contentPackage da
         >
           FT Magazine
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -647,6 +683,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with opinion data 1`] 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Gideon Rachman"
           className="o-teaser__tag"
@@ -655,6 +693,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with opinion data 1`] 
         >
           Gideon Rachman
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -703,6 +743,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with packageItem data 
         >
           FT Series
         </span>
+         
+         
         <a
           aria-label="Category: Financial crisis: Are we safer now? "
           className="o-teaser__tag"
@@ -711,6 +753,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with packageItem data 
         >
           Financial crisis: Are we safer now? 
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -754,6 +798,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with podcast data 1`] 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Tech Tonic podcast"
           className="o-teaser__tag"
@@ -762,6 +808,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with podcast data 1`] 
         >
           Tech Tonic podcast
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -864,6 +912,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with topStory data 1`]
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -872,6 +922,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with topStory data 1`]
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -915,6 +967,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with video data 1`] = 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Global Trade"
           className="o-teaser__tag"
@@ -923,6 +977,8 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with video data 1`] = 
         >
           Global Trade
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -972,6 +1028,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with article data 1`]
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -980,6 +1038,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with article data 1`]
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1036,6 +1096,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with contentPackage d
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: FT Magazine"
           className="o-teaser__tag"
@@ -1044,6 +1106,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with contentPackage d
         >
           FT Magazine
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1100,6 +1164,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with opinion data 1`]
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Gideon Rachman"
           className="o-teaser__tag"
@@ -1108,6 +1174,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with opinion data 1`]
         >
           Gideon Rachman
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1169,6 +1237,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with packageItem data
         >
           FT Series
         </span>
+         
+         
         <a
           aria-label="Category: Financial crisis: Are we safer now? "
           className="o-teaser__tag"
@@ -1177,6 +1247,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with packageItem data
         >
           Financial crisis: Are we safer now? 
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1233,6 +1305,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with podcast data 1`]
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Tech Tonic podcast"
           className="o-teaser__tag"
@@ -1241,6 +1315,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with podcast data 1`]
         >
           Tech Tonic podcast
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -1369,6 +1445,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with topStory data 1`
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -1377,6 +1455,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with topStory data 1`
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1433,6 +1513,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with video data 1`] =
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Global Trade"
           className="o-teaser__tag"
@@ -1441,6 +1523,8 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with video data 1`] =
         >
           Global Trade
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -1503,6 +1587,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with article data 1`] =
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -1511,6 +1597,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with article data 1`] =
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1542,6 +1630,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with contentPackage dat
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: FT Magazine"
           className="o-teaser__tag"
@@ -1550,6 +1640,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with contentPackage dat
         >
           FT Magazine
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1581,6 +1673,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with opinion data 1`] =
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Gideon Rachman"
           className="o-teaser__tag"
@@ -1589,6 +1683,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with opinion data 1`] =
         >
           Gideon Rachman
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1625,6 +1721,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with packageItem data 1
         >
           FT Series
         </span>
+         
+         
         <a
           aria-label="Category: Financial crisis: Are we safer now? "
           className="o-teaser__tag"
@@ -1633,6 +1731,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with packageItem data 1
         >
           Financial crisis: Are we safer now? 
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1664,6 +1764,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with podcast data 1`] =
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Tech Tonic podcast"
           className="o-teaser__tag"
@@ -1672,6 +1774,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with podcast data 1`] =
         >
           Tech Tonic podcast
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -1750,6 +1854,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with topStory data 1`] 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -1758,6 +1864,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with topStory data 1`] 
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1789,6 +1897,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with video data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Global Trade"
           className="o-teaser__tag"
@@ -1797,6 +1907,8 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with video data 1`] = `
         >
           Global Trade
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -1888,6 +2000,8 @@ exports[`x-teaser / snapshots renders a Large teaser with article data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -1896,6 +2010,8 @@ exports[`x-teaser / snapshots renders a Large teaser with article data 1`] = `
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -1964,6 +2080,8 @@ exports[`x-teaser / snapshots renders a Large teaser with contentPackage data 1`
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: FT Magazine"
           className="o-teaser__tag"
@@ -1972,6 +2090,8 @@ exports[`x-teaser / snapshots renders a Large teaser with contentPackage data 1`
         >
           FT Magazine
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2040,6 +2160,8 @@ exports[`x-teaser / snapshots renders a Large teaser with opinion data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Gideon Rachman"
           className="o-teaser__tag"
@@ -2048,6 +2170,8 @@ exports[`x-teaser / snapshots renders a Large teaser with opinion data 1`] = `
         >
           Gideon Rachman
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2121,6 +2245,8 @@ exports[`x-teaser / snapshots renders a Large teaser with packageItem data 1`] =
         >
           FT Series
         </span>
+         
+         
         <a
           aria-label="Category: Financial crisis: Are we safer now? "
           className="o-teaser__tag"
@@ -2129,6 +2255,8 @@ exports[`x-teaser / snapshots renders a Large teaser with packageItem data 1`] =
         >
           Financial crisis: Are we safer now? 
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2197,6 +2325,8 @@ exports[`x-teaser / snapshots renders a Large teaser with podcast data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Tech Tonic podcast"
           className="o-teaser__tag"
@@ -2205,6 +2335,8 @@ exports[`x-teaser / snapshots renders a Large teaser with podcast data 1`] = `
         >
           Tech Tonic podcast
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -2357,6 +2489,8 @@ exports[`x-teaser / snapshots renders a Large teaser with topStory data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -2365,6 +2499,8 @@ exports[`x-teaser / snapshots renders a Large teaser with topStory data 1`] = `
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2433,6 +2569,8 @@ exports[`x-teaser / snapshots renders a Large teaser with video data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Global Trade"
           className="o-teaser__tag"
@@ -2441,6 +2579,8 @@ exports[`x-teaser / snapshots renders a Large teaser with video data 1`] = `
         >
           Global Trade
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -2515,6 +2655,8 @@ exports[`x-teaser / snapshots renders a Small teaser with article data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -2523,6 +2665,8 @@ exports[`x-teaser / snapshots renders a Small teaser with article data 1`] = `
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2554,6 +2698,8 @@ exports[`x-teaser / snapshots renders a Small teaser with contentPackage data 1`
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: FT Magazine"
           className="o-teaser__tag"
@@ -2562,6 +2708,8 @@ exports[`x-teaser / snapshots renders a Small teaser with contentPackage data 1`
         >
           FT Magazine
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2593,6 +2741,8 @@ exports[`x-teaser / snapshots renders a Small teaser with opinion data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Gideon Rachman"
           className="o-teaser__tag"
@@ -2601,6 +2751,8 @@ exports[`x-teaser / snapshots renders a Small teaser with opinion data 1`] = `
         >
           Gideon Rachman
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2637,6 +2789,8 @@ exports[`x-teaser / snapshots renders a Small teaser with packageItem data 1`] =
         >
           FT Series
         </span>
+         
+         
         <a
           aria-label="Category: Financial crisis: Are we safer now? "
           className="o-teaser__tag"
@@ -2645,6 +2799,8 @@ exports[`x-teaser / snapshots renders a Small teaser with packageItem data 1`] =
         >
           Financial crisis: Are we safer now? 
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2676,6 +2832,8 @@ exports[`x-teaser / snapshots renders a Small teaser with podcast data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Tech Tonic podcast"
           className="o-teaser__tag"
@@ -2684,6 +2842,8 @@ exports[`x-teaser / snapshots renders a Small teaser with podcast data 1`] = `
         >
           Tech Tonic podcast
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -2762,6 +2922,8 @@ exports[`x-teaser / snapshots renders a Small teaser with topStory data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -2770,6 +2932,8 @@ exports[`x-teaser / snapshots renders a Small teaser with topStory data 1`] = `
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2801,6 +2965,8 @@ exports[`x-teaser / snapshots renders a Small teaser with video data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Global Trade"
           className="o-teaser__tag"
@@ -2809,6 +2975,8 @@ exports[`x-teaser / snapshots renders a Small teaser with video data 1`] = `
         >
           Global Trade
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -2846,6 +3014,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with article data 1`] 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -2854,6 +3024,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with article data 1`] 
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2922,6 +3094,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with contentPackage da
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: FT Magazine"
           className="o-teaser__tag"
@@ -2930,6 +3104,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with contentPackage da
         >
           FT Magazine
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -2998,6 +3174,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with opinion data 1`] 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Gideon Rachman"
           className="o-teaser__tag"
@@ -3006,6 +3184,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with opinion data 1`] 
         >
           Gideon Rachman
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -3079,6 +3259,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with packageItem data 
         >
           FT Series
         </span>
+         
+         
         <a
           aria-label="Category: Financial crisis: Are we safer now? "
           className="o-teaser__tag"
@@ -3087,6 +3269,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with packageItem data 
         >
           Financial crisis: Are we safer now? 
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -3155,6 +3339,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with podcast data 1`] 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Tech Tonic podcast"
           className="o-teaser__tag"
@@ -3163,6 +3349,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with podcast data 1`] 
         >
           Tech Tonic podcast
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -3315,6 +3503,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with topStory data 1`]
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -3323,6 +3513,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with topStory data 1`]
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -3391,6 +3583,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with video data 1`] = 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Global Trade"
           className="o-teaser__tag"
@@ -3399,6 +3593,8 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with video data 1`] = 
         >
           Global Trade
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -3473,6 +3669,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with article data 1`] = 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -3481,6 +3679,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with article data 1`] = 
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -3524,6 +3724,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with contentPackage data
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: FT Magazine"
           className="o-teaser__tag"
@@ -3532,6 +3734,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with contentPackage data
         >
           FT Magazine
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -3575,6 +3779,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with opinion data 1`] = 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Gideon Rachman"
           className="o-teaser__tag"
@@ -3583,6 +3789,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with opinion data 1`] = 
         >
           Gideon Rachman
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -3631,6 +3839,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with packageItem data 1`
         >
           FT Series
         </span>
+         
+         
         <a
           aria-label="Category: Financial crisis: Are we safer now? "
           className="o-teaser__tag"
@@ -3639,6 +3849,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with packageItem data 1`
         >
           Financial crisis: Are we safer now? 
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -3682,6 +3894,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with podcast data 1`] = 
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Tech Tonic podcast"
           className="o-teaser__tag"
@@ -3690,6 +3904,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with podcast data 1`] = 
         >
           Tech Tonic podcast
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -3792,6 +4008,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with topStory data 1`] =
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -3800,6 +4018,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with topStory data 1`] =
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -3880,6 +4100,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with video data 1`] = `
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Global Trade"
           className="o-teaser__tag"
@@ -3888,6 +4110,8 @@ exports[`x-teaser / snapshots renders a TopStory teaser with video data 1`] = `
         >
           Global Trade
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -3937,6 +4161,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article da
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -3945,6 +4171,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article da
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -4013,6 +4241,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with contentPac
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: FT Magazine"
           className="o-teaser__tag"
@@ -4021,6 +4251,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with contentPac
         >
           FT Magazine
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -4089,6 +4321,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with opinion da
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Gideon Rachman"
           className="o-teaser__tag"
@@ -4097,6 +4331,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with opinion da
         >
           Gideon Rachman
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -4170,6 +4406,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with packageIte
         >
           FT Series
         </span>
+         
+         
         <a
           aria-label="Category: Financial crisis: Are we safer now? "
           className="o-teaser__tag"
@@ -4178,6 +4416,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with packageIte
         >
           Financial crisis: Are we safer now? 
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -4246,6 +4486,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with podcast da
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Tech Tonic podcast"
           className="o-teaser__tag"
@@ -4254,6 +4496,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with podcast da
         >
           Tech Tonic podcast
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >
@@ -4406,6 +4650,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with topStory d
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Sexual misconduct allegations"
           className="o-teaser__tag"
@@ -4414,6 +4660,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with topStory d
         >
           Sexual misconduct allegations
         </a>
+         
+         
       </div>
     </div>
     <div
@@ -4519,6 +4767,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with video data
       <div
         className="o-teaser__meta-tag"
       >
+         
+         
         <a
           aria-label="Category: Global Trade"
           className="o-teaser__tag"
@@ -4527,6 +4777,8 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with video data
         >
           Global Trade
         </a>
+         
+         
         <span
           className="o-teaser__tag-suffix"
         >

--- a/components/x-teaser/src/MetaLink.jsx
+++ b/components/x-teaser/src/MetaLink.jsx
@@ -18,7 +18,7 @@ export default ({ metaPrefixText, metaLink, metaAltLink, metaSuffixText, context
 
 	return (
 		<div className="o-teaser__meta-tag">
-			{showPrefixText ? <span className="o-teaser__tag-prefix">{metaPrefixText}</span> : null}
+			{showPrefixText ? <span className="o-teaser__tag-prefix">{metaPrefixText}</span> : null} {' '}
 			{displayLink ? (
 				<a
 					className="o-teaser__tag"
@@ -27,7 +27,7 @@ export default ({ metaPrefixText, metaLink, metaAltLink, metaSuffixText, context
 					aria-label={`Category: ${displayLink.prefLabel}`}>
 					{displayLink.prefLabel}
 				</a>
-			) : null}
+			) : null} {' '}
 			{showSuffixText ? <span className="o-teaser__tag-suffix">{metaSuffixText}</span> : null}
 		</div>
 	);


### PR DESCRIPTION
This is just fixing a small issue with no word break when two spans next to each have no newline characters in between them. By adding it - CSS can wrap non-fitting characters to the new line.