### PR TITLE
Fix height of x-live-blog-post component

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -3,6 +3,7 @@
 @import 'o-colors/main';
 
 .live-blog-post {
+	overflow: auto;
 	border-bottom: 1px solid oColorsMix(black, paper, 20);
 	margin-top: oSpacingByName('s8');
 	color: oColorsMix(black, paper, 90);


### PR DESCRIPTION
In order for the `Element.clientHeight` property of the `x-live-blog-post` component's main container element to correctly reflect the height of all child elements, including their margins, we need to ensure that the container fully wraps all elements.

Related pull request: https://github.com/Financial-Times/next-article/pull/3929