### PR TITLE
Version 1.0.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@
 ## v1
 
 
+### v1.0.6
+
+- Add `node-sass` dependency to `x-podcast-launchers` component to prevent build failure (#452).
+- Update CircleCI Node.js version to 10.13 to accommodate third-party dependency (Gatsby) introducing a breaking change (#450 and #453).
+
 ### v1.0.5
 
 - Fix article loading upon click issue when image is unavailable (#438)


### PR DESCRIPTION
In accordance with the [Release Guidelines](https://github.com/Financial-Times/x-dash/blob/master/docs/components/release-guidelines.md), this PR updates `changelog.md` to include **v1.0.6**: a patch release that includes unreleased commits merged to `master` branch since the last release (v1.0.5, released 25 Feb 2020).

In addition to the commits added to `changelog.md` in this PR, there were others that did as detailed below, but which are not of any real value to consumers of `x-dash` and so were omitted:
- Update `CODEOWNERS`.
- Remove references to `n-image` in `x-dash` docs.
- Merge and reversion of new component `x-privacy-manager`, which has now been fully tested and will be merged soon.