### PR TITLE
Update CircleCi Node.js version to 10.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ references:
   container_config_node8: &container_config_node8
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8.16
+      - image: circleci/node:10.13
 
   workspace_root: &workspace_root
     ~/project


### PR DESCRIPTION
Gatsby has made a breaking change in a minor version so we need to update to avoid the build breaking.

https://github.com/gatsbyjs/gatsby/pull/22400#issuecomment-627911322

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/master/contribution.md) before submitting.

I have ran this Node.js version locally and ran the various npm scripts and they succeed, so I think we may be OK to upgrade without any changes.

Closes https://github.com/Financial-Times/x-dash/pull/442