### PR TITLE
CI-287 Improve timestamp colour contrast

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -3,68 +3,68 @@
 @import 'o-colors/main';
 
 .live-blog-post {
-  	border-bottom: 1px solid oColorsMix(black, paper, 20);
-  	margin-top: oSpacingByName('s8');
+	border-bottom: 1px solid oColorsMix(black, paper, 20);
+	margin-top: oSpacingByName('s8');
 	color: oColorsMix(black, paper, 90);
 }
 
 .live-blog-post__title {
 	@include oTypographyDisplay($scale: 5);
-  	margin-top: oSpacingByName('s4');
+	margin-top: oSpacingByName('s4');
 }
 
 .live-blog-post__breaking-news + .live-blog-post__title {
-  	margin-top: oSpacingByName('s1');
+	margin-top: oSpacingByName('s1');
 }
 
 .live-blog-post__body {
 	@include oTypographySerif($scale: 1, $line-height: 1.55);
-  	margin-top: oSpacingByName('s6');
+	margin-top: oSpacingByName('s6');
 }
 
 .live-blog-post__body ul {
-  	@include oTypographyList('unordered');
+	@include oTypographyList('unordered');
 }
 
 .live-blog-post__timestamp {
-  	@include oTypographySans($scale:0, $weight: 'semibold');
-  	font-size: 14px;
-  	text-transform: uppercase;
+	@include oTypographySans($scale:0, $weight: 'semibold');
+	font-size: 14px;
+	text-transform: uppercase;
 }
 
 .live-blog-post__timestamp-exact-time {
-  	@include oTypographySans($scale:0, $weight: 'light');
-  	font-size: 14px;
-  	color: oColorsMix(black, paper, 50);
-  	padding-left: oSpacingByName('s2');
+	@include oTypographySans($scale:0, $weight: 'light');
+	font-size: 14px;
+	color: oColorsMix(black, paper, 50);
+	padding-left: oSpacingByName('s2');
 }
 
 .live-blog-post__timestamp-container:after {
-  	content: '';
-  	display: block;
-  	width: oSpacingByName('s4');
-  	border-bottom: 4px solid oColorsMix(black, paper, 90);
+	content: '';
+	display: block;
+	width: oSpacingByName('s4');
+	border-bottom: 4px solid oColorsMix(black, paper, 90);
 }
 
 .live-blog-post__share-buttons {
-  	margin-top: oSpacingByName('s6');
-  	margin-bottom: oSpacingByName('s8');
+	margin-top: oSpacingByName('s6');
+	margin-bottom: oSpacingByName('s8');
 }
 
 .live-blog-post__breaking-news {
-  	@include oTypographySans($scale:0);
+	@include oTypographySans($scale:0);
 	font-size: 12px;
 	color: oColorsByName('crimson');
 	text-transform: uppercase;
-  	margin-top: oSpacingByName('s4');
+	margin-top: oSpacingByName('s4');
 }
 
 .live-blog-post__breaking-news:before {
-  	content: '';
-  	display: inline-block;
-  	width: oSpacingByName('s2');
-  	height: oSpacingByName('s2');
+	content: '';
+	display: inline-block;
+	width: oSpacingByName('s2');
+	height: oSpacingByName('s2');
 	margin-right: oSpacingByName('s1');
-  	border-radius: 50%;
-  	background-color: oColorsByName('crimson');
+	border-radius: 50%;
+	background-color: oColorsByName('crimson');
 }

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -35,7 +35,7 @@
 .live-blog-post__timestamp-exact-time {
 	@include oTypographySans($scale:0, $weight: 'light');
 	font-size: 14px;
-	color: oColorsMix(black, paper, 50);
+	color: oColorsMix(black, paper, 60);
 	padding-left: oSpacingByName('s2');
 }
 


### PR DESCRIPTION
Contrast on the timestamp was too low, making it inaccessible. Josh W. has approved the use of the slightly darker shade. To be honest, both colours looks the same to me 😂 

**Before:**
![image](https://user-images.githubusercontent.com/30316203/89303992-d2cdd580-d664-11ea-90fe-b0b58e4cff4a.png)

![image](https://user-images.githubusercontent.com/30316203/89304314-36580300-d665-11ea-9cce-533fa3834cfb.png)

**After:**
![image](https://user-images.githubusercontent.com/30316203/89303937-c0ec3280-d664-11ea-8d1f-58b744c99c9d.png)

![image](https://user-images.githubusercontent.com/30316203/89303899-b5990700-d664-11ea-824d-467164d7e9c8.png)
