### PR TITLE
Allow users to specify the data-trackable attribute for the teaser

### DIFF
--- a/components/x-teaser/__fixtures__/top-story.json
+++ b/components/x-teaser/__fixtures__/top-story.json
@@ -8,6 +8,7 @@
   "altStandfirst": "Groping and sexual harassment at black-tie dinner charity event",
   "publishedDate": "2018-01-23T15:07:00.000Z",
   "firstPublishedDate": "2018-01-23T13:53:00.000Z",
+  "dataTrackable": "slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1",
   "metaPrefixText": "",
   "metaSuffixText": "",
   "metaLink": {

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -437,6 +437,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with topStory data 1`] = `
 <div
   className="o-teaser o-teaser--article o-teaser--hero o-teaser--has-image js-teaser"
   data-id=""
+  data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"
 >
   <div
     className="o-teaser__content"
@@ -905,6 +906,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with topStory data 1`]
 <div
   className="o-teaser o-teaser--article o-teaser--hero js-teaser"
   data-id=""
+  data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"
 >
   <div
     className="o-teaser__content"
@@ -1438,6 +1440,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with topStory data 1`
 <div
   className="o-teaser o-teaser--article o-teaser--hero o-teaser--hero-image o-teaser--has-image js-teaser"
   data-id=""
+  data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"
 >
   <div
     className="o-teaser__content"
@@ -1822,6 +1825,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with topStory data 1`] 
 <div
   className="o-teaser o-teaser--article o-teaser--hero js-teaser"
   data-id=""
+  data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"
 >
   <div
     className="o-teaser__content"
@@ -2471,6 +2475,7 @@ exports[`x-teaser / snapshots renders a Large teaser with topStory data 1`] = `
 <div
   className="o-teaser o-teaser--article o-teaser--large o-teaser--has-image js-teaser"
   data-id=""
+  data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"
 >
   <div
     className="o-teaser__content"
@@ -2879,6 +2884,7 @@ exports[`x-teaser / snapshots renders a Small teaser with topStory data 1`] = `
 <div
   className="o-teaser o-teaser--article o-teaser--small js-teaser"
   data-id=""
+  data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"
 >
   <div
     className="o-teaser__content"
@@ -3472,6 +3478,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with topStory data 1`]
 <div
   className="o-teaser o-teaser--article o-teaser--small o-teaser--has-image js-teaser"
   data-id=""
+  data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"
 >
   <div
     className="o-teaser__content"
@@ -3964,6 +3971,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with topStory data 1`] =
 <div
   className="o-teaser o-teaser--article o-teaser--top-story js-teaser"
   data-id=""
+  data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"
 >
   <div
     className="o-teaser__content"
@@ -4618,6 +4626,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with topStory d
 <div
   className="o-teaser o-teaser--article o-teaser--top-story o-teaser--landscape o-teaser--has-image js-teaser"
   data-id=""
+  data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"
 >
   <div
     className="o-teaser__content"

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -123,13 +123,14 @@ Feature            | Type    | Notes
 
 #### General Props
 
-Property      | Type                           | Notes
---------------|--------------------------------|-------------------------------------------
-`id`          | String                         | Content UUID
-`url`         | String                         | Canonical URL
-`relativeUrl` | String                         | URL path, will take precendence over `url`
-`type`        | String                         | Content type (article, video, etc.)
-`indicators`  | [indicators](#indicator-props) |
+Property        | Type                           | Notes
+----------------|--------------------------------|-------------------------------------------
+`id`            | String                         | Content UUID
+`url`           | String                         | Canonical URL
+`relativeUrl`   | String                         | URL path, will take precendence over `url`
+`type`          | String                         | Content type (article, video, etc.)
+`indicators`    | [indicators](#indicator-props) |
+`dataTrackable` | String                         | To add to teaser's container for analytics
 
 #### Meta Props
 

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -130,7 +130,7 @@ Property        | Type                           | Notes
 `relativeUrl`   | String                         | URL path, will take precendence over `url`
 `type`          | String                         | Content type (article, video, etc.)
 `indicators`    | [indicators](#indicator-props) |
-`dataTrackable` | String                         | To add to teaser's container for analytics
+`dataTrackable` | String                         | Tracking data for the teaser
 
 #### Meta Props
 

--- a/components/x-teaser/src/Container.jsx
+++ b/components/x-teaser/src/Container.jsx
@@ -30,7 +30,7 @@ export default (props) => {
 		.join(' ');
 
 	return (
-		<div className={`o-teaser ${classNames} js-teaser`} data-id={props.id}>
+		<div className={`o-teaser ${classNames} js-teaser`} data-id={props.id} data-trackable={props.dataTrackable}>
 			{props.children}
 		</div>
 	);

--- a/components/x-teaser/storybook/article.js
+++ b/components/x-teaser/storybook/article.js
@@ -17,6 +17,7 @@ exports.knobs = [
 	'metaPrefixText',
 	'metaSuffixText',
 	'metaLink',
+	'dataTrackable',
 	// Title
 	'showTitle',
 	'title',

--- a/components/x-teaser/storybook/content-package.js
+++ b/components/x-teaser/storybook/content-package.js
@@ -17,6 +17,7 @@ exports.knobs = [
 	// Meta
 	'showMeta',
 	'metaLink',
+	'dataTrackable',
 	// Title
 	'showTitle',
 	'title',

--- a/components/x-teaser/storybook/knobs.js
+++ b/components/x-teaser/storybook/knobs.js
@@ -66,6 +66,9 @@ module.exports = (data, { object, text, number, boolean, date, select }) => {
 		},
 		promotedSuffixText() {
 			return text('Promoted suffix text', data.promotedSuffixText, Groups.Meta);
+		},
+		dataTrackable() {
+			return text('Tracking data', data.dataTrackable, Groups.Meta);
 		}
 	};
 

--- a/components/x-teaser/storybook/opinion.js
+++ b/components/x-teaser/storybook/opinion.js
@@ -19,6 +19,7 @@ exports.knobs = [
 	'metaPrefixText',
 	'metaSuffixText',
 	'metaLink',
+	'dataTrackable',
 	// Title
 	'showTitle',
 	'title',

--- a/components/x-teaser/storybook/package-item.js
+++ b/components/x-teaser/storybook/package-item.js
@@ -20,6 +20,7 @@ exports.knobs = [
 	'metaPrefixText',
 	'metaSuffixText',
 	'metaLink',
+	'dataTrackable',
 	// Title
 	'showTitle',
 	'title',

--- a/components/x-teaser/storybook/podcast.js
+++ b/components/x-teaser/storybook/podcast.js
@@ -17,6 +17,7 @@ exports.knobs = [
 	'metaPrefixText',
 	'metaSuffixText',
 	'metaLink',
+	'dataTrackable',
 	// Title
 	'showTitle',
 	'title',

--- a/components/x-teaser/storybook/promoted.js
+++ b/components/x-teaser/storybook/promoted.js
@@ -16,6 +16,7 @@ exports.knobs = [
 	'showMeta',
 	'promotedPrefixText',
 	'promotedSuffixText',
+	'dataTrackable',
 	// Title
 	'showTitle',
 	'title',

--- a/components/x-teaser/storybook/top-story.js
+++ b/components/x-teaser/storybook/top-story.js
@@ -17,6 +17,7 @@ exports.knobs = [
 	'metaPrefixText',
 	'metaSuffixText',
 	'metaLink',
+	'dataTrackable',
 	// Title
 	'showTitle',
 	'title',

--- a/components/x-teaser/storybook/video.js
+++ b/components/x-teaser/storybook/video.js
@@ -18,6 +18,7 @@ exports.knobs = [
 	'metaPrefixText',
 	'metaSuffixText',
 	'metaLink',
+	'dataTrackable',
 	// Title
 	'showTitle',
 	'title',


### PR DESCRIPTION
This introduces another attribute to the teaser: data-trackable

There are data-trackable for various bits within the teaser (e.g. link type) however we need a data-trackable for the teaser as a whole. One example is to add details where the teaser is placed on the frontpage:

- `data-trackable="slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1"` (first top story)

- `data-trackable="slice:freeform-twocolumns;slicePos:5;layout:standaloneimage;listPos:14"` (last top story)

See https://github.com/Financial-Times/next-front-page/pull/2392 for the code there to add the above tracking. That PR would follow this PR (& release).

So, in short, this PR simply allows users of `x-teaser` to specify, optionally, a tracking value for the teaser.