### PR TITLE
Add an optional cookieDomain to PrivacyManager

### DIFF
--- a/components/x-privacy-manager/readme.md
+++ b/components/x-privacy-manager/readme.md
@@ -26,16 +26,17 @@ The [`x-engine`][engine] module is used to inject your chosen runtime into the c
 Feature                     | Type       | Notes
 ----------------------------|------------|-----------------------------------------------
 `consentSource`             | string     | Name of the consuming app to be included in requests to Consent Proxy (e.g. "next-control-centre")
-`consentProxyEndpoints`    | object     | Dictionary containing already-formed Consent Proxy Endpoints to use (including userId). It must include, at least, `consentProxyEndpoints.createOrUpdateRecord`
+`consentProxyEndpoints`     | object     | Dictionary containing already-formed Consent Proxy Endpoints to use (including userId). It must include, at least, `consentProxyEndpoints.createOrUpdateRecord`
 `consent`                   | boolean    | (optional) Any existing preference expressed by the user
 `referrer`                  | string     | (optional) Used to provide a link back to the referring app's home page
+`cookieDomain`              | string     | (optional) Specify the domain for the cookie set with the response from Consent Proxy (e.g. ".thebanker.com"). Will default to ".ft.com" if not provided
 `legislation`               | string[]   | (optional) An array of the applicable legislation IDs
 `onConsentSavedCallbacks`   | function[] | (optional) An array of callbacks to invoken after a successful request to Consent Proxy
 
 A callback registered with `onConsentSavedCallbacks` will be executed with the following signature:
 ```js
 customCallback(
-  err: null | Error, 
+  err: null | Error,
   {
     consent: boolean,
     payload: {
@@ -56,7 +57,7 @@ customCallback(
 )
 ```
 
-Callbacks are executed on regardless of the success (200 status) or failure of the call to the server, 
+Callbacks are executed on regardless of the success (200 status) or failure of the call to the server,
 so we encourage returning early if the value of the error is anything but `null`:
 
 ```js

--- a/components/x-privacy-manager/src/__tests__/privacy-manager.test.jsx
+++ b/components/x-privacy-manager/src/__tests__/privacy-manager.test.jsx
@@ -34,6 +34,7 @@ const buildPayload = (consent) => ({
 			},
 		},
 	},
+	cookieDomain: '.ft.com',
 	formOfWordsId: 'privacyCCPA',
 });
 
@@ -55,6 +56,7 @@ const defaultProps = {
 	},
 	consentSource: 'consuming-app',
 	referrer: 'www.ft.com',
+	cookieDomain: '.ft.com',
 };
 
 describe('x-privacy-manager', () => {

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -135,6 +135,9 @@ export function BasePrivacyManager({
 	isLoading,
 	_response = undefined,
 }) {
+	const trackingAction = consent ? 'allow' : 'block';
+	const btnTrackingId = `ccpa-advertising-consent-${trackingAction}`;
+
 	return (
 		<div className={s.consent}>
 			<h1 className={s.consent__title}>Do Not Sell My Personal Information</h1>
@@ -191,7 +194,7 @@ export function BasePrivacyManager({
 							<span>Opt out of personalised adverts</span>
 						</RadioBtn>
 					</div>
-					<button className={s.form__submit} type="submit">
+					<button className={s.form__submit} type="submit" data-trackable={btnTrackingId}>
 						Save
 					</button>
 				</form>

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -26,10 +26,11 @@ export const withCustomActions = withActions(() => ({
 	 * @param {string} consentApiEnhancedUrl
 	 * @param {OnSaveCallback[]} onConsentSavedCallbacks
 	 * @param {string} consentSource (e.g. 'next-control-centre')
+	 * @param {string | undefined} cookieDomain (e.g. '.thebanker.com')
 	 *
 	 * @returns {(props: BasePrivacyManagerProps) => Promise<{_response: _Response}>}
 	 */
-	sendConsent(consentApiEnhancedUrl, onConsentSavedCallbacks, consentSource) {
+	sendConsent(consentApiEnhancedUrl, onConsentSavedCallbacks, consentSource, cookieDomain) {
 		return async ({ isLoading, consent }) => {
 			if (isLoading) return;
 
@@ -51,6 +52,11 @@ export const withCustomActions = withActions(() => ({
 					programmaticAds: categoryPayload,
 				},
 			};
+
+			if (cookieDomain) {
+				// Optionally specifiy the domain for the cookie consent api will set
+				payload.cookieDomain = cookieDomain;
+			}
 
 			try {
 				const res = await fetch(consentApiEnhancedUrl, {
@@ -124,6 +130,7 @@ export function BasePrivacyManager({
 	consentSource,
 	onConsentSavedCallbacks = [],
 	referrer,
+	cookieDomain,
 	actions,
 	isLoading,
 	_response = undefined,
@@ -162,7 +169,8 @@ export function BasePrivacyManager({
 						return actions.sendConsent(
 							consentProxyEndpoints.createOrUpdateRecord,
 							onConsentSavedCallbacks,
-							consentSource
+							consentSource,
+							cookieDomain
 						);
 					}}>
 					<div className={s.form__controls}>

--- a/components/x-privacy-manager/src/radio-btn.jsx
+++ b/components/x-privacy-manager/src/radio-btn.jsx
@@ -15,8 +15,9 @@ export function RadioBtn({ value, trackingId, checked, onChange, children }) {
 				value={value}
 				checked={checked}
 				onChange={onChange}
+				data-trackable={trackingId}
 			/>
-			<label htmlFor={id} className={s.label} data-trackable={trackingId}>
+			<label htmlFor={id} className={s.label}>
 				<span className={s.label__text}>
 					{children}
 				</span>

--- a/components/x-privacy-manager/src/types.d.ts
+++ b/components/x-privacy-manager/src/types.d.ts
@@ -45,6 +45,7 @@ type PrivacyManagerProps = {
   userId: string | undefined;
   consent?: boolean;
   referrer?: string;
+  cookieDomain?: string;
   legislation?: string[];
   consentSource: string;
   consentProxyEndpoints: ConsentProxyEndpoints;


### PR DESCRIPTION
Updates `x-privacy-manager`

Adds an optional `cookieDomain` prop that allows consuming apps to override the domain of the consent cookie being set with the successful response from Consent API. When provided, the `cookieDomain` prop is attached to the payload being sent over to Consent Proxy and overrides the default ".ft.com" here https://github.com/Financial-Times/next-consent-proxy/blob/master/src/controllers/set-consent-record-cookie.ts#L58

Background:
This component is used on specialist titles (e.g. https://cookies.ftadviser.com/preferences/privacy-ccpa?referrer=www.ftadviser.com&cookieDomain=.ftadviser.com&legislation=ccpa ) where the consent cookie from Consent API needs to be set to the appropriate domain for the title. 
[This PR in `next-control-centre`](https://github.com/Financial-Times/next-control-centre/pull/189) enables the `&cookieDomain=.ftadviser.com` URL parameter from the example above to be passed as prop to `<PrivacyManager />`. The changes in this current PR are the logical next step that allows for the consent cookie to correctly get set on any specialist title.