### PR TITLE
x-privacy-manager v1.0.1 - codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,4 @@
 
 components/x-teaser @Financial-Times/content-discovery
 components/x-teaser-timeline @Financial-Times/content-discovery
+components/x-privacy-manager @Financial-Times/ads


### PR DESCRIPTION
Hopefully identifying the Ads team as the maintainers of `x-privacy-manager` will reduce overhead on the part of the Platforms team