### PR TITLE
Add a disable guidance attribute to videos

### DIFF
--- a/__tests__/snapshots.test.js
+++ b/__tests__/snapshots.test.js
@@ -21,16 +21,14 @@ for(const pkg of packageDirs) {
 		const { presets = { default: {} } } = require(pkgDir);
 		const name = path.basename(pkg.name);
 
-		describe(`${pkg.name}`, () => {
-			for (const { title, data } of stories) {
-				for (const [preset, options] of Object.entries(presets)) {
-					it(`renders a ${preset} ${title} ${name}`, () => {
-						const props = { ...data, ...options };
-						const tree = renderer.create(h(component, props)).toJSON();
-						expect(tree).toMatchSnapshot();
-					});
-				}
+		for (const { title, data } of stories) {
+			for (const [preset, options] of Object.entries(presets)) {
+				it(`${pkg.name} renders a ${preset} ${title} ${name}`, () => {
+					const props = { ...data, ...options };
+					const tree = renderer.create(h(component, props)).toJSON();
+					expect(tree).toMatchSnapshot();
+				});
 			}
-		});
+		}
 	}
 }

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -1697,6 +1697,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with video data 1`] = `
             data-o-video-placeholder-hint="Play video"
             data-o-video-placeholder-info="[]"
             data-o-video-playsinline="true"
+            data-o-video-show-guidance={true}
           />
         </div>
       </div>

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -1697,7 +1697,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with video data 1`] = `
             data-o-video-placeholder-hint="Play video"
             data-o-video-placeholder-info="[]"
             data-o-video-playsinline="true"
-            data-o-video-show-guidance={true}
+            data-o-video-show-guidance="true"
           />
         </div>
       </div>

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -117,6 +117,7 @@ Feature            | Type    | Notes
 `showImage`        | Boolean |
 `showHeadshot`     | Boolean | Takes precedence over image
 `showVideo`        | Boolean | Takes precedence over image or headshot
+`showGuidance`     | Boolean | Show video captions guidance
 `showRelatedLinks` | Boolean |
 `showCustomSlot`   | Boolean |
 

--- a/components/x-teaser/src/Video.jsx
+++ b/components/x-teaser/src/Video.jsx
@@ -10,7 +10,7 @@ const formatData = (props) => JSON.stringify({
 // To prevent React from touching the DOM after mounting… return an empty <div />
 // <https://reactjs.org/docs/integrating-with-other-libraries.html>
 const Embed = (props) => {
-	const showGuidance = typeof(props.showGuidance) === 'boolean' ? props.showGuidance : true;
+	const showGuidance = typeof props.showGuidance  === 'boolean' ? props.showGuidance.toString() : "true";
 	return (
 	<div className="o-teaser__image-container js-image-container">
 		<div

--- a/components/x-teaser/src/Video.jsx
+++ b/components/x-teaser/src/Video.jsx
@@ -20,6 +20,7 @@ const Embed = (props) => (
 			data-o-video-optimumvideowidth="640"
 			data-o-video-autorender="true"
 			data-o-video-playsinline="true"
+			data-o-video-disableGuidance={props.disableGuidance}
 			data-o-video-placeholder="true"
 			data-o-video-placeholder-info="[]"
 			data-o-video-placeholder-hint="Play video" />

--- a/components/x-teaser/src/Video.jsx
+++ b/components/x-teaser/src/Video.jsx
@@ -9,7 +9,9 @@ const formatData = (props) => JSON.stringify({
 
 // To prevent React from touching the DOM after mounting… return an empty <div />
 // <https://reactjs.org/docs/integrating-with-other-libraries.html>
-const Embed = (props) => (
+const Embed = (props) => {
+	const showGuidance = typeof(props.showGuidance) === 'boolean' ? props.showGuidance : true;
+	return (
 	<div className="o-teaser__image-container js-image-container">
 		<div
 			className="o-video"
@@ -20,12 +22,13 @@ const Embed = (props) => (
 			data-o-video-optimumvideowidth="640"
 			data-o-video-autorender="true"
 			data-o-video-playsinline="true"
-			data-o-video-disableGuidance={props.disableGuidance}
+			data-o-video-show-guidance={showGuidance}
 			data-o-video-placeholder="true"
 			data-o-video-placeholder-info="[]"
 			data-o-video-placeholder-hint="Play video" />
 	</div>
-);
+	)
+};
 
 export default (props) => (
 	<div className="o-teaser__video">


### PR DESCRIPTION
This reapplies @pixelandpage's work to fix video subtitles to a new branch. The `pre-origami-cascade` branch was created from `v1.0.0-beta.21`, and new beta releases should be created from here.

There's definitely some stuff that's slightly wrong about this PR, mostly whitespace, which I'll look into now. I'm going to need help to get this merged and released in a way that doesn't break things.