### PR TITLE
x-privacy-manager v1.1.0

### DIFF
--- a/components/x-privacy-manager/package.json
+++ b/components/x-privacy-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/x-privacy-manager",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A component to let users give or withhold consent to the use of their data",
   "author": "Oliver Turner <oliver.turner@ft.com>",
   "license": "ISC",

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -99,9 +99,30 @@ function renderMessage(isLoading, response, referrer) {
 }
 
 /**
+ * Display a warning to users
+ * @param {string | undefined} userId
+ */
+function renderLoggedOutWarning(userId) {
+	if (userId && userId.length > 0) return null;
+
+	return (
+		<p className={`${s.consent__copy} ${s['consent__copy--cta']}`}>
+			Please{' '}
+			<a href="https://www.ft.com/myaccount" data-trackable="Settings &amp; Account">
+				sign into your account
+			</a>{' '}
+			before submitting your preferences to ensure these changes are applied across all of your
+			devices
+		</p>
+	);
+}
+
+/**
  * @param {BasePrivacyManagerProps} Props
- */	
+ */
+
 export function BasePrivacyManager({
+	userId,
 	consent = true,
 	consentProxyEndpoints,
 	consentSource,
@@ -134,6 +155,7 @@ export function BasePrivacyManager({
 					see the same number of adverts on our Sites.
 				</p>
 				<hr className={s.divider} />
+				{renderLoggedOutWarning(userId)}
 				<div className={s.messages} aria-live="polite">
 					{renderMessage(isLoading, _response, referrer)}
 				</div>

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -107,12 +107,8 @@ function renderLoggedOutWarning(userId) {
 
 	return (
 		<p className={`${s.consent__copy} ${s['consent__copy--cta']}`}>
-			Please{' '}
-			<a href="https://www.ft.com/myaccount" data-trackable="Settings &amp; Account">
-				sign into your account
-			</a>{' '}
-			before submitting your preferences to ensure these changes are applied across all of your
-			devices
+			Please sign into your account before submitting your preferences to ensure these changes are
+			applied across all of your devices
 		</p>
 	);
 }

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -138,13 +138,13 @@ export function BasePrivacyManager({
 			<div className={s.consent__copy}>
 				<p>
 					If you are a California resident, the California Consumer Privacy Act (CCPA) provides you
-					with a right to opt-out of the sale of your personal information. The definition of sale
+					with a right to opt out of the sale of your personal information. The definition of sale
 					is extremely broad under the CCPA, and may include sharing certain pieces of information
 					with our advertising partners, such as cookie identifiers, geolocation and interactions
 					with advertisements, for the purposes of showing you advertising that is relevant to your
 					interests. You can find more information about this in our{' '}
 					<a href="https://help.ft.com/legal-privacy/privacy-policy/">Privacy Policy</a>, including
-					other ways to opt-out.
+					other ways to opt out.
 				</p>
 
 				<p>

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -170,11 +170,19 @@ export function BasePrivacyManager({
 						);
 					}}>
 					<div className={s.form__controls}>
-						<RadioBtn value="true" checked={consent === true} onChange={actions.onConsentChange}>
+						<RadioBtn
+							value="true"
+							trackingId="ccpa-advertising-toggle-allow"
+							checked={consent === true}
+							onChange={actions.onConsentChange}>
 							<strong>Allow</strong>
 							<span>See personalised adverts</span>
 						</RadioBtn>
-						<RadioBtn value="false" checked={consent === false} onChange={actions.onConsentChange}>
+						<RadioBtn
+							value="false"
+							trackingId="ccpa-advertising-toggle-block"
+							checked={consent === false}
+							onChange={actions.onConsentChange}>
 							<strong>Block</strong>
 							<span>Opt out of personalised adverts</span>
 						</RadioBtn>

--- a/components/x-privacy-manager/src/privacy-manager.scss
+++ b/components/x-privacy-manager/src/privacy-manager.scss
@@ -9,6 +9,10 @@
 	vertical-align: middle;
 }
 
+.centred {
+	text-align: center;
+}
+
 .loading {
 	composes: v-middle;
 	margin-left: oSpacingByName(s4)
@@ -35,7 +39,14 @@
 	& a {
 		@include oTypographyLink;
 	}
+	
+	& .consent__copy--cta {
+		padding: 0 oSpacingByName(m12);
+		font-weight: 600;
+		text-align: center;
+	}
 }
+
 
 .divider {
 	margin-top: oSpacingByName(s8);
@@ -45,7 +56,6 @@
 	@include oTypographyHeading($level: 4);
 	
 	margin-top: oSpacingByName(s8);
-	text-align: center;
 }
 
 .form__controls {
@@ -66,6 +76,5 @@
 
 	display: block;
 	margin: oSpacingByName(s8) auto 0;
-	padding-left: oSpacingByName(m12);
-	padding-right: oSpacingByName(m12);
+	padding: 0 oSpacingByName(m12);
 }

--- a/components/x-privacy-manager/src/radio-btn.jsx
+++ b/components/x-privacy-manager/src/radio-btn.jsx
@@ -2,7 +2,7 @@ import { h } from '@financial-times/x-engine';
 
 import s from './radio-btn.scss';
 
-export function RadioBtn({ value, checked, onChange, children }) {
+export function RadioBtn({ value, trackingId, checked, onChange, children }) {
 	const id = `ccpa-${value}`;
 
 	return (
@@ -16,7 +16,7 @@ export function RadioBtn({ value, checked, onChange, children }) {
 				checked={checked}
 				onChange={onChange}
 			/>
-			<label htmlFor={id} className={s.label}>
+			<label htmlFor={id} className={s.label} data-trackable={trackingId}>
 				<span className={s.label__text}>
 					{children}
 				</span>

--- a/components/x-privacy-manager/src/radio-btn.jsx
+++ b/components/x-privacy-manager/src/radio-btn.jsx
@@ -16,7 +16,7 @@ export function RadioBtn({ value, checked, onChange, children }) {
 				checked={checked}
 				onChange={onChange}
 			/>
-			<label htmlFor={id} className={`needsclick ${s.label}`}>
+			<label htmlFor={id} className={s.label}>
 				<span className={s.label__text}>
 					{children}
 				</span>

--- a/components/x-privacy-manager/src/radio-btn.scss
+++ b/components/x-privacy-manager/src/radio-btn.scss
@@ -47,6 +47,11 @@
 		outline: 5px auto -webkit-focus-ring-color;
 		background-color: oColorsByName('teal-40');
 	}
+
+	// Prevent fastclick from blocking events from child elements bubbling up to trigger a change
+	& > * {
+		pointer-events: none;
+	}
 }
 
 

--- a/components/x-privacy-manager/src/types.d.ts
+++ b/components/x-privacy-manager/src/types.d.ts
@@ -42,6 +42,7 @@ type ConsentProxyEndpoint = Record<'core' | 'enhanced' | 'createOrUpdateRecord',
 type ConsentProxyEndpoints = { [key in keyof ConsentProxyEndpoint]: string };
 
 type PrivacyManagerProps = {
+  userId: string | undefined;
   consent?: boolean;
   referrer?: string;
   legislation?: string[];

--- a/components/x-privacy-manager/storybook/data.js
+++ b/components/x-privacy-manager/storybook/data.js
@@ -1,6 +1,7 @@
 const CONSENT_API = 'https://consent.ft.com';
 
 const defaults = {
+	userId: "fakeUserId",
 	consent: true,
 	legislation: [],
 	referrer: 'ft.com',

--- a/components/x-privacy-manager/storybook/knobs.js
+++ b/components/x-privacy-manager/storybook/knobs.js
@@ -1,5 +1,5 @@
 const legislation = {
-	CCPA: ['ccpa', 'gdpr']
+	CCPA: ['ccpa', 'gdpr'],
 	// GDPR: ['gdpr']
 };
 
@@ -19,17 +19,20 @@ const referrers = {
 	'pwmnet.com': 'www.pwmnet.com',
 	'thebanker.com': 'www.thebanker.com',
 	'thebankerdatabase.com': 'www.thebankerdatabase.com',
-	Undefined: ''
+	Undefined: '',
 };
 
 module.exports = (data, { boolean, select }) => ({
+	userId() {
+		return select('Authenticated', { loggedIn: data.userId, loggedOut: undefined });
+	},
 	consent() {
-		return boolean('Consent', data.consent);
+		return boolean('Consent', data.consent, undefined);
 	},
 	legislation() {
 		return select('Legislation', legislation, legislation['CCPA']);
 	},
 	referrer() {
 		return select('Referrer', referrers, referrers['ft.com']);
-	}
+	},
 });


### PR DESCRIPTION
This PR rolls up the following feature additions and bug fixes:
- Bugfix: fastclick requiring double clicks to select an option
- [ADSDEV-543](https://financialtimes.atlassian.net/browse/ADSDEV-543): Encourage logged-out users wishing to update their DNS preferences to sign in
- [ADSDEV-431](https://financialtimes.atlassian.net/browse/ADSDEV-431): Add tracking attributes
- [ADSDEV-527](https://financialtimes.atlassian.net/browse/ADSDEV-527): Update legal copy