### PR TITLE
add a showGuidance data-attribute to the Video.jsx template

### DIFF
--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -1899,7 +1899,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with video data 1`] = `
             data-o-video-placeholder-hint="Play video"
             data-o-video-placeholder-info="[]"
             data-o-video-playsinline="true"
-            data-o-video-show-guidance={true}
+            data-o-video-show-guidance="true"
             data-o-video-systemcode="x-teaser"
           />
         </div>

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -1899,6 +1899,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with video data 1`] = `
             data-o-video-placeholder-hint="Play video"
             data-o-video-placeholder-info="[]"
             data-o-video-playsinline="true"
+            data-o-video-show-guidance={true}
             data-o-video-systemcode="x-teaser"
           />
         </div>

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -117,6 +117,7 @@ Feature            | Type    | Notes
 `showImage`        | Boolean |
 `showHeadshot`     | Boolean | Takes precedence over image
 `showVideo`        | Boolean | Takes precedence over image or headshot
+`showGuidance`     | Boolean | Show video captions guidance
 `showRelatedLinks` | Boolean |
 `showCustomSlot`   | Boolean |
 

--- a/components/x-teaser/src/Video.jsx
+++ b/components/x-teaser/src/Video.jsx
@@ -10,7 +10,7 @@ const formatData = (props) => JSON.stringify({
 // To prevent React from touching the DOM after mounting… return an empty <div />
 // <https://reactjs.org/docs/integrating-with-other-libraries.html>
 const Embed = (props) => {
-	const showGuidance = typeof(props.showGuidance) === 'boolean' ? props.showGuidance : true;
+	const showGuidance = typeof props.showGuidance  === 'boolean' ? props.showGuidance.toString() : "true";
 	return (
 	<div className="o-teaser__image-container js-image-container">
 		<div

--- a/components/x-teaser/src/Video.jsx
+++ b/components/x-teaser/src/Video.jsx
@@ -9,7 +9,9 @@ const formatData = (props) => JSON.stringify({
 
 // To prevent React from touching the DOM after mounting… return an empty <div />
 // <https://reactjs.org/docs/integrating-with-other-libraries.html>
-const Embed = (props) => (
+const Embed = (props) => {
+	const showGuidance = typeof(props.showGuidance) === 'boolean' ? props.showGuidance : true;
+	return (
 	<div className="o-teaser__image-container js-image-container">
 		<div
 			className="o-video"
@@ -20,13 +22,14 @@ const Embed = (props) => (
 			data-o-video-optimumvideowidth="640"
 			data-o-video-autorender="true"
 			data-o-video-playsinline="true"
-			data-o-video-disableGuidance={props.disableGuidance}
+			data-o-video-show-guidance={showGuidance}
 			data-o-video-placeholder="true"
 			data-o-video-placeholder-info="[]"
 			data-o-video-placeholder-hint="Play video"
 			data-o-video-systemcode={props.systemCode} />
 	</div>
-);
+	)
+};
 
 export default (props) => (
 	<div className="o-teaser__video">

--- a/components/x-teaser/src/Video.jsx
+++ b/components/x-teaser/src/Video.jsx
@@ -20,6 +20,7 @@ const Embed = (props) => (
 			data-o-video-optimumvideowidth="640"
 			data-o-video-autorender="true"
 			data-o-video-playsinline="true"
+			data-o-video-disableGuidance={props.disableGuidance}
 			data-o-video-placeholder="true"
 			data-o-video-placeholder-info="[]"
 			data-o-video-placeholder-hint="Play video"


### PR DESCRIPTION
Adds a `data-o-video-show-guidance` data-attribute to the Video.jsx template which defaults to `true`. 

This will allow us to disable the 'No captions available' guidance for videos which use x-teaser. We want to remove this guidance  for videos on the Front Page as tests have shown that it decreases engagement; [discussion in this trello ticket](https://trello.com/c/qSiuMpf4/110-remove-subtitles-info-from-video-promo-on-ft-homepage). 

Related PR in o-video to support the new attribute: https://github.com/Financial-Times/o-video/pull/149
Related PR to implement this change in next-front-page: https://github.com/Financial-Times/next-front-page/pull/2208

