### PR TITLE
Satisfy eslint's describe() demands

### DIFF
--- a/__tests__/snapshots.test.js
+++ b/__tests__/snapshots.test.js
@@ -21,16 +21,14 @@ for(const pkg of packageDirs) {
 		const { presets = { default: {} } } = require(pkgDir);
 		const name = path.basename(pkg.name);
 
-		describe(`${pkg.name}`, () => {
-			for (const { title, data } of stories) {
-				for (const [preset, options] of Object.entries(presets)) {
-					it(`renders a ${preset} ${title} ${name}`, () => {
-						const props = { ...data, ...options };
-						const tree = renderer.create(h(component, props)).toJSON();
-						expect(tree).toMatchSnapshot();
-					});
-				}
+		for (const { title, data } of stories) {
+			for (const [preset, options] of Object.entries(presets)) {
+				it(`${pkg.name} renders a ${preset} ${title} ${name}`, () => {
+					const props = { ...data, ...options };
+					const tree = renderer.create(h(component, props)).toJSON();
+					expect(tree).toMatchSnapshot();
+				});
 			}
-		});
+		}
 	}
 }


### PR DESCRIPTION
This generates the same snapshot naming convention but goes along with eslint's demands.

```sh
 27:12  error  First argument must be name  jest/valid-describe
```