### PR TITLE
Revert "refactor image service helper to use URL constructor"

### DIFF
--- a/components/x-teaser/src/Headshot.jsx
+++ b/components/x-teaser/src/Headshot.jsx
@@ -6,9 +6,7 @@ import imageService from './concerns/image-service';
 const DEFAULT_TINT = '054593,d6d5d3';
 
 export default ({ headshot, headshotTint }) => {
-	const options = {
-		tint: headshotTint || DEFAULT_TINT,
-	};
+	const options = `tint=${headshotTint || DEFAULT_TINT}`;
 
 	return headshot ? (
 		<img

--- a/components/x-teaser/src/concerns/image-service.js
+++ b/components/x-teaser/src/concerns/image-service.js
@@ -1,9 +1,5 @@
-const BASE_URL = 'https://www.ft.com/__origami/service/image/v2/images/raw/';
-const DEFAULT_OPTIONS = {
-	source: 'next',
-	fit: 'scale-down',
-	dpr: 2
-};
+const BASE_URL = 'https://www.ft.com/__origami/service/image/v2/images/raw';
+const OPTIONS = ['source=next', 'fit=scale-down', 'dpr=2'];
 
 /**
  * Image Service
@@ -11,14 +7,8 @@ const DEFAULT_OPTIONS = {
  * @param {Number} width
  * @param {String} options
  */
-export default function imageService(url, width, options = {}) {
+export default function imageService(url, width, options) {
 	const encoded = encodeURIComponent(url);
-	const imageServiceUrl = new URL(encoded, BASE_URL);
-	imageServiceUrl.search = new URLSearchParams({
-		...DEFAULT_OPTIONS,
-		...options,
-		width
-	});
-
-	return imageServiceUrl.toString();
+	const href = `${BASE_URL}/${encoded}?${OPTIONS.join('&')}&width=${width}`;
+	return options ? href + '&' + options : href;
 }


### PR DESCRIPTION
The global `URL` is only available in node v10