### PR TITLE
Add error arg to consent callbacks in x-privacy-manager

### DIFF
--- a/components/x-privacy-manager/src/__tests__/privacy-manager.test.jsx
+++ b/components/x-privacy-manager/src/__tests__/privacy-manager.test.jsx
@@ -39,6 +39,7 @@ const buildPayload = (consent) => ({
 
 function checkPayload(opts, expected) {
 	const consents = JSON.parse(String(opts.body)).data;
+
 	let worked = true;
 	for (const category in consents) {
 		worked = worked && consents[category].onsite.status === expected;
@@ -58,7 +59,11 @@ describe('x-privacy-manager', () => {
 	describe('initial state', () => {
 		beforeEach(() => {
 			fetchMock.reset();
-			fetchMock.mock(TEST_CONSENT_URL, 200, { delay: 500 });
+			const okResponse = {
+				body: { a: 'b' },
+				status: 200
+			};
+			fetchMock.mock(TEST_CONSENT_URL, okResponse, { delay: 500 });
 		});
 
 		it('defaults to "Allow"', () => {
@@ -120,8 +125,8 @@ describe('x-privacy-manager', () => {
 			await form.prop('onSubmit')(undefined);
 
 			// Check both callbacks were run with `payload`
-			expect(callback1).toHaveBeenCalledWith({ payload, consent: true });
-			expect(callback2).toHaveBeenCalledWith({ payload, consent: true });
+			expect(callback1).toHaveBeenCalledWith(null, { payload, consent: true });
+			expect(callback2).toHaveBeenCalledWith(null, { payload, consent: true });
 
 			// Reconcile snapshot with state
 			subject.update();

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -62,9 +62,12 @@ export const withCustomActions = withActions(() => ({
 					credentials: 'include'
 				});
 
+				const json = await res.json();
+				const error = (json.body && json.body.error) || null;
+
 				// Call any externally defined handlers with the value of `payload`
 				for (const fn of onConsentSavedCallbacks) {
-					fn({ consent, payload });
+					fn(error, { consent, payload });
 				}
 
 				return { _response: { ok: res.ok } };


### PR DESCRIPTION
This adds `error` as the first parameter to consent callbacks in `x-privacy-manager` in the style of Node.js callbacks.