### PR TITLE
X privacy manager enhanced types

### DIFF
--- a/components/x-privacy-manager/src/__tests__/privacy-manager.test.jsx
+++ b/components/x-privacy-manager/src/__tests__/privacy-manager.test.jsx
@@ -120,8 +120,8 @@ describe('x-privacy-manager', () => {
 			await form.prop('onSubmit')(undefined);
 
 			// Check both callbacks were run with `payload`
-			expect(callback1).toHaveBeenCalledWith(payload)
-			expect(callback2).toHaveBeenCalledWith(payload)
+			expect(callback1).toHaveBeenCalledWith({ payload, consent: true });
+			expect(callback2).toHaveBeenCalledWith({ payload, consent: true });
 
 			// Reconcile snapshot with state
 			subject.update();

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -25,7 +25,9 @@ export const withCustomActions = withActions(() => ({
 	 *
 	 * @param {string} consentApiEnhancedUrl
 	 * @param {OnSaveCallback[]} onConsentSavedCallbacks
-	 * @param {string} consentSource (e.g. 'next-control-centre'
+	 * @param {string} consentSource (e.g. 'next-control-centre')
+	 *
+	 * @returns {(props: BasePrivacyManagerProps) => Promise<{_response: _Response}>}
 	 */
 	sendConsent(consentApiEnhancedUrl, onConsentSavedCallbacks, consentSource) {
 		return async ({ isLoading, consent }) => {
@@ -36,7 +38,7 @@ export const withCustomActions = withActions(() => ({
 					status: consent,
 					lbi: true,
 					source: consentSource,
-					fow: `${FOW_NAME}/${FOW_VERSION}`,
+					fow: `${FOW_NAME}/${FOW_VERSION}`
 				}
 			};
 
@@ -46,7 +48,7 @@ export const withCustomActions = withActions(() => ({
 				data: {
 					behaviouralAds: categoryPayload,
 					demographicAds: categoryPayload,
-					programmaticAds: categoryPayload,
+					programmaticAds: categoryPayload
 				}
 			};
 
@@ -54,7 +56,7 @@ export const withCustomActions = withActions(() => ({
 				const res = await fetch(consentApiEnhancedUrl, {
 					method: 'POST',
 					headers: {
-						'Content-Type': 'application/json',
+						'Content-Type': 'application/json'
 					},
 					body: JSON.stringify(payload),
 					credentials: 'include'
@@ -62,7 +64,7 @@ export const withCustomActions = withActions(() => ({
 
 				// Call any externally defined handlers with the value of `payload`
 				for (const fn of onConsentSavedCallbacks) {
-					fn(payload);
+					fn({ consent, payload });
 				}
 
 				return { _response: { ok: res.ok } };
@@ -85,17 +87,7 @@ function renderMessage(isLoading, response, referrer) {
 }
 
 /**
- * @param {{
- *   consent?: boolean
- *   referrer?: string
- *   legislation?: string[]
- *   onConsentSavedCallbacks?: OnSaveCallback[]
- *   consentProxyEndpoints: object
- *   consentSource: string
- *   actions: Actions,
- *   isLoading: boolean
- *   _response?: _Response
- * }} Props
+ * @param {BasePrivacyManagerProps} Props
  */
 export function BasePrivacyManager({
 	consent = true,
@@ -131,7 +123,11 @@ export function BasePrivacyManager({
 					action={consentProxyEndpoints.createOrUpdateRecord}
 					onSubmit={(event) => {
 						event && event.preventDefault();
-						return actions.sendConsent(consentProxyEndpoints.createOrUpdateRecord, onConsentSavedCallbacks, consentSource);
+						return actions.sendConsent(
+							consentProxyEndpoints.createOrUpdateRecord,
+							onConsentSavedCallbacks,
+							consentSource
+						);
 					}}>
 					<h2 className={s.form__title}>Use of my personal information for advertising purposes</h2>
 					<div className={s.form__controls}>

--- a/components/x-privacy-manager/src/types.d.ts
+++ b/components/x-privacy-manager/src/types.d.ts
@@ -18,7 +18,7 @@ type CCPAConsentPayload = {
   data: CCPAConsentData;
 };
 
-type OnSaveCallback = ({ consent: boolean, payload: CCPAConsentPayload }) => void;
+type OnSaveCallback = (args: { consent: boolean, payload: CCPAConsentPayload }) => void;
 
 type Actions = {
   onConsentChange: () => void;

--- a/components/x-privacy-manager/src/types.d.ts
+++ b/components/x-privacy-manager/src/types.d.ts
@@ -1,20 +1,54 @@
-type CCPAConsentPayload = {
-  demographic: boolean;
-  behavioural: boolean;
-  programmatic: boolean;
+type CategoryPayload = {
+  onsite: {
+    status: boolean;
+    lbi: boolean;
+    source: string;
+    fow: string;
+  };
 };
 
-type OnSaveCallback = (payload: CCPAConsentPayload) => void;
+type CCPAConsentData = Record<
+  'behaviouralAds' | 'demographicAds' | 'programmaticAds',
+  CategoryPayload
+>;
+
+type CCPAConsentPayload = {
+  formOfWordsId: string;
+  consentSource: string;
+  data: CCPAConsentData;
+};
+
+type OnSaveCallback = ({ consent: boolean, payload: CCPAConsentPayload }) => void;
 
 type Actions = {
   onConsentChange: () => void;
   sendConsent: (
     consentApiUrl: string,
-    onConsentSavedCallbacks: OnSaveCallback[]
+    onConsentSavedCallbacks: OnSaveCallback[],
+    consentSource: string
   ) => Promise<{ _response: _Response }>;
 };
 
 type _Response = {
   ok: boolean;
   status?: number;
+};
+
+type ConsentProxyEndpoint = Record<'core' | 'enhanced' | 'createOrUpdateRecord', string>;
+
+type ConsentProxyEndpoints = { [key in keyof ConsentProxyEndpoint]: string };
+
+type PrivacyManagerProps = {
+  consent?: boolean;
+  referrer?: string;
+  legislation?: string[];
+  consentSource: string;
+  consentProxyEndpoints: ConsentProxyEndpoints;
+  onConsentSavedCallbacks: OnSaveCallback[];
+};
+
+type BasePrivacyManagerProps = PrivacyManagerProps & {
+  actions: Actions;
+  isLoading?: boolean;
+  _response: _Response;
 };


### PR DESCRIPTION
This PR extends and enhances the typings for the component and is the submission referred to in the conversation in https://github.com/Financial-Times/x-dash/pull/460 about providing stronger guidance re required/optional props

Although X-Dash does not support TS itself, the combination of JSDoc comments and VSCode Intellisense can greatly add to the ease of development and consistency of documentation