### PR TITLE
Add imageDataUrl prop to enable apps offline functionality

### DIFF
--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -171,7 +171,7 @@ Property        | Type                  | Notes
 `image`         | [media](#media-props) |
 `imageSize`     | String                | XS, Small, Medium, Large, XL or XXL
 `imageLazyload` | Boolean, String       | Output image with `data-src` attribute. If this is a string it will be appended to the image as a class name.
-`imageDataUrl`	|	Boolean								|	Signifies that the image URL is a self-contained data URL.
+`imageDataUrl`  | Boolean, String       | Signifies that the image URL is a self-contained data URL.
 
 [nimg]: https://github.com/Financial-Times/n-image/
 

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -171,6 +171,7 @@ Property        | Type                  | Notes
 `image`         | [media](#media-props) |
 `imageSize`     | String                | XS, Small, Medium, Large, XL or XXL
 `imageLazyload` | Boolean, String       | Output image with `data-src` attribute. If this is a string it will be appended to the image as a class name.
+`imageDataUrl`	|	Boolean								|	Signifies that the image URL is a self-contained data URL.
 
 [nimg]: https://github.com/Financial-Times/n-image/
 

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -171,7 +171,6 @@ Property        | Type                  | Notes
 `image`         | [media](#media-props) |
 `imageSize`     | String                | XS, Small, Medium, Large, XL or XXL
 `imageLazyload` | Boolean, String       | Output image with `data-src` attribute. If this is a string it will be appended to the image as a class name.
-`imageDataUrl`  | Boolean, String       | Signifies that the image URL is a self-contained data URL.
 
 [nimg]: https://github.com/Financial-Times/n-image/
 
@@ -237,7 +236,7 @@ Property      | Type   | Notes
 
 Property | Type   | Notes
 ---------|--------|--------------
-`url`    | String | Content UUID
+`url`    | String | Content UUID or, in the case of images, `data:` URL
 `width`  | Number |
 `height` | Number |
 

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -26,9 +26,9 @@ const LazyImage = ({ src, lazyLoad }) => {
 	return <img className={`o-teaser__image ${lazyClassName}`} data-src={src} alt="" />;
 };
 
-export default ({ dataUrl, relativeUrl, url, image, imageSize, imageLazyLoad, ...props }) => {
+export default ({ imageDataUrl, relativeUrl, url, image, imageSize, imageLazyLoad, ...props }) => {
 	const displayUrl = relativeUrl || url;
-	const imageSrc = dataUrl ? image.url : imageService(image.url, ImageSizes[imageSize]);
+	const imageSrc = imageDataUrl ? image.url : imageService(image.url, ImageSizes[imageSize]);
 	const ImageComponent = imageLazyLoad ? LazyImage : NormalImage;
 
 	return image ? (

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -28,7 +28,7 @@ const LazyImage = ({ src, lazyLoad }) => {
 
 export default ({ imageDataUrl, relativeUrl, url, image, imageSize, imageLazyLoad, ...props }) => {
 	const displayUrl = relativeUrl || url;
-	const imageSrc = imageDataUrl ? image.url : imageService(image.url, ImageSizes[imageSize]);
+	const imageSrc = image.url.startsWith('data:') ? image.url : imageService(image.url, ImageSizes[imageSize]);
 	const ImageComponent = imageLazyLoad ? LazyImage : NormalImage;
 
 	return image ? (

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -26,7 +26,7 @@ const LazyImage = ({ src, lazyLoad }) => {
 	return <img className={`o-teaser__image ${lazyClassName}`} data-src={src} alt="" />;
 };
 
-export default ({ imageDataUrl, relativeUrl, url, image, imageSize, imageLazyLoad, ...props }) => {
+export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, ...props }) => {
 	const displayUrl = relativeUrl || url;
 	const imageSrc = image.url.startsWith('data:') ? image.url : imageService(image.url, ImageSizes[imageSize]);
 	const ImageComponent = imageLazyLoad ? LazyImage : NormalImage;

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -26,9 +26,9 @@ const LazyImage = ({ src, lazyLoad }) => {
 	return <img className={`o-teaser__image ${lazyClassName}`} data-src={src} alt="" />;
 };
 
-export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, ...props }) => {
+export default ({ dataUrl, relativeUrl, url, image, imageSize, imageLazyLoad, ...props }) => {
 	const displayUrl = relativeUrl || url;
-	const imageSrc = imageService(image.url, ImageSizes[imageSize]);
+	const imageSrc = dataUrl ? image.url : imageService(image.url, ImageSizes[imageSize]);
 	const ImageComponent = imageLazyLoad ? LazyImage : NormalImage;
 
 	return image ? (


### PR DESCRIPTION
## What is this?

This PR adds an `imageDataUrl` boolean prop to x-teaser which can be used to indicate that the image URL provided is a self-contained image and the component does not have to construct an image URL or make a request to the origami image service.

## Why is it necessary?

The apps team are currently working on the capability to store images offline and consume them in teasers directly from this offline store. In order to make this work, we need x-teaser to accept images in data-url format and not to attempt to construct a URL for the image and request it from the origami image service. The new `imageDataUrl` prop achieves this.

I sense-checked this very briefly with Maggie before beginning - please let me know if there's anybody else I should assign to review!
