### PR TITLE
ACC-432 radio buttons group reference

### DIFF
--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -83,8 +83,16 @@ exports[`@financial-times/x-gift-article renders a default With a bad response f
         Share this article (unable to fetch credits)
       </div>
       <div
+        aria-labelledby="article-share-options"
         className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--radio-round__2_6YL GiftArticle_o-forms-input--inline__1816j GiftArticle_o-forms-field__3VFUz GiftArticle_radio-button-section__qCYDb"
+        role="group"
       >
+        <span
+          className="GiftArticle_share-option-title__1CFAK"
+          id="article-share-options"
+        >
+          Article share options
+        </span>
         <label
           htmlFor="giftLink"
         >
@@ -192,8 +200,16 @@ exports[`@financial-times/x-gift-article renders a default With gift credits x-g
         Share this article (with credit)
       </div>
       <div
+        aria-labelledby="article-share-options"
         className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--radio-round__2_6YL GiftArticle_o-forms-input--inline__1816j GiftArticle_o-forms-field__3VFUz GiftArticle_radio-button-section__qCYDb"
+        role="group"
       >
+        <span
+          className="GiftArticle_share-option-title__1CFAK"
+          id="article-share-options"
+        >
+          Article share options
+        </span>
         <label
           htmlFor="giftLink"
         >
@@ -387,8 +403,16 @@ exports[`@financial-times/x-gift-article renders a default With native share on 
         Share this article (on App)
       </div>
       <div
+        aria-labelledby="article-share-options"
         className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--radio-round__2_6YL GiftArticle_o-forms-input--inline__1816j GiftArticle_o-forms-field__3VFUz GiftArticle_radio-button-section__qCYDb"
+        role="group"
       >
+        <span
+          className="GiftArticle_share-option-title__1CFAK"
+          id="article-share-options"
+        >
+          Article share options
+        </span>
         <label
           htmlFor="giftLink"
         >
@@ -496,8 +520,16 @@ exports[`@financial-times/x-gift-article renders a default Without gift credits 
         Share this article (without credit)
       </div>
       <div
+        aria-labelledby="article-share-options"
         className="GiftArticle_o-forms-input__1bOBy GiftArticle_o-forms-input--radio-round__2_6YL GiftArticle_o-forms-input--inline__1816j GiftArticle_o-forms-field__3VFUz GiftArticle_radio-button-section__qCYDb"
+        role="group"
       >
+        <span
+          className="GiftArticle_share-option-title__1CFAK"
+          id="article-share-options"
+        >
+          Article share options
+        </span>
         <label
           htmlFor="giftLink"
         >

--- a/components/x-gift-article/bower.json
+++ b/components/x-gift-article/bower.json
@@ -8,6 +8,7 @@
     "o-forms": "^8.0.0",
     "o-loading": "^4.0.0",
     "o-message": "^4.0.0",
-    "o-typography": "6.0.0"
+    "o-typography": "6.0.0",
+    "o-normalise": "^2.0.0"
   }
 }

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -1,4 +1,5 @@
 @import 'src/lib/variables';
+@import 'o-normalise/main';
 
 $o-buttons-is-silent: true;
 @import 'o-buttons/main';
@@ -35,6 +36,22 @@ $o-typography-is-silent: true;
 
 	.radio-button-section {
 		margin-bottom: 12px;
+	}
+
+	.share-option-title {
+		@include oNormaliseVisuallyHidden();
+	}
+
+	.share-option-title {
+		@include oNormaliseVisuallyHidden();
+	}
+
+	.share-option-title {
+		@include oNormaliseVisuallyHidden();
+	}
+
+	.share-option-title {
+		@include oNormaliseVisuallyHidden();
 	}
 }
 

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -11,7 +11,8 @@ const radioSectionClassNames = [
 ].join(' ');
 
 export default ({ shareType, showGiftUrlSection, showNonGiftUrlSection }) => (
-	<div className={ radioSectionClassNames }>
+	<div className={ radioSectionClassNames } role="group" aria-labelledby="article-share-options">
+		<span className={ styles["share-option-title"] } id="article-share-options">Article share options</span>
 		<label htmlFor="giftLink">
 			<input
 				type="radio"


### PR DESCRIPTION
Groups radio button inputs as a multiple form input for Assistive technology(AT).. 

Addresses the DAC issue raised in the Q2 audit see: https://financialtimes.atlassian.net/browse/ACC-432

DAC recommendation was to group in fieldset and ledgend but the grouping has been applied using role on the containing element and aria-labelledby properties for reasons described in o-forms accessibility docs: 
https://github.com/Financial-Times/o-forms/blob/master/ACCESSIBILITY.md#multiple-inputs