### PR TITLE
Specify components owned by content disco

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,8 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
 * matt.hinchliffe@ft.com bren.brightwell@ft.com
+
+# component ownership
+
+components/x-teaser @Financial-Times/content-discovery
+components/x-teaser-timeline @Financial-Times/content-discovery


### PR DESCRIPTION
In the durable teams world, the following components are known to be owned by content discovery:

- x-teaser
- x-teaser-timeline

Setting codeowners will direct PR reviews to content disco, which is a good start for ownership.

Other components, such as x-follow-button, are TBC.