### PR TITLE
related content links can use url or relatedUrl as the href

### DIFF
--- a/components/x-teaser/src/RelatedLinks.jsx
+++ b/components/x-teaser/src/RelatedLinks.jsx
@@ -1,15 +1,18 @@
 import { h } from '@financial-times/x-engine';
 
-const renderLink = ({ id, relativeUrl, type, title }, i) => (
-	<li
-		key={`related-${i}`}
-		data-content-id={id}
-		className={`o-teaser__related-item o-teaser__related-item--${type}`}>
-		<a data-trackable="related" href={relativeUrl}>
-			{title}
-		</a>
-	</li>
-);
+const renderLink = ({ id, type, title, url, relativeUrl }, i) => {
+	const displayUrl = relativeUrl || url;
+	return (
+		<li
+			key={`related-${i}`}
+			data-content-id={id}
+			className={`o-teaser__related-item o-teaser__related-item--${type}`}>
+			<a data-trackable="related" href={displayUrl}>
+				{title}
+			</a>
+		</li>
+	);
+}
 
 export default ({ relatedLinks = [] }) => (
 	relatedLinks && relatedLinks.length ? (


### PR DESCRIPTION
Allows the relatedLinks x-teaser component to use either the `relatedUrl` or the `url` property if available. This brings the component more inline with other teaser components:

- https://github.com/Financial-Times/x-dash/blob/master/components/x-teaser/src/Image.jsx#L30
- https://github.com/Financial-Times/x-dash/blob/master/components/x-teaser/src/MetaLink.jsx#L26

This change will affect the relatedLinks component only.