### PR TITLE
Extract logic from x-teaser-timeline and add tests

### DIFF
--- a/components/x-teaser-timeline/__tests__/lib/transform.test.js
+++ b/components/x-teaser-timeline/__tests__/lib/transform.test.js
@@ -1,4 +1,4 @@
-import { getItemGroups, getGroupAndIndex } from '../../src/lib/transform';
+import { buildModel } from '../../src/lib/transform';
 
 const props = {
 	'items': [
@@ -55,11 +55,9 @@ const props = {
 	],
 	'showSaveButtons': false,
 	'latestItemsTime': null,
-	'customSlotContent': { 'children': [], 'attributes': { 'shouldRender': false } },
-	'customSlotPosition': 2,
 	'children': []
 };
-const itemGroups = [
+const groupedItems = [
 	{
 		'date': '2020-01-14',
 		'title': 'Earlier Today',
@@ -151,36 +149,80 @@ const itemGroups = [
 	}
 ];
 
-describe.only('getItemGroups', () => {
-	test('correctly groups some stuff', () => {
-		const result = getItemGroups({ ...props, timezoneOffset: 0, localTodayDate: '2020-01-14' });
-		expect(result).toEqual(itemGroups);
+describe.only('buildModel without custom slot content', () => {
+	test('correctly builds model from props', () => {
+		const result = buildModel({ ...props, timezoneOffset: 0, localTodayDate: '2020-01-14' });
+		expect(result).toEqual(groupedItems);
 	});
 });
 
-describe.only('getGroupAndIndex', () => {
-	test('returns correct group and index for middle of first group', () => {
-		const insertPosition = 2;
-		const result = getGroupAndIndex( itemGroups, insertPosition );
-		expect(result.group).toBe(0);
-		expect(result.index).toBe(2);
+describe.only('buildModel with custom slot content', () => {
+	test('returns correct model for custom slot in middle of first group', () => {
+		const result = buildModel({
+			...props,
+			timezoneOffset: 0,
+			localTodayDate: '2020-01-14',
+			customSlotContent: { foo: 1 },
+			customSlotPosition: 2
+		});
+		expect(result).toEqual([
+			{
+				...groupedItems[0],
+				items: [groupedItems[0].items[0], groupedItems[0].items[1], { foo: 1 }, groupedItems[0].items[2], groupedItems[0].items[3]]
+			},
+			groupedItems[1],
+			groupedItems[2]
+		]);
 	});
-	test('returns correct group and index for end of second group', () => {
-		const insertPosition = 5;
-		const result = getGroupAndIndex( itemGroups, insertPosition );
-		expect(result.group).toBe(1);
-		expect(result.index).toBe(1);
+	test('returns correct model for custom slot at end of second group', () => {
+		const result = buildModel({
+			...props,
+			timezoneOffset: 0,
+			localTodayDate: '2020-01-14',
+			customSlotContent: { foo: 1 },
+			customSlotPosition: 5
+		});
+		expect(result).toEqual([
+			groupedItems[0],
+			{
+				...groupedItems[1],
+				items: [groupedItems[1].items[0], { foo: 1 }]
+			},
+			groupedItems[2]
+		]);
 	});
-	test('returns correct group and index for off end of all groups', () => {
-		const insertPosition = 10;
-		const result = getGroupAndIndex( itemGroups, insertPosition );
-		expect(result.group).toBe(2);
-		expect(result.index).toBe(5);
+	test('returns correct model for custom slot off end of all groups', () => {
+		const result = buildModel({
+			...props,
+			timezoneOffset: 0,
+			localTodayDate: '2020-01-14',
+			customSlotContent: { foo: 1 },
+			customSlotPosition: 10
+		});
+		expect(result).toEqual([
+			groupedItems[0],
+			groupedItems[1],
+			{
+				...groupedItems[2],
+				items: [...groupedItems[2].items, { foo: 1 }]
+			}
+		]);
 	});
-	test('returns correct group and index for position 0', () => {
-		const insertPosition = 0;
-		const result = getGroupAndIndex([], insertPosition );
-		expect(result.group).toBe(0);
-		expect(result.index).toBe(0);
+	test('returns correct model for custom slot in position 0', () => {
+		const result = buildModel({
+			...props,
+			timezoneOffset: 0,
+			localTodayDate: '2020-01-14',
+			customSlotContent: { foo: 1 },
+			customSlotPosition: 0
+		});
+		expect(result).toEqual([
+			{
+				...groupedItems[0],
+				items: [{ foo: 1 }, groupedItems[0].items[0], groupedItems[0].items[1], groupedItems[0].items[2], groupedItems[0].items[3]]
+			},
+			groupedItems[1],
+			groupedItems[2]
+		]);
 	});
 });

--- a/components/x-teaser-timeline/__tests__/lib/transform.test.js
+++ b/components/x-teaser-timeline/__tests__/lib/transform.test.js
@@ -1,0 +1,159 @@
+import { getItemGroups } from '../../src/lib/transform';
+
+const props = {
+	'items': [
+		{
+			'id': '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4',
+			'title': 'Europeans step up pressure on Iran over nuclear deal',
+			'publishedDate': '2020-01-14T11:10:26.000Z'
+		},
+		{
+			'id': '01eaf2fc-36ac-11ea-a6d3-9a26f8c3cba4',
+			'title': 'Iran’s judiciary threatens to expel UK ambassador',
+			'publishedDate': '2020-01-14T10:23:14.000Z'
+		},
+		{
+			'id': 'dcac61ea-361c-11ea-a6d3-9a26f8c3cba4',
+			'title': 'Iran’s regime loses the battle for public opinion',
+			'publishedDate': '2020-01-14T10:00:27.000Z'
+		},
+		{
+			'id': 'bf0752ee-3685-11ea-a6d3-9a26f8c3cba4',
+			'title': 'Justin Trudeau partly blames US for Iran plane crash',
+			'publishedDate': '2020-01-14T08:15:05.000Z'
+		},
+		{
+			'id': '1d1527fa-356c-11ea-a6d3-9a26f8c3cba4',
+			'title': 'Biden and Sanders reprise Iraq war fight in 2020 race',
+			'publishedDate': '2020-01-13T11:00:26.000Z'
+		},
+		{
+			'id': '6524b530-355b-11ea-a6d3-9a26f8c3cba4',
+			'title': 'Esper ‘didn’t see’ specific evidence of embassy threat',
+			'publishedDate': '2020-01-12T18:36:39.000Z'
+		},
+		{
+			'id': '86df67f6-3524-11ea-a6d3-9a26f8c3cba4',
+			'title': 'Lies over air crash shake Iran’s trust in its rulers',
+			'publishedDate': '2020-01-12T16:29:11.000Z'
+		},
+		{
+			'id': '37084c8c-3508-11ea-a6d3-9a26f8c3cba4',
+			'title': 'Iran questions Revolutionary Guard over downing of airliner',
+			'publishedDate': '2020-01-12T09:51:13.000Z'
+		},
+		{
+			'id': 'b931cc22-3073-11ea-a329-0bcf87a328f2',
+			'title': 'What next for oil as US-Iran tensions simmer?',
+			'publishedDate': '2020-01-12T09:00:26.000Z'
+		},
+		{
+			'id': '0e76e39a-3428-11ea-9703-eea0cae3f0de',
+			'title': 'Iran admits it shot down Ukrainian jet',
+			'publishedDate': '2020-01-12T05:35:29.000Z'
+		}
+	],
+	'showSaveButtons': false,
+	'latestItemsTime': null,
+	'customSlotContent': { 'children': [], 'attributes': { 'shouldRender': false } },
+	'customSlotPosition': 2,
+	'children': []
+};
+const expected = [
+	{
+		'date': '2020-01-14',
+		'title': 'Earlier Today',
+		'items': [
+			{
+				'articleIndex': 0,
+				'localisedLastUpdated': '2020-01-14T11:10:26.000+00:00',
+				'id': '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4',
+				'title': 'Europeans step up pressure on Iran over nuclear deal',
+				'publishedDate': '2020-01-14T11:10:26.000Z'
+			},
+			{
+				'articleIndex': 1,
+				'localisedLastUpdated': '2020-01-14T10:23:14.000+00:00',
+				'id': '01eaf2fc-36ac-11ea-a6d3-9a26f8c3cba4',
+				'title': 'Iran’s judiciary threatens to expel UK ambassador',
+				'publishedDate': '2020-01-14T10:23:14.000Z'
+			},
+			{
+				'articleIndex': 2,
+				'localisedLastUpdated': '2020-01-14T10:00:27.000+00:00',
+				'id': 'dcac61ea-361c-11ea-a6d3-9a26f8c3cba4',
+				'title': 'Iran’s regime loses the battle for public opinion',
+				'publishedDate': '2020-01-14T10:00:27.000Z'
+			},
+			{
+				'articleIndex': 3,
+				'localisedLastUpdated': '2020-01-14T08:15:05.000+00:00',
+				'id': 'bf0752ee-3685-11ea-a6d3-9a26f8c3cba4',
+				'title': 'Justin Trudeau partly blames US for Iran plane crash',
+				'publishedDate': '2020-01-14T08:15:05.000Z'
+			}
+		]
+	},
+	{
+		'date': '2020-01-13',
+		'title': 'Yesterday',
+		'items':
+			[
+				{
+					'articleIndex': 4,
+					'localisedLastUpdated': '2020-01-13T11:00:26.000+00:00',
+					'id': '1d1527fa-356c-11ea-a6d3-9a26f8c3cba4',
+					'title': 'Biden and Sanders reprise Iraq war fight in 2020 race',
+					'publishedDate': '2020-01-13T11:00:26.000Z'
+				}
+			]
+	},
+	{
+		'date': '2020-01-12',
+		'title': 'January 12, 2020',
+		'items': [
+			{
+				'articleIndex': 5,
+				'localisedLastUpdated': '2020-01-12T18:36:39.000+00:00',
+				'id': '6524b530-355b-11ea-a6d3-9a26f8c3cba4',
+				'title': 'Esper ‘didn’t see’ specific evidence of embassy threat',
+				'publishedDate': '2020-01-12T18:36:39.000Z'
+			},
+			{
+				'articleIndex': 6,
+				'localisedLastUpdated': '2020-01-12T16:29:11.000+00:00',
+				'id': '86df67f6-3524-11ea-a6d3-9a26f8c3cba4',
+				'title': 'Lies over air crash shake Iran’s trust in its rulers',
+				'publishedDate': '2020-01-12T16:29:11.000Z'
+			},
+			{
+				'articleIndex': 7,
+				'localisedLastUpdated': '2020-01-12T09:51:13.000+00:00',
+				'id': '37084c8c-3508-11ea-a6d3-9a26f8c3cba4',
+				'title': 'Iran questions Revolutionary Guard over downing of airliner',
+				'publishedDate': '2020-01-12T09:51:13.000Z'
+			},
+			{
+				'articleIndex': 8,
+				'localisedLastUpdated': '2020-01-12T09:00:26.000+00:00',
+				'id': 'b931cc22-3073-11ea-a329-0bcf87a328f2',
+				'title': 'What next for oil as US-Iran tensions simmer?',
+				'publishedDate': '2020-01-12T09:00:26.000Z'
+			},
+			{
+				'articleIndex': 9,
+				'localisedLastUpdated': '2020-01-12T05:35:29.000+00:00',
+				'id': '0e76e39a-3428-11ea-9703-eea0cae3f0de',
+				'title': 'Iran admits it shot down Ukrainian jet',
+				'publishedDate': '2020-01-12T05:35:29.000Z'
+			}
+		]
+	}
+];
+
+describe.only('groupItemsByLocalisedDate', () => {
+	test('correctly groups some stuff', () => {
+		const result = getItemGroups({ ...props, timezoneOffset: 0, localTodayDate: '2020-01-14' });
+		expect(result).toEqual(expected);
+	});
+});

--- a/components/x-teaser-timeline/__tests__/lib/transform.test.js
+++ b/components/x-teaser-timeline/__tests__/lib/transform.test.js
@@ -1,4 +1,4 @@
-import { getItemGroups } from '../../src/lib/transform';
+import { getItemGroups, getGroupAndIndex } from '../../src/lib/transform';
 
 const props = {
 	'items': [
@@ -59,7 +59,7 @@ const props = {
 	'customSlotPosition': 2,
 	'children': []
 };
-const expected = [
+const itemGroups = [
 	{
 		'date': '2020-01-14',
 		'title': 'Earlier Today',
@@ -151,9 +151,36 @@ const expected = [
 	}
 ];
 
-describe.only('groupItemsByLocalisedDate', () => {
+describe.only('getItemGroups', () => {
 	test('correctly groups some stuff', () => {
 		const result = getItemGroups({ ...props, timezoneOffset: 0, localTodayDate: '2020-01-14' });
-		expect(result).toEqual(expected);
+		expect(result).toEqual(itemGroups);
+	});
+});
+
+describe.only('getGroupAndIndex', () => {
+	test('returns correct group and index for middle of first group', () => {
+		const insertPosition = 2;
+		const result = getGroupAndIndex( itemGroups, insertPosition );
+		expect(result.group).toBe(0);
+		expect(result.index).toBe(2);
+	});
+	test('returns correct group and index for end of second group', () => {
+		const insertPosition = 5;
+		const result = getGroupAndIndex( itemGroups, insertPosition );
+		expect(result.group).toBe(1);
+		expect(result.index).toBe(1);
+	});
+	test('returns correct group and index for off end of all groups', () => {
+		const insertPosition = 10;
+		const result = getGroupAndIndex( itemGroups, insertPosition );
+		expect(result.group).toBe(2);
+		expect(result.index).toBe(5);
+	});
+	test('returns correct group and index for position 0', () => {
+		const insertPosition = 0;
+		const result = getGroupAndIndex([], insertPosition );
+		expect(result.group).toBe(0);
+		expect(result.index).toBe(0);
 	});
 });

--- a/components/x-teaser-timeline/__tests__/lib/transform.test.js
+++ b/components/x-teaser-timeline/__tests__/lib/transform.test.js
@@ -1,62 +1,58 @@
 import { buildModel } from '../../src/lib/transform';
 
-const props = {
-	'items': [
-		{
-			'id': '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4',
-			'title': 'Europeans step up pressure on Iran over nuclear deal',
-			'publishedDate': '2020-01-14T11:10:26.000Z'
-		},
-		{
-			'id': '01eaf2fc-36ac-11ea-a6d3-9a26f8c3cba4',
-			'title': 'Iran’s judiciary threatens to expel UK ambassador',
-			'publishedDate': '2020-01-14T10:23:14.000Z'
-		},
-		{
-			'id': 'dcac61ea-361c-11ea-a6d3-9a26f8c3cba4',
-			'title': 'Iran’s regime loses the battle for public opinion',
-			'publishedDate': '2020-01-14T10:00:27.000Z'
-		},
-		{
-			'id': 'bf0752ee-3685-11ea-a6d3-9a26f8c3cba4',
-			'title': 'Justin Trudeau partly blames US for Iran plane crash',
-			'publishedDate': '2020-01-14T08:15:05.000Z'
-		},
-		{
-			'id': '1d1527fa-356c-11ea-a6d3-9a26f8c3cba4',
-			'title': 'Biden and Sanders reprise Iraq war fight in 2020 race',
-			'publishedDate': '2020-01-13T11:00:26.000Z'
-		},
-		{
-			'id': '6524b530-355b-11ea-a6d3-9a26f8c3cba4',
-			'title': 'Esper ‘didn’t see’ specific evidence of embassy threat',
-			'publishedDate': '2020-01-12T18:36:39.000Z'
-		},
-		{
-			'id': '86df67f6-3524-11ea-a6d3-9a26f8c3cba4',
-			'title': 'Lies over air crash shake Iran’s trust in its rulers',
-			'publishedDate': '2020-01-12T16:29:11.000Z'
-		},
-		{
-			'id': '37084c8c-3508-11ea-a6d3-9a26f8c3cba4',
-			'title': 'Iran questions Revolutionary Guard over downing of airliner',
-			'publishedDate': '2020-01-12T09:51:13.000Z'
-		},
-		{
-			'id': 'b931cc22-3073-11ea-a329-0bcf87a328f2',
-			'title': 'What next for oil as US-Iran tensions simmer?',
-			'publishedDate': '2020-01-12T09:00:26.000Z'
-		},
-		{
-			'id': '0e76e39a-3428-11ea-9703-eea0cae3f0de',
-			'title': 'Iran admits it shot down Ukrainian jet',
-			'publishedDate': '2020-01-12T05:35:29.000Z'
-		}
-	],
-	'showSaveButtons': false,
-	'latestItemsTime': null,
-	'children': []
-};
+const items = [
+	{
+		'id': '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4',
+		'title': 'Europeans step up pressure on Iran over nuclear deal',
+		'publishedDate': '2020-01-14T11:10:26.000Z'
+	},
+	{
+		'id': '01eaf2fc-36ac-11ea-a6d3-9a26f8c3cba4',
+		'title': 'Iran’s judiciary threatens to expel UK ambassador',
+		'publishedDate': '2020-01-14T10:23:14.000Z'
+	},
+	{
+		'id': 'dcac61ea-361c-11ea-a6d3-9a26f8c3cba4',
+		'title': 'Iran’s regime loses the battle for public opinion',
+		'publishedDate': '2020-01-14T10:00:27.000Z'
+	},
+	{
+		'id': 'bf0752ee-3685-11ea-a6d3-9a26f8c3cba4',
+		'title': 'Justin Trudeau partly blames US for Iran plane crash',
+		'publishedDate': '2020-01-14T08:15:05.000Z'
+	},
+	{
+		'id': '1d1527fa-356c-11ea-a6d3-9a26f8c3cba4',
+		'title': 'Biden and Sanders reprise Iraq war fight in 2020 race',
+		'publishedDate': '2020-01-13T11:00:26.000Z'
+	},
+	{
+		'id': '6524b530-355b-11ea-a6d3-9a26f8c3cba4',
+		'title': 'Esper ‘didn’t see’ specific evidence of embassy threat',
+		'publishedDate': '2020-01-12T18:36:39.000Z'
+	},
+	{
+		'id': '86df67f6-3524-11ea-a6d3-9a26f8c3cba4',
+		'title': 'Lies over air crash shake Iran’s trust in its rulers',
+		'publishedDate': '2020-01-12T16:29:11.000Z'
+	},
+	{
+		'id': '37084c8c-3508-11ea-a6d3-9a26f8c3cba4',
+		'title': 'Iran questions Revolutionary Guard over downing of airliner',
+		'publishedDate': '2020-01-12T09:51:13.000Z'
+	},
+	{
+		'id': 'b931cc22-3073-11ea-a329-0bcf87a328f2',
+		'title': 'What next for oil as US-Iran tensions simmer?',
+		'publishedDate': '2020-01-12T09:00:26.000Z'
+	},
+	{
+		'id': '0e76e39a-3428-11ea-9703-eea0cae3f0de',
+		'title': 'Iran admits it shot down Ukrainian jet',
+		'publishedDate': '2020-01-12T05:35:29.000Z'
+	}
+];
+
 const groupedItems = [
 	{
 		'date': '2020-01-14',
@@ -149,80 +145,107 @@ const groupedItems = [
 	}
 ];
 
-describe.only('buildModel without custom slot content', () => {
-	test('correctly builds model from props', () => {
-		const result = buildModel({ ...props, timezoneOffset: 0, localTodayDate: '2020-01-14' });
-		expect(result).toEqual(groupedItems);
+describe('buildModel', () => {
+	describe('without custom slot content', () => {
+		test('correctly builds model', () => {
+			const result = buildModel({ items, timezoneOffset: 0, localTodayDate: '2020-01-14' });
+			expect(result).toEqual(groupedItems);
+		});
 	});
-});
 
-describe.only('buildModel with custom slot content', () => {
-	test('returns correct model for custom slot in middle of first group', () => {
-		const result = buildModel({
-			...props,
-			timezoneOffset: 0,
-			localTodayDate: '2020-01-14',
-			customSlotContent: { foo: 1 },
-			customSlotPosition: 2
+	describe('with latestItemsTime today', () => {
+		test('correctly builds model with today\'s group split', () => {
+			const result = buildModel({
+				items,
+				timezoneOffset: 0,
+				localTodayDate: '2020-01-14',
+				latestItemsTime: '2020-01-14T10:00:00+00:00'
+			});
+			expect(result).toEqual([
+				{
+					date: 'today-latest',
+					title: 'Latest News',
+					items: [groupedItems[0].items[0], groupedItems[0].items[1], groupedItems[0].items[2]]
+				},
+				{
+					...groupedItems[0],
+					date: 'today-earlier',
+					items: [groupedItems[0].items[3]]
+				},
+				groupedItems[1],
+				groupedItems[2]
+			]);
 		});
-		expect(result).toEqual([
-			{
-				...groupedItems[0],
-				items: [groupedItems[0].items[0], groupedItems[0].items[1], { foo: 1 }, groupedItems[0].items[2], groupedItems[0].items[3]]
-			},
-			groupedItems[1],
-			groupedItems[2]
-		]);
 	});
-	test('returns correct model for custom slot at end of second group', () => {
-		const result = buildModel({
-			...props,
-			timezoneOffset: 0,
-			localTodayDate: '2020-01-14',
-			customSlotContent: { foo: 1 },
-			customSlotPosition: 5
+
+	describe('with custom slot content', () => {
+		test('returns correct model for custom slot in middle of first group', () => {
+			const result = buildModel({
+				items,
+				timezoneOffset: 0,
+				localTodayDate: '2020-01-14',
+				customSlotContent: { foo: 1 },
+				customSlotPosition: 2
+			});
+			expect(result).toEqual([
+				{
+					...groupedItems[0],
+					items: [groupedItems[0].items[0], groupedItems[0].items[1], { foo: 1 }, groupedItems[0].items[2], groupedItems[0].items[3]]
+				},
+				groupedItems[1],
+				groupedItems[2]
+			]);
 		});
-		expect(result).toEqual([
-			groupedItems[0],
-			{
-				...groupedItems[1],
-				items: [groupedItems[1].items[0], { foo: 1 }]
-			},
-			groupedItems[2]
-		]);
-	});
-	test('returns correct model for custom slot off end of all groups', () => {
-		const result = buildModel({
-			...props,
-			timezoneOffset: 0,
-			localTodayDate: '2020-01-14',
-			customSlotContent: { foo: 1 },
-			customSlotPosition: 10
+		test('returns correct model for custom slot at end of second group', () => {
+			const result = buildModel({
+				items,
+				timezoneOffset: 0,
+				localTodayDate: '2020-01-14',
+				customSlotContent: { foo: 1 },
+				customSlotPosition: 5
+			});
+			expect(result).toEqual([
+				groupedItems[0],
+				{
+					...groupedItems[1],
+					items: [groupedItems[1].items[0], { foo: 1 }]
+				},
+				groupedItems[2]
+			]);
 		});
-		expect(result).toEqual([
-			groupedItems[0],
-			groupedItems[1],
-			{
-				...groupedItems[2],
-				items: [...groupedItems[2].items, { foo: 1 }]
-			}
-		]);
-	});
-	test('returns correct model for custom slot in position 0', () => {
-		const result = buildModel({
-			...props,
-			timezoneOffset: 0,
-			localTodayDate: '2020-01-14',
-			customSlotContent: { foo: 1 },
-			customSlotPosition: 0
+		test('returns correct model for custom slot off end of all groups', () => {
+			const result = buildModel({
+				items,
+				timezoneOffset: 0,
+				localTodayDate: '2020-01-14',
+				customSlotContent: { foo: 1 },
+				customSlotPosition: 10
+			});
+			expect(result).toEqual([
+				groupedItems[0],
+				groupedItems[1],
+				{
+					...groupedItems[2],
+					items: [...groupedItems[2].items, { foo: 1 }]
+				}
+			]);
 		});
-		expect(result).toEqual([
-			{
-				...groupedItems[0],
-				items: [{ foo: 1 }, groupedItems[0].items[0], groupedItems[0].items[1], groupedItems[0].items[2], groupedItems[0].items[3]]
-			},
-			groupedItems[1],
-			groupedItems[2]
-		]);
+		test('returns correct model for custom slot in position 0', () => {
+			const result = buildModel({
+				items,
+				timezoneOffset: 0,
+				localTodayDate: '2020-01-14',
+				customSlotContent: { foo: 1 },
+				customSlotPosition: 0
+			});
+			expect(result).toEqual([
+				{
+					...groupedItems[0],
+					items: [{ foo: 1 }, groupedItems[0].items[0], groupedItems[0].items[1], groupedItems[0].items[2], groupedItems[0].items[3]]
+				},
+				groupedItems[1],
+				groupedItems[2]
+			]);
+		});
 	});
 });

--- a/components/x-teaser-timeline/src/TeaserTimeline.jsx
+++ b/components/x-teaser-timeline/src/TeaserTimeline.jsx
@@ -6,11 +6,19 @@ import styles from './TeaserTimeline.scss';
 import classNames from 'classnames';
 
 const TeaserTimeline = props => {
+	const now = new Date();
 	const {
 		csrfToken = null,
-		showSaveButtons = true
+		showSaveButtons = true,
+		customSlotContent,
+		customSlotPosition = 2,
+		items,
+		timezoneOffset = now.getTimezoneOffset(),
+		localTodayDate = getDateOnly(now.toISOString()),
+		latestItemsTime
 	} = props;
-	const itemGroups = buildModel(props);
+
+	const itemGroups = buildModel({items, customSlotContent, customSlotPosition, timezoneOffset, localTodayDate, latestItemsTime});
 
 	return itemGroups.length > 0 && (
 		<div>

--- a/components/x-teaser-timeline/src/TeaserTimeline.jsx
+++ b/components/x-teaser-timeline/src/TeaserTimeline.jsx
@@ -2,6 +2,7 @@ import { h } from '@financial-times/x-engine';
 import { ArticleSaveButton } from '@financial-times/x-article-save-button';
 import { Teaser, presets } from '@financial-times/x-teaser';
 import { buildModel } from './lib/transform';
+import { getDateOnly } from './lib/date';
 import styles from './TeaserTimeline.scss';
 import classNames from 'classnames';
 

--- a/components/x-teaser-timeline/src/TeaserTimeline.jsx
+++ b/components/x-teaser-timeline/src/TeaserTimeline.jsx
@@ -1,29 +1,16 @@
 import { h } from '@financial-times/x-engine';
 import { ArticleSaveButton } from '@financial-times/x-article-save-button';
 import { Teaser, presets } from '@financial-times/x-teaser';
-import { getGroupAndIndex, getItemGroups } from './lib/transform';
+import { buildModel } from './lib/transform';
 import styles from './TeaserTimeline.scss';
 import classNames from 'classnames';
 
 const TeaserTimeline = props => {
 	const {
 		csrfToken = null,
-		customSlotContent,
-		customSlotPosition = 2,
-		items,
 		showSaveButtons = true
 	} = props;
-	const itemGroups = getItemGroups(props);
-
-	if (itemGroups.length > 0 && customSlotContent) {
-		const insertPosition = Math.min(customSlotPosition, items.length);
-		const insert = getGroupAndIndex(itemGroups, insertPosition);
-		const copyOfItems = [...itemGroups[insert.group].items];
-
-		copyOfItems.splice(insert.index, 0, customSlotContent);
-
-		itemGroups[insert.group].items = copyOfItems;
-	}
+	const itemGroups = buildModel(props);
 
 	return itemGroups.length > 0 && (
 		<div>

--- a/components/x-teaser-timeline/src/lib/date.js
+++ b/components/x-teaser-timeline/src/lib/date.js
@@ -47,3 +47,5 @@ export const splitLatestEarlier = (items, splitDate) => {
 
 	return { latestItems, earlierItems };
 };
+
+export const getDateOnly = date => date.substr(0, 10);

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -4,9 +4,9 @@ import {
 	splitLatestEarlier
 } from './date';
 
-export const getDateOnly = date => date.substr(0, 10);
+const getDateOnly = date => date.substr(0, 10);
 
-export const groupItemsByLocalisedDate = (items, timezoneOffset) => {
+const groupItemsByLocalisedDate = (items, timezoneOffset) => {
 	const itemsByLocalisedDate = {};
 
 	items.forEach((item, index) => {
@@ -27,7 +27,7 @@ export const groupItemsByLocalisedDate = (items, timezoneOffset) => {
 	}));
 };
 
-export const splitTodaysItems = (itemGroups, localTodayDate, latestItemsTime) => {
+const splitTodaysItems = (itemGroups, localTodayDate, latestItemsTime) => {
 	const firstGroupIsToday = itemGroups[0] && itemGroups[0].date === localTodayDate;
 	const latestTimeIsToday = getDateOnly(latestItemsTime) === localTodayDate;
 
@@ -59,7 +59,7 @@ export const splitTodaysItems = (itemGroups, localTodayDate, latestItemsTime) =>
 	return itemGroups;
 };
 
-export const addItemGroupTitles = (itemGroups, localTodayDate) => {
+const addItemGroupTitles = (itemGroups, localTodayDate) => {
 	return itemGroups.map(group => {
 		group.title = getTitleForItemGroup(group.date, localTodayDate);
 

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -67,15 +67,7 @@ const addItemGroupTitles = (itemGroups, localTodayDate) => {
 	});
 };
 
-const getItemGroups = props => {
-	const now = new Date();
-	const {
-		items,
-		timezoneOffset = now.getTimezoneOffset(),
-		localTodayDate = getDateOnly(now.toISOString()),
-		latestItemsTime
-	} = props;
-
+const getItemGroups = ({items, timezoneOffset, localTodayDate, latestItemsTime}) => {
 	if (!items || !Array.isArray(items) || items.length === 0) {
 		return [];
 	}
@@ -106,12 +98,8 @@ const getGroupAndIndex = (groups, position) => {
 	};
 };
 
-export const buildModel = props => {
-	const itemGroups = getItemGroups(props);
-	const {		customSlotContent,
-		customSlotPosition = 2,
-		items
-	} = props;
+export const buildModel = ({items, customSlotContent, customSlotPosition, timezoneOffset, localTodayDate, latestItemsTime}) => {
+	const itemGroups = getItemGroups({items, timezoneOffset, localTodayDate, latestItemsTime});
 
 	if (itemGroups.length > 0 && customSlotContent) {
 		const insertPosition = Math.min(customSlotPosition, items.length);

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -1,10 +1,10 @@
 import {
 	getLocalisedISODate,
 	getTitleForItemGroup,
-	splitLatestEarlier
+	splitLatestEarlier,
+	getDateOnly
 } from './date';
 
-const getDateOnly = date => date.substr(0, 10);
 
 const groupItemsByLocalisedDate = (items, timezoneOffset) => {
 	const itemsByLocalisedDate = {};

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -67,7 +67,7 @@ const addItemGroupTitles = (itemGroups, localTodayDate) => {
 	});
 };
 
-export const getItemGroups = props => {
+const getItemGroups = props => {
 	const now = new Date();
 	const {
 		items,
@@ -89,7 +89,7 @@ export const getItemGroups = props => {
 	return addItemGroupTitles(itemGroups, localTodayDate);
 };
 
-export const getGroupAndIndex = (groups, position) => {
+const getGroupAndIndex = (groups, position) => {
 	if (position > 0) {
 		const group = groups.findIndex(g => g.items.some(item => item.articleIndex === position - 1));
 		const index = groups[group].items.findIndex(item => item.articleIndex === position - 1);
@@ -104,4 +104,23 @@ export const getGroupAndIndex = (groups, position) => {
 		group: 0,
 		index: 0
 	};
+};
+
+export const buildModel = props => {
+	const itemGroups = getItemGroups(props);
+	const {		customSlotContent,
+		customSlotPosition = 2,
+		items
+	} = props;
+
+	if (itemGroups.length > 0 && customSlotContent) {
+		const insertPosition = Math.min(customSlotPosition, items.length);
+		const insert = getGroupAndIndex(itemGroups, insertPosition);
+		const copyOfItems = [...itemGroups[insert.group].items];
+
+		copyOfItems.splice(insert.index, 0, customSlotContent);
+
+		itemGroups[insert.group].items = copyOfItems;
+	}
+	return itemGroups;
 };


### PR DESCRIPTION
This PR does not change behaviour or appearance, simply a small refactor in preparation for fixing this bug: https://trello.com/c/tTPiw9x1/3976-topic-bubbles-fix-latest-news-problem-on-stream-pages

It collects together the presentation logic in teaser-timeline into a single entry point `buildModel`, and puts tests around that function, with the aim that `buildModel` can then be refactored safely without changing its behaviour.