### PR TITLE
CI-288 Update timestamp to use latest version of `o-date`

### DIFF
--- a/components/x-live-blog-post/src/Timestamp.jsx
+++ b/components/x-live-blog-post/src/Timestamp.jsx
@@ -27,19 +27,19 @@ export default ({ publishedTimestamp }) => {
 			<time
 				data-o-component="o-date"
 				className={`o-date ${styles['live-blog-post__timestamp']}`}
-				itemProp="datePublished"
+				dateTime={publishedTimestamp}
 				data-o-date-format={format}
-				dateTime={publishedTimestamp}>{formatted}
+				itemProp="datePublished">
+					<span data-o-date-printer>{formatted}</span>
+					{showExactTime && (
+						<span
+							className={`o-date ${styles['live-blog-post__timestamp-exact-time']}`}
+							data-o-date-printer
+							data-o-date-format="HH:mm"
+							itemProp="exactTime">
+						</span>
+					)}
 			</time>
-			{showExactTime && (
-			<time
-				data-o-component="o-date"
-				className={`o-date ${styles['live-blog-post__timestamp-exact-time']}`}
-				itemProp="exactTime"
-				data-o-date-format="HH:mm"
-				dateTime={publishedTimestamp}>{formatted}
-			</time>
-			)}
 		</div>
 	);
 };

--- a/components/x-live-blog-post/src/__tests__/Timestamp.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/Timestamp.test.jsx
@@ -23,7 +23,7 @@ describe('x-live-blog-post', () => {
 			it('renders the time in MMM dd, HH:mm', () => {
 				const date = twoDaysAgo();
 				const timestamp = mount(<Timestamp publishedTimestamp={date.toISOString()} />);
-				const dateEl = timestamp.find('time[data-o-component="o-date"]').first();
+				const dateEl = timestamp.find('time[data-o-component="o-date"]');
 
 				expect(dateEl.prop('data-o-date-format')).toEqual('MMM dd, HH:mm');
 				expect(dateEl.prop('dateTime')).toEqual(date.toISOString());
@@ -32,9 +32,9 @@ describe('x-live-blog-post', () => {
 
 			it('does not render exact time', () => {
 				const timestamp = mount(<Timestamp publishedTimestamp={twoDaysAgo().toISOString()} />);
-				const exactTimeElements = timestamp.find('time[data-o-component="o-date"]');
+				const exactTimeEl = timestamp.find('span').at(1);
 
-				expect(exactTimeElements.length).toEqual(1);
+				expect(exactTimeEl).not.toExist();
 			});
 		});
 
@@ -42,7 +42,7 @@ describe('x-live-blog-post', () => {
 			it('renders the time in "time ago" format', () => {
 				const date = twoMinutesAgo();
 				const timestamp = mount(<Timestamp publishedTimestamp={date.toISOString()} />);
-				const dateEl = timestamp.find('time[data-o-component="o-date"]').first();
+				const dateEl = timestamp.find('time[data-o-component="o-date"]');
 
 				expect(dateEl.prop('data-o-date-format')).toEqual('time-ago-no-seconds');
 				expect(dateEl.prop('dateTime')).toEqual(date.toISOString());
@@ -51,7 +51,7 @@ describe('x-live-blog-post', () => {
 
 			it('renders the exact time', () => {
 				const timestamp = mount(<Timestamp publishedTimestamp={twoMinutesAgo().toISOString()} />);
-				const exactTimeEl = timestamp.find('time[data-o-component="o-date"] + time').first();
+				const exactTimeEl = timestamp.find('span').at(1);
 
 				expect(exactTimeEl.prop('data-o-date-format')).toEqual('HH:mm');
 			});


### PR DESCRIPTION
The latest version allows us to render a date multiple times within the
same `o-date` component by including multiple `data-o-date-printer`
elements.

FYI, there is no visual change to the timestamp.

See https://github.com/Financial-Times/o-date/releases/tag/v4.1.0.