### PR TITLE
CI-261 Remove `&amp;` from share URLs

### DIFF
--- a/components/x-live-blog-post/src/ShareButtons.jsx
+++ b/components/x-live-blog-post/src/ShareButtons.jsx
@@ -7,9 +7,9 @@ export default ({ postId, articleUrl, title }) => {
 		shareUrl.hash = `post-${postId}`;
 	}
 
-	const twitterUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&amp;text=${encodeURIComponent(title)}&amp;via=financialtimes`;
-	const facebookUrl = `http://www.facebook.com/sharer.php?u=${encodeURIComponent(shareUrl)}&amp;t=${encodeURIComponent(title)}`;
-	const linkedInUrl = `http://www.linkedin.com/shareArticle?mini=true&amp;url=${encodeURIComponent(shareUrl)}&amp;title=${encodeURIComponent(title)}&amp;source=Financial+Times`;
+	const twitterUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(title)}&via=financialtimes`;
+	const facebookUrl = `http://www.facebook.com/sharer.php?u=${encodeURIComponent(shareUrl)}&t=${encodeURIComponent(title)}`;
+	const linkedInUrl = `http://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(shareUrl)}&title=${encodeURIComponent(title)}&source=Financial+Times`;
 
 	return (
 		<div className={styles['live-blog-post__share-buttons']}>

--- a/components/x-live-blog-post/src/__tests__/ShareButtons.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/ShareButtons.test.jsx
@@ -17,21 +17,21 @@ describe('x-live-blog-post', () => {
 			const shareButtons = mount(<ShareButtons {...props} />);
 			const twitterButton = shareButtons.find('.o-share__icon--twitter').first();
 
-			expect(twitterButton.prop('href')).toEqual('https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.ft.com%2F%23post-12345&amp;text=Test%20title&amp;via=financialtimes');
+			expect(twitterButton.prop('href')).toEqual('https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.ft.com%2F%23post-12345&text=Test%20title&via=financialtimes');
 		});
 
 		it('renders correct facebook url', () => {
 			const shareButtons = mount(<ShareButtons {...props} />);
 			const facebookButton = shareButtons.find('.o-share__icon--facebook').first();
 
-			expect(facebookButton.prop('href')).toEqual('http://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.ft.com%2F%23post-12345&amp;t=Test%20title');
+			expect(facebookButton.prop('href')).toEqual('http://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.ft.com%2F%23post-12345&t=Test%20title');
 		});
 
 		it('renders correct linkedin url', () => {
 			const shareButtons = mount(<ShareButtons {...props} />);
 			const linkedinButton = shareButtons.find('.o-share__icon--linkedin').first();
 
-			expect(linkedinButton.prop('href')).toEqual('http://www.linkedin.com/shareArticle?mini=true&amp;url=https%3A%2F%2Fwww.ft.com%2F%23post-12345&amp;title=Test%20title&amp;source=Financial+Times');
+			expect(linkedinButton.prop('href')).toEqual('http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fwww.ft.com%2F%23post-12345&title=Test%20title&source=Financial+Times');
 		});
 
 	})


### PR DESCRIPTION
The `x-live-blog-post` share URLs are not working in `next-article` because at some point they are being double encoded. As a result, users who click on the LinkedIn share link on a live blog post are being sent to an error page:

![image](https://user-images.githubusercontent.com/30316203/87673105-e2e04c80-c76b-11ea-8975-9e51dd93b621.png)

[Content Innovation Ticket](https://financialtimes.atlassian.net/browse/CI-261)