### PR TITLE
Update o-forms and o-buttons in podcast launcher

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -569,7 +569,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
   >
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcastAppLink__69RMR"
+        className="PodcastLaunchers_podcastAppLink__69RMR"
         data-trackable="apple-podcasts"
         href="podcast://access.acast.com/rss/therachmanreview/abc-123"
       >
@@ -578,7 +578,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
     </li>
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcastAppLink__69RMR"
+        className="PodcastLaunchers_podcastAppLink__69RMR"
         data-trackable="overcast"
         href="overcast://x-callback-url/add?url=https://access.acast.com/rss/therachmanreview/abc-123"
       >
@@ -587,7 +587,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
     </li>
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcastAppLink__69RMR"
+        className="PodcastLaunchers_podcastAppLink__69RMR"
         data-trackable="pocket-casts"
         href="pktc://subscribe/access.acast.com/rss/therachmanreview/abc-123"
       >
@@ -596,7 +596,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
     </li>
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcastAppLink__69RMR"
+        className="PodcastLaunchers_podcastAppLink__69RMR"
         data-trackable="podcast-addict"
         href="podcastaddict://access.acast.com/rss/therachmanreview/abc-123"
       >
@@ -605,7 +605,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
     </li>
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big PodcastLaunchers_podcastAppLink__69RMR"
+        className="PodcastLaunchers_podcastAppLink__69RMR"
         data-trackable="acast"
         href="acast://subscribe/https://access.acast.com/rss/therachmanreview/abc-123"
       >
@@ -613,19 +613,18 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
       </a>
     </li>
     <li
-      className="o-forms__affix-wrapper PodcastLaunchers_rssUrlWrapper__vc1zt"
+      className="PodcastLaunchers_rssUrlWrapper__vc1zt"
     >
-      <input
-        className="o-forms__text PodcastLaunchers_rssUrlInput__O7wL-"
-        readOnly={true}
-        type="text"
-        value="https://access.acast.com/rss/therachmanreview/abc-123"
-      />
-      <div
-        className="o-forms__suffix PodcastLaunchers_rssUrlCopyButton__2_4c0"
+      <span
+        className="PodcastLaunchers_o-forms-input--suffix__rDClE PodcastLaunchers_o-forms-input--text__2jeJ0 PodcastLaunchers_o-forms-input__dI9dQ"
       >
+        <input
+          readOnly={true}
+          type="text"
+          value="https://access.acast.com/rss/therachmanreview/abc-123"
+        />
         <button
-          className="o-buttons o-buttons--primary o-buttons--big"
+          className="PodcastLaunchers_rssUrlCopyButton__2_4c0"
           data-trackable="copy-rss"
           data-url="https://access.acast.com/rss/therachmanreview/abc-123"
           onClick={[Function]}
@@ -633,7 +632,7 @@ exports[`@financial-times/x-podcast-launchers renders a default Example x-podcas
         >
           Copy RSS
         </button>
-      </div>
+      </span>
     </li>
   </ul>
   <div

--- a/components/x-podcast-launchers/bower.json
+++ b/components/x-podcast-launchers/bower.json
@@ -4,6 +4,8 @@
   "main": "dist/PodcastLaunchers.es5.js",
   "private": true,
   "dependencies": {
-    "o-typography": "^5.12.0"
+    "o-typography": "^5.12.0",
+    "o-forms": "^7.0.0",
+    "o-buttons": "^5.0.0"
   }
 }

--- a/components/x-podcast-launchers/readme.md
+++ b/components/x-podcast-launchers/readme.md
@@ -32,7 +32,7 @@ $o-buttons-themes: (
 	primary: 'primary',
 );
 ```
-[o-forms](https://registry.origami.ft.com/components/o-forms)  v6 (v7 above breaks the styling)  
+[o-forms](https://registry.origami.ft.com/components/o-forms)  v7
 :memo: Only uses the text input with suffix button style classes
 
 ## Usage

--- a/components/x-podcast-launchers/readme.md
+++ b/components/x-podcast-launchers/readme.md
@@ -23,17 +23,7 @@ The [`x-engine`][engine] module is used to inject your chosen runtime into the c
 
 ## Styling
 
-To get correct styling, Your app should have origami components below.  
-[o-typography](https://registry.origami.ft.com/components/o-typography)  
-[o-buttons](https://registry.origami.ft.com/components/o-buttons) v5  
-:memo: Only needs its `primary` theme classes
-```
-$o-buttons-themes: (
-	primary: 'primary',
-);
-```
-[o-forms](https://registry.origami.ft.com/components/o-forms)  v7
-:memo: Only uses the text input with suffix button style classes
+The styles required for this components are bundled with it.
 
 ## Usage
 
@@ -53,7 +43,6 @@ const c = React.createElement(PodcastLaunchers, props);
 // within your app's sass file
 @import "@financial-times/x-podcast-launchers/dist/PodcastLaunchers";
 ```
-:warning: This component depends on styles provided by o-forms and o-buttons, and therefore o-forms and o-buttons needs to be imported before x-podcast-launchers.
 
 All `x-` components are designed to be compatible with a variety of runtimes, not just React. Check out the [`x-engine`][engine] documentation for a list of recommended libraries and frameworks.
 

--- a/components/x-podcast-launchers/src/PodcastLaunchers.jsx
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.jsx
@@ -6,22 +6,10 @@ import acastSeriesIds from './config/series-ids';
 import styles from './PodcastLaunchers.scss';
 import copyToClipboard from './copy-to-clipboard';
 
-const basicButtonStyles = [
-	'o-buttons',
-	'o-buttons--primary',
-	'o-buttons--big'
-].join(' ');
-
-const podcastAppLinkStyles = [
-	basicButtonStyles,
-	styles.podcastAppLink
-].join(' ');
-
-const rssUrlWrapperStyles = [
-	'o-forms-input',
-	'o-forms-input--suffix',
-	'o-forms-input--text',
-	styles.rssUrlWrapper
+const rssUrlWrapperInner = [
+	styles["o-forms-input--suffix"],
+	styles["o-forms-input--text"],
+	styles["o-forms-input"]
 ].join(' ');
 
 const noAppWrapperStyles = [
@@ -30,6 +18,7 @@ const noAppWrapperStyles = [
 ].join(' ');
 
 function defaultFollowButtonRender (conceptId, conceptName, csrfToken, isFollowed) {
+	console.log(styles)
 	return (
 		<FollowButton
 			conceptId={conceptId}
@@ -71,25 +60,25 @@ class PodcastLaunchers extends Component {
 						<li key={name}>
 							<a
 								href={url}
-								className={podcastAppLinkStyles}
+								className={styles.podcastAppLink}
 								data-trackable={trackingId}>
 								{name}
 							</a>
 						</li>
 					))}
 
-					<li key='Rss Url' className={rssUrlWrapperStyles}>
-						<input className={styles.rssUrlInput} value={rssUrl} type='text' readOnly/>
-						<div className={styles.rssUrlCopyButton}>
-							<button
-								className={basicButtonStyles}
-								onClick={copyToClipboard}
-								data-url={rssUrl}
-								data-trackable='copy-rss'
-								type='button'>
-								Copy RSS
-							</button>
-						</div>
+					<li key='Rss Url' className={styles.rssUrlWrapper}>
+						<span className={rssUrlWrapperInner}>
+							<input value={rssUrl} type='text' readOnly/>
+								<button
+									className={styles.rssUrlCopyButton}
+									onClick={copyToClipboard}
+									data-url={rssUrl}
+									data-trackable='copy-rss'
+									type='button'>
+									Copy RSS
+								</button>
+						</span>
 					</li>
 				</ul>
 

--- a/components/x-podcast-launchers/src/PodcastLaunchers.jsx
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.jsx
@@ -18,18 +18,10 @@ const podcastAppLinkStyles = [
 ].join(' ');
 
 const rssUrlWrapperStyles = [
-	'o-forms__affix-wrapper',
+	'o-forms-input',
+	'o-forms-input--suffix',
+	'o-forms-input--text',
 	styles.rssUrlWrapper
-].join(' ');
-
-const rssUrlInputStyles = [
-	'o-forms__text',
-	styles.rssUrlInput
-].join(' ');
-
-const rssUrlCopyButtonWrapperStyles = [
-	'o-forms__suffix',
-	styles.rssUrlCopyButton
 ].join(' ');
 
 const noAppWrapperStyles = [
@@ -87,8 +79,8 @@ class PodcastLaunchers extends Component {
 					))}
 
 					<li key='Rss Url' className={rssUrlWrapperStyles}>
-						<input className={rssUrlInputStyles} value={rssUrl} type='text' readOnly/>
-						<div className={rssUrlCopyButtonWrapperStyles}>
+						<input className={styles.rssUrlInput} value={rssUrl} type='text' readOnly/>
+						<div className={styles.rssUrlCopyButton}>
 							<button
 								className={basicButtonStyles}
 								onClick={copyToClipboard}

--- a/components/x-podcast-launchers/src/PodcastLaunchers.jsx
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.jsx
@@ -18,7 +18,6 @@ const noAppWrapperStyles = [
 ].join(' ');
 
 function defaultFollowButtonRender (conceptId, conceptName, csrfToken, isFollowed) {
-	console.log(styles)
 	return (
 		<FollowButton
 			conceptId={conceptId}

--- a/components/x-podcast-launchers/src/PodcastLaunchers.scss
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.scss
@@ -1,6 +1,12 @@
 $o-typography-is-silent: true;
 @import 'o-typography/main';
 
+$o-forms-is-silent: true;
+@import 'o-forms/main';
+
+$o-buttons-is-silent: true;
+@import 'o-buttons/main';
+
 :global {
 	@import "~@financial-times/x-follow-button/dist/FollowButton";
 }
@@ -48,11 +54,13 @@ $o-typography-is-silent: true;
 }
 
 .podcastAppLink {
+	@include oButtons(big, primary);
 	width: 100%;
 	margin-top: 8px;
 }
 
 .rssUrlWrapper {
+	@include oForms($opts: (elements:(text), features:(suffix)));
 	margin-top: 8px;
 }
 
@@ -61,7 +69,7 @@ $o-typography-is-silent: true;
 }
 
 .rssUrlCopyButton {
-	padding-left: 0px;
+	@include oButtons(big, primary);
 }
 
 .rssUrlCopySpan {

--- a/components/x-podcast-launchers/src/PodcastLaunchers.scss
+++ b/components/x-podcast-launchers/src/PodcastLaunchers.scss
@@ -61,7 +61,9 @@ $o-buttons-is-silent: true;
 
 .rssUrlWrapper {
 	@include oForms($opts: (elements:(text), features:(suffix)));
-	margin-top: 8px;
+	.o-forms-input {
+		margin-top: 8px;
+	}
 }
 
 .rssUrlInput {

--- a/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
+++ b/components/x-podcast-launchers/src/__tests__/__snapshots__/PodcastLaunchers.test.jsx.snap
@@ -12,7 +12,6 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
   <ul>
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="apple-podcasts"
         href="podcast://acast.access/rss/therachmanreview/123-abc"
       >
@@ -21,7 +20,6 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
     </li>
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="overcast"
         href="overcast://x-callback-url/add?url=https://acast.access/rss/therachmanreview/123-abc"
       >
@@ -30,7 +28,6 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
     </li>
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="pocket-casts"
         href="pktc://subscribe/acast.access/rss/therachmanreview/123-abc"
       >
@@ -39,7 +36,6 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
     </li>
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="podcast-addict"
         href="podcastaddict://acast.access/rss/therachmanreview/123-abc"
       >
@@ -48,27 +44,22 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
     </li>
     <li>
       <a
-        className="o-buttons o-buttons--primary o-buttons--big "
         data-trackable="acast"
         href="acast://subscribe/https://acast.access/rss/therachmanreview/123-abc"
       >
         Acast
       </a>
     </li>
-    <li
-      className="o-forms__affix-wrapper "
-    >
-      <input
-        className="o-forms__text "
-        readOnly={true}
-        type="text"
-        value="https://acast.access/rss/therachmanreview/123-abc"
-      />
-      <div
-        className="o-forms__suffix "
+    <li>
+      <span
+        className="  "
       >
+        <input
+          readOnly={true}
+          type="text"
+          value="https://acast.access/rss/therachmanreview/123-abc"
+        />
         <button
-          className="o-buttons o-buttons--primary o-buttons--big"
           data-trackable="copy-rss"
           data-url="https://acast.access/rss/therachmanreview/123-abc"
           onClick={[Function]}
@@ -76,7 +67,7 @@ exports[`PodcastLaunchers should render the app links based on concept Id 1`] = 
         >
           Copy RSS
         </button>
-      </div>
+      </span>
     </li>
   </ul>
   <div

--- a/components/x-podcast-launchers/stories/index.js
+++ b/components/x-podcast-launchers/stories/index.js
@@ -9,7 +9,7 @@ exports.dependencies = {
 	'o-normalise': '^1.6.0',
 	'o-typography': '^5.5.0',
 	'o-buttons': '^5.16.6',
-	'o-forms': '^6.0.3'
+	'o-forms': '^7.0.0'
 };
 
 exports.stories = [


### PR DESCRIPTION
This PR updates o-forms and o-buttons in the PodCast Launcher.

As there are some big Origami changes coming next week it makes sense to upgrade these components now because they'll block the more straightforward upgrades next week.

As part of updating o-forms I realised the way o-forms was being included (declaratively, with the expectation that the consuming client will include all the component sass) is likely to lead to version conflicts that nobody notices. 

To address this, I have brought the code into the component implicitly, and am only using the necessary styles for the rss field. 

I have tested this in next-article and it works as I would expect. I don't anticipate any issues with the app as these are pretty simple changes, but if someone with the apps spun up could help me verify that, that would be good.

BEFORE
![Screenshot 2019-11-21 at 15 32 52](https://user-images.githubusercontent.com/68009/69352084-34374b00-0c74-11ea-8b18-4c57221f8e26.png)
![Screenshot 2019-11-21 at 15 32 42](https://user-images.githubusercontent.com/68009/69352099-3a2d2c00-0c74-11ea-89bc-e78d2aaa4fea.png)

AFTER
![Screenshot 2019-11-21 at 15 28 18](https://user-images.githubusercontent.com/68009/69352047-208be480-0c74-11ea-99d3-a76d73634ca1.png)
![Screenshot 2019-11-21 at 15 28 25](https://user-images.githubusercontent.com/68009/69352051-2255a800-0c74-11ea-978b-325d975bfa51.png)
