### PR TITLE
Remove references to n-image in x-dash docs

### DIFF
--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -173,8 +173,6 @@ Property        | Type                  | Notes
 `imageSize`     | String                | XS, Small, Medium, Large, XL or XXL
 `imageLazyLoad` | Boolean, String       | Output image with `data-src` attribute. If this is a string it will be appended to the image as a class name.
 
-[nimg]: https://github.com/Financial-Times/n-image/
-
 #### Headshot Props
 
 Property       | Type   | Notes

--- a/docs/guides/migrating-to-x-teaser.md
+++ b/docs/guides/migrating-to-x-teaser.md
@@ -139,15 +139,10 @@ Teasers may be configured by providing attributes. Common use cases are provided
 
 ### 6. Image lazy loading (optional)
 
-If you have implemented image lazy loading on your pages using [n-image] or [o-lazy-load] you can continue to use this functionality with x-teaser. Setting the `imageLazyload` property to `true` will instruct the component to render the image with a `data-src` property instead of a `src` property. If you need to set a specific class name to identify these images you can set the `imageLazyLoad` property to a string, which will be appended to list of image class names.
+If you have implemented image lazy loading on your pages using [o-lazy-load] you can continue to use this functionality with x-teaser. Setting the `imageLazyload` property to `true` will instruct the component to render the image with a `data-src` property instead of a `src` property. If you need to set a specific class name to identify these images you can set the `imageLazyLoad` property to a string, which will be appended to list of image class names.
 
 ```handlebars
 <!-- if using o-lazy-load -->
 {{{x package="x-teaser" component="Teaser" preset="SmallHeavy" imageLazyLoad="o-lazy-load"}}}
 
-<!-- if using n-image -->
-{{{x package="x-teaser" component="Teaser" preset="SmallHeavy" imageLazyLoad="n-image--lazy-loading"}}}
-```
-
-[n-image]: https://github.com/Financial-Times/n-image
 [o-lazy-load]: https://github.com/Financial-Times/o-lazy-load/


### PR DESCRIPTION
Removes references to `n-image` from the `x-dash` documentation as we are in the process of deprecating this module.