### PR TITLE
Update typings to reflect revised callback signatures

### DIFF
--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -1,5 +1,7 @@
 /// <reference path="./types.d.ts" />
 
+/* eslint no-console: "off" */
+
 import { h } from '@financial-times/x-engine';
 import { withActions } from '@financial-times/x-interaction';
 
@@ -76,7 +78,7 @@ export const withCustomActions = withActions(() => ({
 				// Allows callbacks to decide how to handle a failure scenario
 
 				if (res.ok === false) {
-					throw new Error(res.statusText || res.status);
+					throw new Error(res.statusText || String(res.status));
 				}
 
 				for (const fn of onConsentSavedCallbacks) {

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -62,16 +62,30 @@ export const withCustomActions = withActions(() => ({
 					credentials: 'include'
 				});
 
+<<<<<<< HEAD
 				const json = await res.json();
 				const error = (json.body && json.body.error) || null;
 
 				// Call any externally defined handlers with the value of `payload`
 				for (const fn of onConsentSavedCallbacks) {
 					fn(error, { consent, payload });
+=======
+				// Call any externally defined handlers following Node's convention:
+				// 1. `null` as the first argument
+				// 2. An object containing `consent` and `payload` as the second
+				for (const fn of onConsentSavedCallbacks) {
+					fn(null, { consent, payload });
+>>>>>>> 4d0eaada... Update typings to reflect revised callback signatures
 				}
 
 				return { _response: { ok: res.ok } };
 			} catch (err) {
+				// Call any externally defined handlers with the value of err as the first argument
+				// Allows callbacks to decide how to handle a failure scenario
+				for (const fn of onConsentSavedCallbacks) {
+					fn(err, { consent, payload });
+				}
+
 				return { _response: { ok: false } };
 			}
 		};

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -38,8 +38,8 @@ export const withCustomActions = withActions(() => ({
 					status: consent,
 					lbi: true,
 					source: consentSource,
-					fow: `${FOW_NAME}/${FOW_VERSION}`
-				}
+					fow: `${FOW_NAME}/${FOW_VERSION}`,
+				},
 			};
 
 			const payload = {
@@ -48,40 +48,43 @@ export const withCustomActions = withActions(() => ({
 				data: {
 					behaviouralAds: categoryPayload,
 					demographicAds: categoryPayload,
-					programmaticAds: categoryPayload
-				}
+					programmaticAds: categoryPayload,
+				},
 			};
 
 			try {
 				const res = await fetch(consentApiEnhancedUrl, {
 					method: 'POST',
 					headers: {
-						'Content-Type': 'application/json'
+						'Content-Type': 'application/json',
 					},
 					body: JSON.stringify(payload),
-					credentials: 'include'
+					credentials: 'include',
 				});
 
-<<<<<<< HEAD
 				const json = await res.json();
 				const error = (json.body && json.body.error) || null;
 
 				// Call any externally defined handlers with the value of `payload`
 				for (const fn of onConsentSavedCallbacks) {
 					fn(error, { consent, payload });
-=======
-				// Call any externally defined handlers following Node's convention:
-				// 1. `null` as the first argument
-				// 2. An object containing `consent` and `payload` as the second
-				for (const fn of onConsentSavedCallbacks) {
-					fn(null, { consent, payload });
->>>>>>> 4d0eaada... Update typings to reflect revised callback signatures
 				}
 
-				return { _response: { ok: res.ok } };
-			} catch (err) {
-				// Call any externally defined handlers with the value of err as the first argument
+				// On response call any externally defined handlers following Node's convention:
+				// 1. Either an error object or `null` as the first argument
+				// 2. An object containing `consent` and `payload` as the second
 				// Allows callbacks to decide how to handle a failure scenario
+
+				if (res.ok === false) {
+					throw new Error(res.statusText);
+				}
+
+				for (const fn of onConsentSavedCallbacks) {
+					fn(null, { consent, payload });
+				}
+
+				return { _response: { ok: true } };
+			} catch (err) {
 				for (const fn of onConsentSavedCallbacks) {
 					fn(err, { consent, payload });
 				}
@@ -89,7 +92,7 @@ export const withCustomActions = withActions(() => ({
 				return { _response: { ok: false } };
 			}
 		};
-	}
+	},
 }));
 
 /**
@@ -114,7 +117,7 @@ export function BasePrivacyManager({
 	referrer,
 	actions,
 	isLoading,
-	_response = undefined
+	_response = undefined,
 }) {
 	return (
 		<div className={s.consent}>

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -76,7 +76,7 @@ export const withCustomActions = withActions(() => ({
 				// Allows callbacks to decide how to handle a failure scenario
 
 				if (res.ok === false) {
-					throw new Error(res.statusText);
+					throw new Error(res.statusText || res.status);
 				}
 
 				for (const fn of onConsentSavedCallbacks) {

--- a/components/x-privacy-manager/src/types.d.ts
+++ b/components/x-privacy-manager/src/types.d.ts
@@ -18,7 +18,10 @@ type CCPAConsentPayload = {
   data: CCPAConsentData;
 };
 
-type OnSaveCallback = (args: { consent: boolean, payload: CCPAConsentPayload }) => void;
+type OnSaveCallback = (
+  err: null | string,
+  data: { consent: boolean; payload: CCPAConsentPayload }
+) => void;
 
 type Actions = {
   onConsentChange: () => void;

--- a/components/x-privacy-manager/src/types.d.ts
+++ b/components/x-privacy-manager/src/types.d.ts
@@ -19,7 +19,7 @@ type CCPAConsentPayload = {
 };
 
 type OnSaveCallback = (
-  err: null | string,
+  err: null | Error,
   data: { consent: boolean; payload: CCPAConsentPayload }
 ) => void;
 

--- a/components/x-privacy-manager/storybook/data.js
+++ b/components/x-privacy-manager/storybook/data.js
@@ -1,12 +1,17 @@
 const CONSENT_API = 'https://consent.ft.com';
+
 const defaults = {
 	consent: true,
 	legislation: [],
 	referrer: 'ft.com',
-	consentApiUrl: CONSENT_API
+	consentProxyEndpoints: {
+		core: CONSENT_API,
+		enhanced: CONSENT_API,
+		createOrUpdateRecord: CONSENT_API,
+	},
 };
 
 module.exports = {
 	CONSENT_API,
-	defaults
+	defaults,
 };

--- a/components/x-privacy-manager/storybook/story-save-failed.js
+++ b/components/x-privacy-manager/storybook/story-save-failed.js
@@ -1,19 +1,14 @@
-
 const { CONSENT_API, defaults } = require('./data');
 
 exports.title = 'Save failed';
 
-exports.data = {
-	...defaults,
-	consent: true
-};
+exports.data = defaults;
 
 exports.knobs = Object.keys(exports.data);
 
 exports.fetchMock = (fetchMock) => {
-	fetchMock.patch(CONSENT_API, 500, {
-		throw: new Error('bad membership api'),
-		delay: 1000
+	fetchMock.mock(CONSENT_API, 200, {
+		delay: 1000,
 	});
 };
 


### PR DESCRIPTION
Running registered callbacks on both success and error responses from the server requires a change to the typings to accept an error message as the first argument (following the Node convention)