### PR TITLE
Fix article load issue when image is unavailable

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -777,27 +777,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc8a8d52e-d20a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -875,27 +875,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F8ba50178-d216-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -986,27 +986,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa3695666-d201-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1091,27 +1091,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9be47d9e-d17a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1194,27 +1194,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F23529cb0-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1292,27 +1292,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff08f8340-d1a0-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1403,27 +1403,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fece474ca-d151-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1506,27 +1506,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5319de7e-d12f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1604,27 +1604,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F62fd9e46-d14f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1702,27 +1702,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fcb11f55e-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1788,27 +1788,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F383a4ea2-d14a-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1874,27 +1874,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31d2be9e-d13d-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1972,27 +1972,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd7517de4-d131-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2143,27 +2143,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa6afae18-d069-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2241,27 +2241,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9a6adda6-d07a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2352,27 +2352,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fac0fd098-d075-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2499,27 +2499,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd0cbda02-cbb7-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2602,27 +2602,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Faea311c6-c32d-11e8-95b1-d36dfef1b89a?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2700,27 +2700,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff87f782a-d089-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2798,27 +2798,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31c1c612-d079-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2896,27 +2896,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff1191270-ce41-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2982,27 +2982,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc77408fa-d065-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3080,27 +3080,27 @@ exports[`@financial-times/x-teaser-timeline renders a default Timeline x-teaser-
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F66d87a12-d06f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div

--- a/components/x-teaser-timeline/__tests__/__snapshots__/TeaserTimeline.test.jsx.snap
+++ b/components/x-teaser-timeline/__tests__/__snapshots__/TeaserTimeline.test.jsx.snap
@@ -62,27 +62,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc8a8d52e-d20a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -160,27 +160,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F8ba50178-d216-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -258,27 +258,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa3695666-d201-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -356,27 +356,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9be47d9e-d17a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -459,27 +459,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F23529cb0-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -557,27 +557,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff08f8340-d1a0-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -668,27 +668,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fece474ca-d151-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -771,27 +771,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5319de7e-d12f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -869,27 +869,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F62fd9e46-d14f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -967,27 +967,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fcb11f55e-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1053,27 +1053,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F383a4ea2-d14a-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1139,27 +1139,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31d2be9e-d13d-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1237,27 +1237,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd7517de4-d131-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1408,27 +1408,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa6afae18-d069-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1506,27 +1506,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9a6adda6-d07a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1617,27 +1617,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fac0fd098-d075-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1764,27 +1764,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd0cbda02-cbb7-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1867,27 +1867,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Faea311c6-c32d-11e8-95b1-d36dfef1b89a?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -1965,27 +1965,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff87f782a-d089-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2063,27 +2063,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31c1c612-d079-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2161,27 +2161,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff1191270-ce41-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2247,27 +2247,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc77408fa-d065-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2345,27 +2345,27 @@ exports[`x-teaser-timeline given latestItemsTime is not set renders earlier, yes
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F66d87a12-d06f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2588,27 +2588,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc8a8d52e-d20a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2686,27 +2686,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F8ba50178-d216-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2784,27 +2784,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa3695666-d201-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2882,27 +2882,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9be47d9e-d17a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -2985,27 +2985,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F23529cb0-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3083,27 +3083,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff08f8340-d1a0-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3181,27 +3181,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fece474ca-d151-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3284,27 +3284,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5319de7e-d12f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3382,27 +3382,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F62fd9e46-d14f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3480,27 +3480,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fcb11f55e-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3566,27 +3566,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F383a4ea2-d14a-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3652,27 +3652,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31d2be9e-d13d-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3750,27 +3750,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd7517de4-d131-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -3934,27 +3934,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa6afae18-d069-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -4045,27 +4045,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9a6adda6-d07a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -4143,27 +4143,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fac0fd098-d075-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -4290,27 +4290,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd0cbda02-cbb7-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -4393,27 +4393,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Faea311c6-c32d-11e8-95b1-d36dfef1b89a?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -4491,27 +4491,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff87f782a-d089-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -4589,27 +4589,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31c1c612-d079-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -4687,27 +4687,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff1191270-ce41-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -4773,27 +4773,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc77408fa-d065-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -4871,27 +4871,27 @@ exports[`x-teaser-timeline given latestItemsTime is set and results in all today
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F66d87a12-d06f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -5114,27 +5114,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc8a8d52e-d20a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -5212,27 +5212,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F8ba50178-d216-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -5310,27 +5310,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa3695666-d201-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -5408,27 +5408,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9be47d9e-d17a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -5511,27 +5511,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F23529cb0-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -5609,27 +5609,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff08f8340-d1a0-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -5720,27 +5720,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fece474ca-d151-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -5823,27 +5823,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5319de7e-d12f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -5921,27 +5921,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F62fd9e46-d14f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -6019,27 +6019,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fcb11f55e-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -6105,27 +6105,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F383a4ea2-d14a-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -6191,27 +6191,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31d2be9e-d13d-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -6289,27 +6289,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd7517de4-d131-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -6460,27 +6460,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa6afae18-d069-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -6558,27 +6558,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9a6adda6-d07a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -6669,27 +6669,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fac0fd098-d075-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -6816,27 +6816,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd0cbda02-cbb7-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -6919,27 +6919,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Faea311c6-c32d-11e8-95b1-d36dfef1b89a?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -7017,27 +7017,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff87f782a-d089-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -7115,27 +7115,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31c1c612-d079-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -7213,27 +7213,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff1191270-ce41-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -7299,27 +7299,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc77408fa-d065-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -7397,27 +7397,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is more than latestI
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F66d87a12-d06f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -7640,27 +7640,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc8a8d52e-d20a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -7738,27 +7738,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F8ba50178-d216-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -7836,27 +7836,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa3695666-d201-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -7934,27 +7934,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9be47d9e-d17a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8037,27 +8037,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F23529cb0-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8135,27 +8135,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff08f8340-d1a0-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8246,27 +8246,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fece474ca-d151-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8349,27 +8349,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5319de7e-d12f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8447,27 +8447,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F62fd9e46-d14f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8545,27 +8545,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fcb11f55e-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8631,27 +8631,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F383a4ea2-d14a-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8717,27 +8717,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31d2be9e-d13d-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8815,27 +8815,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd7517de4-d131-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -8986,27 +8986,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa6afae18-d069-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -9084,27 +9084,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9a6adda6-d07a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -9195,27 +9195,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fac0fd098-d075-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -9342,27 +9342,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd0cbda02-cbb7-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -9445,27 +9445,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Faea311c6-c32d-11e8-95b1-d36dfef1b89a?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -9543,27 +9543,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff87f782a-d089-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -9641,27 +9641,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31c1c612-d079-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -9739,27 +9739,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff1191270-ce41-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -9825,27 +9825,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc77408fa-d065-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -9923,27 +9923,27 @@ exports[`x-teaser-timeline given latestItemsTime is set but is not same date as 
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F66d87a12-d06f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -10166,27 +10166,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc8a8d52e-d20a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -10264,27 +10264,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F8ba50178-d216-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -10375,27 +10375,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa3695666-d201-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -10473,27 +10473,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9be47d9e-d17a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -10576,27 +10576,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F23529cb0-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -10674,27 +10674,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff08f8340-d1a0-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -10785,27 +10785,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fece474ca-d151-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -10888,27 +10888,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5319de7e-d12f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -10986,27 +10986,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F62fd9e46-d14f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -11084,27 +11084,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fcb11f55e-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -11170,27 +11170,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F383a4ea2-d14a-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -11256,27 +11256,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31d2be9e-d13d-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -11354,27 +11354,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd7517de4-d131-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -11525,27 +11525,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa6afae18-d069-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -11623,27 +11623,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9a6adda6-d07a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -11734,27 +11734,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fac0fd098-d075-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -11881,27 +11881,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd0cbda02-cbb7-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -11984,27 +11984,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Faea311c6-c32d-11e8-95b1-d36dfef1b89a?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -12082,27 +12082,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff87f782a-d089-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -12180,27 +12180,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31c1c612-d079-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -12278,27 +12278,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff1191270-ce41-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -12364,27 +12364,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc77408fa-d065-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -12462,27 +12462,27 @@ exports[`x-teaser-timeline given latestItemsTime is set renders latest, earlier,
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F66d87a12-d06f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -12705,27 +12705,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc8a8d52e-d20a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -12803,27 +12803,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F8ba50178-d216-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -12901,27 +12901,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa3695666-d201-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -12999,27 +12999,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9be47d9e-d17a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -13102,27 +13102,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F23529cb0-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -13200,27 +13200,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff08f8340-d1a0-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -13311,27 +13311,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fece474ca-d151-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -13414,27 +13414,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5319de7e-d12f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -13512,27 +13512,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F62fd9e46-d14f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -13610,27 +13610,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fcb11f55e-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -13696,27 +13696,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F383a4ea2-d14a-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -13782,27 +13782,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31d2be9e-d13d-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -13880,27 +13880,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd7517de4-d131-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14051,27 +14051,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa6afae18-d069-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14149,27 +14149,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9a6adda6-d07a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14260,27 +14260,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fac0fd098-d075-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14407,27 +14407,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd0cbda02-cbb7-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14510,27 +14510,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Faea311c6-c32d-11e8-95b1-d36dfef1b89a?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14608,27 +14608,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff87f782a-d089-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14706,27 +14706,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31c1c612-d079-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14804,27 +14804,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff1191270-ce41-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14890,27 +14890,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc77408fa-d065-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -14988,27 +14988,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is not set or i
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F66d87a12-d06f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
@@ -15231,27 +15231,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/65867e26-d203-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc8a8d52e-d20a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15304,27 +15304,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/93614586-d1f1-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F8ba50178-d216-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15377,27 +15377,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa3695666-d201-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15450,27 +15450,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9be47d9e-d17a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15528,27 +15528,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F23529cb0-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15601,27 +15601,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/868cedae-d18a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff08f8340-d1a0-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15687,27 +15687,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fece474ca-d151-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15765,27 +15765,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a1566658-d12e-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5319de7e-d12f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15838,27 +15838,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F62fd9e46-d14f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15911,27 +15911,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fcb11f55e-d140-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -15972,27 +15972,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d7472b20-d148-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F383a4ea2-d14a-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16033,27 +16033,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31d2be9e-d13d-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16106,27 +16106,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd7517de4-d131-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16227,27 +16227,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa6afae18-d069-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16300,27 +16300,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F9a6adda6-d07a-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16386,27 +16386,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fac0fd098-d075-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16483,27 +16483,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/fadfb212-d091-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fd0cbda02-cbb7-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16561,27 +16561,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/79939f94-c320-11e8-8d55-54197280d3f7"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Faea311c6-c32d-11e8-95b1-d36dfef1b89a?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16634,27 +16634,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/bfffa642-d079-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff87f782a-d089-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16707,27 +16707,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/82ae2756-d073-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F31c1c612-d079-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16780,27 +16780,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/a8181102-ce1e-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Ff1191270-ce41-11e8-8d0b-a6539b949662?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16841,27 +16841,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fc77408fa-d065-11e8-a9f2-7574db66bcd5?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>
@@ -16914,27 +16914,27 @@ exports[`x-teaser-timeline showSaveButtons given showSaveButtons is set to false
           <div
             className="o-teaser__image-container js-teaser-image-container"
           >
-            <div
-              className="o-teaser__image-placeholder"
-              style={
-                Object {
-                  "paddingBottom": "56.2500%",
-                }
-              }
+            <a
+              aria-hidden="true"
+              data-trackable="image-link"
+              href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
+              tabIndex="-1"
             >
-              <a
-                aria-hidden="true"
-                data-trackable="image-link"
-                href="/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab"
-                tabIndex="-1"
+              <div
+                className="o-teaser__image-placeholder"
+                style={
+                  Object {
+                    "paddingBottom": "56.2500%",
+                  }
+                }
               >
                 <img
                   alt=""
                   className="o-teaser__image"
                   src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F66d87a12-d06f-11e8-9a3c-5d5eac8f1ab4?source=next&fit=scale-down&dpr=2&width=240"
                 />
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </li>

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -35,27 +35,27 @@ exports[`x-teaser / snapshots renders a Hero teaser with article data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -95,27 +95,27 @@ exports[`x-teaser / snapshots renders a Hero teaser with article-with-data-image
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -155,27 +155,27 @@ exports[`x-teaser / snapshots renders a Hero teaser with contentPackage data 1`]
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F7e97f5b6-578d-11e8-b8b2-d6ceb45fa9d0?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -215,27 +215,27 @@ exports[`x-teaser / snapshots renders a Hero teaser with opinion data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F1005ca96-364b-11e8-8b98-2f31af407cc8?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -280,27 +280,27 @@ exports[`x-teaser / snapshots renders a Hero teaser with packageItem data 1`] = 
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -346,27 +346,27 @@ exports[`x-teaser / snapshots renders a Hero teaser with podcast data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__origami%2Fservice%2Fimage%2Fv2%2Fimages%2Fraw%2Fhttp%253A%252F%252Fprod-upp-image-read.ft.com%252F5d1a54aa-f49b-11e8-ae55-df4bf40f9d0d%3Fsource%3Dnext%26fit%3Dscale-down%26compression%3Dbest%26width%3D240?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -408,27 +408,27 @@ exports[`x-teaser / snapshots renders a Hero teaser with promoted data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2857%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2857%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Ftpc.googlesyndication.com%2Fpagead%2Fimgad%3Fid%3DCICAgKCrm_3yahABGAEyCMx3RoLss603?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -468,27 +468,27 @@ exports[`x-teaser / snapshots renders a Hero teaser with topStory data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -534,27 +534,27 @@ exports[`x-teaser / snapshots renders a Hero teaser with video data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fcom.ft.imagepublish.upp-prod-eu.s3.amazonaws.com%2Fa27ce49b-85b8-445b-b883-db6e2f533194?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1036,27 +1036,27 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with article data 1`]
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1096,27 +1096,27 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with article-with-dat
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1156,27 +1156,27 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with contentPackage d
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F7e97f5b6-578d-11e8-b8b2-d6ceb45fa9d0?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1216,27 +1216,27 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with opinion data 1`]
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F1005ca96-364b-11e8-8b98-2f31af407cc8?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1281,27 +1281,27 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with packageItem data
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1347,27 +1347,27 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with podcast data 1`]
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__origami%2Fservice%2Fimage%2Fv2%2Fimages%2Fraw%2Fhttp%253A%252F%252Fprod-upp-image-read.ft.com%252F5d1a54aa-f49b-11e8-ae55-df4bf40f9d0d%3Fsource%3Dnext%26fit%3Dscale-down%26compression%3Dbest%26width%3D240?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1409,27 +1409,27 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with promoted data 1`
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2857%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2857%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Ftpc.googlesyndication.com%2Fpagead%2Fimgad%3Fid%3DCICAgKCrm_3yahABGAEyCMx3RoLss603?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1469,27 +1469,27 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with topStory data 1`
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1535,27 +1535,27 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with video data 1`] =
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fcom.ft.imagepublish.upp-prod-eu.s3.amazonaws.com%2Fa27ce49b-85b8-445b-b883-db6e2f533194?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -1910,27 +1910,27 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with video data 1`] = `
         <div
           className="o-teaser__image-container js-teaser-image-container"
         >
-          <div
-            className="o-teaser__image-placeholder"
-            style={
-              Object {
-                "paddingBottom": "56.2500%",
-              }
-            }
+          <a
+            aria-hidden="true"
+            data-trackable="image-link"
+            href="#"
+            tabIndex="-1"
           >
-            <a
-              aria-hidden="true"
-              data-trackable="image-link"
-              href="#"
-              tabIndex="-1"
+            <div
+              className="o-teaser__image-placeholder"
+              style={
+                Object {
+                  "paddingBottom": "56.2500%",
+                }
+              }
             >
               <img
                 alt=""
                 className="o-teaser__image"
                 src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fcom.ft.imagepublish.upp-prod-eu.s3.amazonaws.com%2Fa27ce49b-85b8-445b-b883-db6e2f533194?source=next&fit=scale-down&dpr=2&width=420"
               />
-            </a>
-          </div>
+            </div>
+          </a>
         </div>
       </div>
     </div>
@@ -1997,27 +1997,27 @@ exports[`x-teaser / snapshots renders a Large teaser with article data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -2069,27 +2069,27 @@ exports[`x-teaser / snapshots renders a Large teaser with article-with-data-imag
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -2141,27 +2141,27 @@ exports[`x-teaser / snapshots renders a Large teaser with contentPackage data 1`
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F7e97f5b6-578d-11e8-b8b2-d6ceb45fa9d0?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -2213,27 +2213,27 @@ exports[`x-teaser / snapshots renders a Large teaser with opinion data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F1005ca96-364b-11e8-8b98-2f31af407cc8?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -2290,27 +2290,27 @@ exports[`x-teaser / snapshots renders a Large teaser with packageItem data 1`] =
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -2368,27 +2368,27 @@ exports[`x-teaser / snapshots renders a Large teaser with podcast data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__origami%2Fservice%2Fimage%2Fv2%2Fimages%2Fraw%2Fhttp%253A%252F%252Fprod-upp-image-read.ft.com%252F5d1a54aa-f49b-11e8-ae55-df4bf40f9d0d%3Fsource%3Dnext%26fit%3Dscale-down%26compression%3Dbest%26width%3D240?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -2442,27 +2442,27 @@ exports[`x-teaser / snapshots renders a Large teaser with promoted data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2857%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2857%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Ftpc.googlesyndication.com%2Fpagead%2Fimgad%3Fid%3DCICAgKCrm_3yahABGAEyCMx3RoLss603?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -2514,27 +2514,27 @@ exports[`x-teaser / snapshots renders a Large teaser with topStory data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -2592,27 +2592,27 @@ exports[`x-teaser / snapshots renders a Large teaser with video data 1`] = `
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fcom.ft.imagepublish.upp-prod-eu.s3.amazonaws.com%2Fa27ce49b-85b8-445b-b883-db6e2f533194?source=next&fit=scale-down&dpr=2&width=340"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -2998,27 +2998,27 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with article data 1`] 
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=240"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -3070,27 +3070,27 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with article-with-data
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -3142,27 +3142,27 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with contentPackage da
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F7e97f5b6-578d-11e8-b8b2-d6ceb45fa9d0?source=next&fit=scale-down&dpr=2&width=240"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -3214,27 +3214,27 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with opinion data 1`] 
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F1005ca96-364b-11e8-8b98-2f31af407cc8?source=next&fit=scale-down&dpr=2&width=240"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -3291,27 +3291,27 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with packageItem data 
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=240"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -3369,27 +3369,27 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with podcast data 1`] 
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__origami%2Fservice%2Fimage%2Fv2%2Fimages%2Fraw%2Fhttp%253A%252F%252Fprod-upp-image-read.ft.com%252F5d1a54aa-f49b-11e8-ae55-df4bf40f9d0d%3Fsource%3Dnext%26fit%3Dscale-down%26compression%3Dbest%26width%3D240?source=next&fit=scale-down&dpr=2&width=240"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -3443,27 +3443,27 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with promoted data 1`]
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2857%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2857%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Ftpc.googlesyndication.com%2Fpagead%2Fimgad%3Fid%3DCICAgKCrm_3yahABGAEyCMx3RoLss603?source=next&fit=scale-down&dpr=2&width=240"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -3515,27 +3515,27 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with topStory data 1`]
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=240"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -3593,27 +3593,27 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with video data 1`] = 
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fcom.ft.imagepublish.upp-prod-eu.s3.amazonaws.com%2Fa27ce49b-85b8-445b-b883-db6e2f533194?source=next&fit=scale-down&dpr=2&width=240"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -4144,27 +4144,27 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article da
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -4216,27 +4216,27 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article-wi
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -4288,27 +4288,27 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with contentPac
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F7e97f5b6-578d-11e8-b8b2-d6ceb45fa9d0?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -4360,27 +4360,27 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with opinion da
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F1005ca96-364b-11e8-8b98-2f31af407cc8?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -4437,27 +4437,27 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with packageIte
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -4515,27 +4515,27 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with podcast da
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="https://www.ft.com/content/d1246074-f7d3-4aaf-951c-80a6db495765"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__origami%2Fservice%2Fimage%2Fv2%2Fimages%2Fraw%2Fhttp%253A%252F%252Fprod-upp-image-read.ft.com%252F5d1a54aa-f49b-11e8-ae55-df4bf40f9d0d%3Fsource%3Dnext%26fit%3Dscale-down%26compression%3Dbest%26width%3D240?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -4589,27 +4589,27 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with promoted d
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2857%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2857%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Ftpc.googlesyndication.com%2Fpagead%2Fimgad%3Fid%3DCICAgKCrm_3yahABGAEyCMx3RoLss603?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;
@@ -4661,27 +4661,27 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with topStory d
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2Fa25832ea-0053-11e8-9650-9c0ad2d7c5b5?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
   <ul
     className="o-teaser__related"
@@ -4776,27 +4776,27 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with video data
   <div
     className="o-teaser__image-container js-teaser-image-container"
   >
-    <div
-      className="o-teaser__image-placeholder"
-      style={
-        Object {
-          "paddingBottom": "56.2500%",
-        }
-      }
+    <a
+      aria-hidden="true"
+      data-trackable="image-link"
+      href="#"
+      tabIndex="-1"
     >
-      <a
-        aria-hidden="true"
-        data-trackable="image-link"
-        href="#"
-        tabIndex="-1"
+      <div
+        className="o-teaser__image-placeholder"
+        style={
+          Object {
+            "paddingBottom": "56.2500%",
+          }
+        }
       >
         <img
           alt=""
           className="o-teaser__image"
           src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fcom.ft.imagepublish.upp-prod-eu.s3.amazonaws.com%2Fa27ce49b-85b8-445b-b883-db6e2f533194?source=next&fit=scale-down&dpr=2&width=640"
         />
-      </a>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -34,15 +34,15 @@ export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, ...props })
 
 	return image ? (
 		<div className="o-teaser__image-container js-teaser-image-container">
-			<div className="o-teaser__image-placeholder" style={{ paddingBottom: aspectRatio(image) }}>
-				<Link {...props} url={displayUrl} attrs={{
+			<Link {...props} url={displayUrl} attrs={{
 					'data-trackable': 'image-link',
 					'tabIndex': '-1',
 					'aria-hidden': 'true',
 				}}>
+				<div className="o-teaser__image-placeholder" style={{ paddingBottom: aspectRatio(image) }}>
 					<ImageComponent src={imageSrc} lazyLoad={imageLazyLoad} />
-				</Link>
-			</div>
+				</div>
+			</Link>
 		</div>
 	) : null;
 };


### PR DESCRIPTION
The change will fix an issue with opening an article when an image isn't available.

The article would not load if a user clicks on an image that isn't available. 
![Screenshot 2020-02-25 at 12 41 41](https://user-images.githubusercontent.com/14136353/75248642-72408f80-57cc-11ea-8eae-d1bc9d24ea28.png)

- the fix is very small - we only change the order of a Link and Image components in order to include the ImageComponent inside Link - which fixes the issue. 
