### PR TITLE
Wrap x-live-blog-post title in conditional

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -20,7 +20,7 @@ const LiveBlogPost = (props) => {
 				<Timestamp publishedTimestamp={publishedTimestamp} />
 			</div>
 			{isBreakingNews && <div className={styles['live-blog-post__breaking-news']}>Breaking news</div>}
-			<h1 className={styles['live-blog-post__title']}>{title}</h1>
+			{title && <h1 className={styles['live-blog-post__title']}>{title}</h1>}
 			<div className={styles['live-blog-post__body']} dangerouslySetInnerHTML={{ __html: content }} />
 			{showShareButtons &&
 			<ShareButtons postId={postId} articleUrl={articleUrl} title={title} />}

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -24,10 +24,27 @@ const regularPost = {
 }
 
 describe('x-live-blog-post', () => {
-	it('renders title', () => {
-		const liveBlogPost = mount(<LiveBlogPost {...regularPost} />);
+	describe('title property exists', () => {
+		it('renders title', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPost} />);
 
-		expect(liveBlogPost.html()).toContain('Test title');
+			expect(liveBlogPost.html()).toContain('Test title');
+			expect(liveBlogPost.html()).toContain('</h1>');
+		});
+	});
+
+	describe('title property is missing', () => {
+		let postWithoutTitle = Object.assign({}, regularPost);
+
+		beforeAll(() => {
+			delete postWithoutTitle.title
+		});
+
+		it('skips rendering of the title', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...postWithoutTitle} />);
+
+			expect(liveBlogPost.html()).not.toContain('</h1>');
+		});
 	});
 
 	it('renders timestamp', () => {


### PR DESCRIPTION
Only render the H1 element if a title property exists.

Some old blogs posts don't have titles and this will generate empty h1 tags which will fail accessibility checks