### PR TITLE
Bumps x-privacy-manager version to 1.0.0

### DIFF
--- a/components/x-privacy-manager/package.json
+++ b/components/x-privacy-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/x-privacy-manager",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A component to let users give or withhold consent to the use of their data",
   "author": "Oliver Turner <oliver.turner@ft.com>",
   "license": "ISC",


### PR DESCRIPTION
As the first production release of the component, the PR updates the version to 1.0.0