### PR TITLE
ACC-433 gift article form field label

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -27,7 +27,7 @@ exports[`@financial-times/x-gift-article renders a default Free article x-gift-a
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
-            aria-label="gift-article-link"
+            aria-label="Gift article shareable link"
             className="GiftArticle_url-input__1vM0-"
             disabled={false}
             name="non-gift-link"
@@ -136,7 +136,7 @@ exports[`@financial-times/x-gift-article renders a default With a bad response f
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
-            aria-label="gift-article-link"
+            aria-label="Gift article shareable link"
             className="GiftArticle_url-input__1vM0-"
             disabled={true}
             name="example-gift-link"
@@ -245,7 +245,7 @@ exports[`@financial-times/x-gift-article renders a default With gift credits x-g
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
-            aria-label="gift-article-link"
+            aria-label="Gift article shareable link"
             className="GiftArticle_url-input__1vM0-"
             disabled={true}
             name="example-gift-link"
@@ -440,7 +440,7 @@ exports[`@financial-times/x-gift-article renders a default With native share on 
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
-            aria-label="gift-article-link"
+            aria-label="Gift article shareable link"
             className="GiftArticle_url-input__1vM0-"
             disabled={true}
             name="example-gift-link"
@@ -549,7 +549,7 @@ exports[`@financial-times/x-gift-article renders a default Without gift credits 
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
-            aria-label="gift-article-link"
+            aria-label="Gift article shareable link"
             className="GiftArticle_url-input__1vM0-"
             disabled={true}
             name="example-gift-link"

--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -27,6 +27,7 @@ exports[`@financial-times/x-gift-article renders a default Free article x-gift-a
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
+            aria-label="gift-article-link"
             className="GiftArticle_url-input__1vM0-"
             disabled={false}
             name="non-gift-link"
@@ -135,6 +136,7 @@ exports[`@financial-times/x-gift-article renders a default With a bad response f
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
+            aria-label="gift-article-link"
             className="GiftArticle_url-input__1vM0-"
             disabled={true}
             name="example-gift-link"
@@ -243,6 +245,7 @@ exports[`@financial-times/x-gift-article renders a default With gift credits x-g
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
+            aria-label="gift-article-link"
             className="GiftArticle_url-input__1vM0-"
             disabled={true}
             name="example-gift-link"
@@ -437,6 +440,7 @@ exports[`@financial-times/x-gift-article renders a default With native share on 
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
+            aria-label="gift-article-link"
             className="GiftArticle_url-input__1vM0-"
             disabled={true}
             name="example-gift-link"
@@ -545,6 +549,7 @@ exports[`@financial-times/x-gift-article renders a default Without gift credits 
           className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--text__1CetU"
         >
           <input
+            aria-label="gift-article-link"
             className="GiftArticle_url-input__1vM0-"
             disabled={true}
             name="example-gift-link"

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -54,6 +54,18 @@ $o-typography-is-silent: true;
 
 }
 
+.hidden-label-text {
+	position: absolute;
+	clip: rect(0 0 0 0);
+	margin: -1px;
+	border: 0;
+	overflow: hidden;
+	padding: 0;
+	width: 1px;
+	height: 1px;
+	white-space: nowrap;
+}
+
 .url-input {
 	grid-area: share-url;
 	max-width: none;

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -54,23 +54,10 @@ $o-typography-is-silent: true;
 
 }
 
-.hidden-label-text {
-	position: absolute;
-	clip: rect(0 0 0 0);
-	margin: -1px;
-	border: 0;
-	overflow: hidden;
-	padding: 0;
-	width: 1px;
-	height: 1px;
-	white-space: nowrap;
-}
-
 .url-input {
 	grid-area: share-url;
 	max-width: none;
 }
-
 
 .copy-confirmation {
 	margin-top: 8px;

--- a/components/x-gift-article/src/Url.jsx
+++ b/components/x-gift-article/src/Url.jsx
@@ -22,7 +22,7 @@ export default ({ shareType, isGiftUrlCreated, url, urlType }) => {
 				className={ urlClassNames }
 				disabled={ shareType === ShareType.gift && !isGiftUrlCreated }
 				readOnly
-				aria-label="gift-article-link"
+				aria-label="Gift article shareable link"
 			/>
 		</span>
 	);

--- a/components/x-gift-article/src/Url.jsx
+++ b/components/x-gift-article/src/Url.jsx
@@ -12,14 +12,9 @@ const urlClassNames = [
 	styles['url-input']
 ].join(' ');
 
-const urlLabelClassNames = [
-	styles['hidden-label-text']
-].join('');
-
 export default ({ shareType, isGiftUrlCreated, url, urlType }) => {
 	return (
 		<span className={ urlWrapperClassNames }>
-			<label htmlFor={urlType} className={urlLabelClassNames}></label>
 			<input
 				type="text"
 				name={ urlType }
@@ -27,6 +22,7 @@ export default ({ shareType, isGiftUrlCreated, url, urlType }) => {
 				className={ urlClassNames }
 				disabled={ shareType === ShareType.gift && !isGiftUrlCreated }
 				readOnly
+				aria-label="gift-article-link"
 			/>
 		</span>
 	);

--- a/components/x-gift-article/src/Url.jsx
+++ b/components/x-gift-article/src/Url.jsx
@@ -12,9 +12,14 @@ const urlClassNames = [
 	styles['url-input']
 ].join(' ');
 
+const urlLabelClassNames = [
+	styles['hidden-label-text']
+].join('');
+
 export default ({ shareType, isGiftUrlCreated, url, urlType }) => {
 	return (
 		<span className={ urlWrapperClassNames }>
+			<label htmlFor={urlType} className={urlLabelClassNames}></label>
 			<input
 				type="text"
 				name={ urlType }


### PR DESCRIPTION
Fixes issue rasied in DAC Q2 2020 audit.
Gift article link input has no associated label or aria-label property.
For more detail see: https://financialtimes.atlassian.net/browse/ACC-433
Adds aria-label to input as this seems the most aproprate fix due to the context of it being in a 'gift article' modal box.
Should be treated as a patch release.