### PR TITLE
Update unit tests of x-privacy-manager

### DIFF
--- a/components/x-privacy-manager/readme.md
+++ b/components/x-privacy-manager/readme.md
@@ -42,6 +42,7 @@ customCallback(
     payload: {
       formOfWordsId: string,
       consentSource: string,
+      cookieDomain: string | undefined,
       data: {
         ['behaviouralAds' | 'demographicAds' | 'programmaticAds']: {
           onsite: {

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -54,7 +54,7 @@ export const withCustomActions = withActions(() => ({
 			};
 
 			if (cookieDomain) {
-				// Optionally specifiy the domain for the cookie consent api will set
+				// Optionally specifiy the domain for the cookie that consent api will set
 				payload.cookieDomain = cookieDomain;
 			}
 


### PR DESCRIPTION
This PR fills some gaps in unit-test coverage of `x-privacy-manager`:
- testing whether the optional `cookieDomain` prop is attached to fetch request and callback payloads
- testing that callbacks are called with an error argument in case of fetch request failure

The unit test layout is changed so we can extract the `consent choice handling` logic from the `initial state` cases.