### PR TITLE
Update stories and remove duplicated logic on server response

### DIFF
--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -1,7 +1,5 @@
 /// <reference path="./types.d.ts" />
 
-/* eslint no-console: "off" */
-
 import { h } from '@financial-times/x-engine';
 import { withActions } from '@financial-times/x-interaction';
 
@@ -63,14 +61,6 @@ export const withCustomActions = withActions(() => ({
 					body: JSON.stringify(payload),
 					credentials: 'include',
 				});
-
-				const json = await res.json();
-				const error = (json.body && json.body.error) || null;
-
-				// Call any externally defined handlers with the value of `payload`
-				for (const fn of onConsentSavedCallbacks) {
-					fn(error, { consent, payload });
-				}
 
 				// On response call any externally defined handlers following Node's convention:
 				// 1. Either an error object or `null` as the first argument

--- a/components/x-privacy-manager/storybook/data.js
+++ b/components/x-privacy-manager/storybook/data.js
@@ -11,7 +11,17 @@ const defaults = {
 	},
 };
 
+const getFetchMock = (status = 200, options = {}) => (fetchMock) => {
+	console.log({ status, options });
+
+	fetchMock.mock(CONSENT_API, status, {
+		delay: 1000,
+		...options,
+	});
+};
+
 module.exports = {
 	CONSENT_API,
 	defaults,
+	getFetchMock,
 };

--- a/components/x-privacy-manager/storybook/data.js
+++ b/components/x-privacy-manager/storybook/data.js
@@ -12,7 +12,6 @@ const defaults = {
 };
 
 const getFetchMock = (status = 200, options = {}) => (fetchMock) => {
-	console.log({ status, options });
 
 	fetchMock.mock(CONSENT_API, status, {
 		delay: 1000,

--- a/components/x-privacy-manager/storybook/story-consent-accepted.js
+++ b/components/x-privacy-manager/storybook/story-consent-accepted.js
@@ -1,4 +1,4 @@
-const { CONSENT_API, defaults } = require('./data');
+const { defaults, getFetchMock } = require('./data');
 
 exports.title = 'Consent: accepted';
 
@@ -9,9 +9,7 @@ exports.data = {
 
 exports.knobs = Object.keys(exports.data);
 
-exports.fetchMock = (fetchMock) => {
-	fetchMock.mock(CONSENT_API, 200, { delay: 1000 });
-};
+exports.fetchMock = getFetchMock();
 
 // This reference is only required for hot module loading in development
 // <https://webpack.js.org/concepts/hot-module-replacement/>

--- a/components/x-privacy-manager/storybook/story-consent-blocked.js
+++ b/components/x-privacy-manager/storybook/story-consent-blocked.js
@@ -1,4 +1,4 @@
-const { CONSENT_API, defaults } = require('./data');
+const { defaults, getFetchMock } = require('./data');
 
 exports.title = 'Consent: blocked';
 
@@ -9,9 +9,7 @@ exports.data = {
 
 exports.knobs = Object.keys(exports.data);
 
-exports.fetchMock = (fetchMock) => {
-	fetchMock.mock(CONSENT_API, 200, { delay: 1000 });
-};
+exports.fetchMock = getFetchMock();
 
 // This reference is only required for hot module loading in development
 // <https://webpack.js.org/concepts/hot-module-replacement/>

--- a/components/x-privacy-manager/storybook/story-consent-indeterminate.js
+++ b/components/x-privacy-manager/storybook/story-consent-indeterminate.js
@@ -1,4 +1,4 @@
-const { CONSENT_API, defaults } = require('./data');
+const { defaults, getFetchMock } = require('./data');
 
 exports.title = 'Consent: indeterminate';
 
@@ -9,9 +9,7 @@ exports.data = {
 
 exports.knobs = Object.keys(exports.data);
 
-exports.fetchMock = (fetchMock) => {
-	fetchMock.mock(CONSENT_API, 200, { delay: 1000 });
-};
+exports.fetchMock = getFetchMock();
 
 // This reference is only required for hot module loading in development
 // <https://webpack.js.org/concepts/hot-module-replacement/>

--- a/components/x-privacy-manager/storybook/story-save-failed.js
+++ b/components/x-privacy-manager/storybook/story-save-failed.js
@@ -1,4 +1,4 @@
-const { CONSENT_API, defaults } = require('./data');
+const { defaults, getFetchMock } = require('./data');
 
 exports.title = 'Save failed';
 
@@ -6,11 +6,7 @@ exports.data = defaults;
 
 exports.knobs = Object.keys(exports.data);
 
-exports.fetchMock = (fetchMock) => {
-	fetchMock.mock(CONSENT_API, 200, {
-		delay: 1000,
-	});
-};
+exports.fetchMock = getFetchMock(500);
 
 // This reference is only required for hot module loading in development
 // <https://webpack.js.org/concepts/hot-module-replacement/>


### PR DESCRIPTION
Updates in this PR:

## Stories
1. Supply the expected shape & content for `consentProxyEndpoints`
1. Make `fetchMock` calls configurable to allow simulating a failed response

## Component
Duplicated logic on server response was removed
