### PR TITLE
Modify x-teaser image to support blob: URLs for images without trying to pass them to the image service

### DIFF
--- a/components/x-teaser/__fixtures__/article-with-data-image.json
+++ b/components/x-teaser/__fixtures__/article-with-data-image.json
@@ -1,0 +1,30 @@
+{
+  "type": "article",
+  "id": "",
+  "url": "#",
+  "title": "Inside charity fundraiser where hostesses are put on show",
+  "altTitle": "Men Only, the charity fundraiser with hostesses on show",
+  "standfirst": "FT investigation finds groping and sexual harassment at secretive black-tie dinner",
+  "altStandfirst": "Groping and sexual harassment at black-tie dinner charity event",
+  "publishedDate": "2018-01-23T15:07:00.000Z",
+  "firstPublishedDate": "2018-01-23T13:53:00.000Z",
+  "metaPrefixText": "",
+  "metaSuffixText": "",
+  "metaLink": {
+    "url": "#",
+    "prefLabel": "Sexual misconduct allegations"
+  },
+  "metaAltLink": {
+    "url": "#",
+    "prefLabel": "FT Investigations"
+  },
+  "image": {
+    "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==",
+    "width": 2048,
+    "height": 1152,
+    "imageLazyLoad": "js-image-lazy-load"
+  },
+  "indicators": {
+    "isEditorsChoice": true
+  }
+}

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -60,6 +60,66 @@ exports[`x-teaser / snapshots renders a Hero teaser with article data 1`] = `
 </div>
 `;
 
+exports[`x-teaser / snapshots renders a Hero teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--hero o-teaser--has-image o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+  </div>
+  <div
+    className="o-teaser__image-container js-teaser-image-container"
+  >
+    <div
+      className="o-teaser__image-placeholder"
+      style={
+        Object {
+          "paddingBottom": "56.2500%",
+        }
+      }
+    >
+      <a
+        aria-hidden="true"
+        data-trackable="image-link"
+        href="#"
+        tabIndex="-1"
+      >
+        <img
+          alt=""
+          className="o-teaser__image"
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
+        />
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`x-teaser / snapshots renders a Hero teaser with contentPackage data 1`] = `
 <div
   className="o-teaser o-teaser--package o-teaser--hero o-teaser--has-image js-teaser"
@@ -546,6 +606,53 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with article data 1`] 
 </div>
 `;
 
+exports[`x-teaser / snapshots renders a HeroNarrow teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--hero o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
+  </div>
+</div>
+`;
+
 exports[`x-teaser / snapshots renders a HeroNarrow teaser with contentPackage data 1`] = `
 <div
   className="o-teaser o-teaser--package o-teaser--hero js-teaser"
@@ -947,6 +1054,66 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with article data 1`]
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&compression=best&width=640"
+        />
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`x-teaser / snapshots renders a HeroOverlay teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--hero o-teaser--hero-image o-teaser--has-image o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+  </div>
+  <div
+    className="o-teaser__image-container js-teaser-image-container"
+  >
+    <div
+      className="o-teaser__image-placeholder"
+      style={
+        Object {
+          "paddingBottom": "56.2500%",
+        }
+      }
+    >
+      <a
+        aria-hidden="true"
+        data-trackable="image-link"
+        href="#"
+        tabIndex="-1"
+      >
+        <img
+          alt=""
+          className="o-teaser__image"
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         />
       </a>
     </div>
@@ -1428,6 +1595,41 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with article data 1`] =
 </div>
 `;
 
+exports[`x-teaser / snapshots renders a HeroVideo teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--hero o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`x-teaser / snapshots renders a HeroVideo teaser with contentPackage data 1`] = `
 <div
   className="o-teaser o-teaser--package o-teaser--hero js-teaser"
@@ -1811,6 +2013,78 @@ exports[`x-teaser / snapshots renders a Large teaser with article data 1`] = `
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&compression=best&width=340"
+        />
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`x-teaser / snapshots renders a Large teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--large o-teaser--has-image o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
+  </div>
+  <div
+    className="o-teaser__image-container js-teaser-image-container"
+  >
+    <div
+      className="o-teaser__image-placeholder"
+      style={
+        Object {
+          "paddingBottom": "56.2500%",
+        }
+      }
+    >
+      <a
+        aria-hidden="true"
+        data-trackable="image-link"
+        href="#"
+        tabIndex="-1"
+      >
+        <img
+          alt=""
+          className="o-teaser__image"
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         />
       </a>
     </div>
@@ -2376,6 +2650,41 @@ exports[`x-teaser / snapshots renders a Small teaser with article data 1`] = `
 </div>
 `;
 
+exports[`x-teaser / snapshots renders a Small teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--small o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`x-teaser / snapshots renders a Small teaser with contentPackage data 1`] = `
 <div
   className="o-teaser o-teaser--package o-teaser--small js-teaser"
@@ -2705,6 +3014,78 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with article data 1`] 
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&compression=best&width=240"
+        />
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`x-teaser / snapshots renders a SmallHeavy teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--small o-teaser--has-image o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
+  </div>
+  <div
+    className="o-teaser__image-container js-teaser-image-container"
+  >
+    <div
+      className="o-teaser__image-placeholder"
+      style={
+        Object {
+          "paddingBottom": "56.2500%",
+        }
+      }
+    >
+      <a
+        aria-hidden="true"
+        data-trackable="image-link"
+        href="#"
+        tabIndex="-1"
+      >
+        <img
+          alt=""
+          className="o-teaser__image"
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         />
       </a>
     </div>
@@ -3282,6 +3663,53 @@ exports[`x-teaser / snapshots renders a TopStory teaser with article data 1`] = 
 </div>
 `;
 
+exports[`x-teaser / snapshots renders a TopStory teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--top-story o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
+  </div>
+</div>
+`;
+
 exports[`x-teaser / snapshots renders a TopStory teaser with contentPackage data 1`] = `
 <div
   className="o-teaser o-teaser--package o-teaser--top-story js-teaser"
@@ -3732,6 +4160,78 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article da
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&compression=best&width=640"
+        />
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--top-story o-teaser--landscape o-teaser--has-image o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
+  </div>
+  <div
+    className="o-teaser__image-container js-teaser-image-container"
+  >
+    <div
+      className="o-teaser__image-placeholder"
+      style={
+        Object {
+          "paddingBottom": "56.2500%",
+        }
+      }
+    >
+      <a
+        aria-hidden="true"
+        data-trackable="image-link"
+        href="#"
+        tabIndex="-1"
+      >
+        <img
+          alt=""
+          className="o-teaser__image"
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         />
       </a>
     </div>

--- a/components/x-teaser/__tests__/snapshots.test.js
+++ b/components/x-teaser/__tests__/snapshots.test.js
@@ -4,6 +4,7 @@ const { Teaser, presets } = require('../');
 
 const storyData = {
 	article: require('../__fixtures__/article.json'),
+	'article-with-data-image': require('../__fixtures__/article-with-data-image.json'),
 	opinion: require('../__fixtures__/opinion.json'),
 	contentPackage: require('../__fixtures__/content-package.json'),
 	packageItem: require('../__fixtures__/package-item.json'),

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -236,7 +236,7 @@ Property      | Type   | Notes
 
 Property | Type   | Notes
 ---------|--------|--------------
-`url`    | String | Content UUID or, in the case of images, `data:` URL
+`url`    | String | Content UUID or, in the case of images, `data:` or `blob:` URL
 `width`  | Number |
 `height` | Number |
 

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -28,7 +28,8 @@ const LazyImage = ({ src, lazyLoad }) => {
 
 export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, ...props }) => {
 	const displayUrl = relativeUrl || url;
-	const imageSrc = image.url.startsWith('data:') ? image.url : imageService(image.url, ImageSizes[imageSize]);
+	const useImageService = !(image.url.startsWith('data:') || image.url.startsWith('blob:'));
+	const imageSrc = useImageService ? imageService(image.url, ImageSizes[imageSize]) : image.url;
 	const ImageComponent = imageLazyLoad ? LazyImage : NormalImage;
 
 	return image ? (


### PR DESCRIPTION
To improve speed of loading images in the app, we'd like to switch to `blob:` URLs generated via `URL.createObjectURL()`. At the moment x-teaser doesn't recognise these and so tries to load them via the image service; this is a simple change just adding them to the existing exception that exists for `data:` URLs.

I've added a test for the `data:` uri functionality just to ensure that wasn't broken - thought it was superfluous to add a similar snapshot for a `blob:` url but happy to do so if you'd like...