### PR TITLE
Updates to use this component at the client side

### DIFF
--- a/components/x-live-blog-wrapper/readme.md
+++ b/components/x-live-blog-wrapper/readme.md
@@ -34,6 +34,24 @@ All `x-` components are designed to be compatible with a variety of runtimes, no
 
 [jsx-wtf]: https://jasonformat.com/wtf-is-jsx/
 
+### Client side rendering
+This component can be used at the client side. To access the actions, a function needs to be passed into the actionsRef property of the LiveBlogWrapper element.
+
+```jsx
+import { LiveBlogWrapper } from '@financial-times/x-live-blog-wrapper';
+
+const actionsRef = actions => {
+    // Use actions to insert, update and delete live blog posts
+};
+
+<LiveBlogWrapper articleUrl="https://www.ft.com/content/live_blog_package_uuid"
+    showShareButtons={true}
+    id="live-blog-wrapper"
+    posts={posts}
+    actionsRef={actionsRef}
+    />
+```
+
 ### Server side rendering and hydrating
 When rendering this component at the server side, hydration data must be rendered to the document using `Serialiser` and `HydrationData` components which are provided by `x-interaction`.
 
@@ -64,13 +82,59 @@ hydrate();
 ```
 
 ### Live updates
-This component exports a function named `listenToLiveBlogEvents` which is used for listening to client side live blog updates. This function should be called after hydrating the component if it is rendered at the server side. 
+This component exports a function named `listenToLiveBlogEvents` which is used for listening to client side live blog updates. These updates come in the form of server sent events sent by `next-live-event-api`.
+
+This function is used in slightly different ways when rendering the component at the client side vs rendering it at the server side. 
+
+#### Client side rendering
+A reference to the actions object should be passed as an argument when calling this function for a client side rendered component.
+```jsx
+import { LiveBlogWrapper, listenToLiveBlogEvents } from '@financial-times/x-live-blog-wrapper';
+
+const actionsRef = actions => {
+    listenToLiveBlogEvents({
+          liveBlogWrapperElementId: 'live-blog-wrapper', 
+          liveBlogPackageUuid: 'package-uuid',
+          actions // for client side rendered component only
+    });
+};
+
+<LiveBlogWrapper articleUrl="https://www.ft.com/content/live_blog_package_uuid"
+    showShareButtons={true}
+    id="live-blog-wrapper"
+    posts={posts}
+    actionsRef={actionsRef}
+    />
+```
+
+#### Server side rendering
+This function should be called after hydrating the component if it is rendered at the server side.
+
+Server side:
+```jsx
+import { Serialiser, HydrationData } from '@financial-times/x-interaction';
+import { LiveBlogWrapper } from '@financial-times/x-live-blog-wrapper';
+
+const serialiser = new Serialiser();
+
+<LiveBlogWrapper articleUrl="https://www.ft.com/content/live_blog_package_uuid"
+    showShareButtons={true}
+    id="live-blog-wrapper"
+    posts={posts}
+    serialiser={serialiser} />
+<HydrationData serialiser={serialiser} />
+```
+
+Client side:
 ```js
 import { hydrate } from '@financial-times/x-interaction';
 import { listenToLiveBlogEvents } from '@financial-times/x-live-blog-wrapper';
 
 hydrate();
-listenToLiveBlogEvents();
+listenToLiveBlogEvents({
+      liveBlogWrapperElementId: 'live-blog-wrapper', 
+      liveBlogPackageUuid: 'package-uuid'
+});
 ```
 
 ### Client side events
@@ -125,3 +189,4 @@ Feature          | Type   | Notes
 `articleUrl`  | String | URL of the live blog - used for sharing
 `showShareButtons`  | Boolean | if `true` displays social media sharing buttons in posts
 `posts`  | Array | Array of live blog post data
+`id` | String | **(required)** Unique id used for identifying the element in the document. 

--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -35,7 +35,7 @@ const withLiveBlogWrapperActions = withActions({
 	}
 });
 
-const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons }) => {
+const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons, id }) => {
 	const postElements = posts.map(post =>
 		<LiveBlogPost key={`live-blog-post-${post.postId}`}
 			{...post}
@@ -44,7 +44,7 @@ const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons }) => {
 	);
 
 	return (
-		<div className='x-live-blog-wrapper'>
+		<div className='x-live-blog-wrapper' data-live-blog-wrapper-id={id}>
 			{postElements}
 		</div>
 	);

--- a/components/x-live-blog-wrapper/src/LiveEventListener.js
+++ b/components/x-live-blog-wrapper/src/LiveEventListener.js
@@ -9,16 +9,36 @@ const parsePost = (event) => {
 };
 
 
-const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid }) => {
-	const wrapper = document.querySelector(`[data-x-dash-id="${liveBlogWrapperElementId}"]`);
+const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid, actions }) => {
+	const wrapper = document.querySelector(`[data-live-blog-wrapper-id="${liveBlogWrapperElementId}"]`);
 
 	const invokeAction = (action, args) => {
-		wrapper.dispatchEvent(
-			new CustomEvent(
-				'x-interaction.trigger-action',
-				{ detail: { action, args } }
-			)
-		);
+		if (actions) {
+			// When the component is rendered at the client side, we get a reference to the
+			// actions via setting the actionsRef property.
+			//
+			// In that case 'actions' argument should be passed when calling the
+			// listenToLiveBlogEvents function. We use those actions directly when that
+			// argument is defined.
+			//
+			// For more information:
+			// https://github.com/Financial-Times/x-dash/tree/master/components/x-interaction#triggering-actions-externally
+			actions[action](...args);
+		} else {
+			// When the component is rendered at the server side, we don't have a reference to
+			// the actions object. HydrationWrapper in x-interaction listens to this specific
+			// event and triggers the action supplied in the event detail.
+			//
+			// If no 'actions' argument is passed when calling listenToLiveBlogEvents
+			// function, we assume the component is rendered at the server side and trigger
+			// the actions using this method.
+			wrapper.dispatchEvent(
+				new CustomEvent(
+					'x-interaction.trigger-action',
+					{ detail: { action, args } }
+				)
+			);
+		}
 	};
 
 	const dispatchLiveUpdateEvent = (eventType, data) => {


### PR DESCRIPTION
There are two major updates to use this component at the client side:

## 1. Add a property named data-x-live-blog-wrapper-id

We need to render a property named `data-x-live-blog-wrapper-id` in the main element. This is now used to identify the element at the client side for live updates.

Previously we used `data-x-dash-id` for this purpose, but that property is only rendered when using this component with server side rendering.

## 2. Pass actions object to listenToLiveBlogEvents function

With server side rendering and hydrating at the client side, component actions can be triggered by dispatching a custom event named `x-interaction.trigger-actions`. This method can't be used with client side rendering. Therefore we need pass the `actions` object to `listenToLiveEvents` function as an argument.

`actions` object can be gathered by passing a callback function to the component in a property named actionsRef.

For more information, see https://github.com/Financial-Times/x-dash/tree/master/components/x-interaction#triggering-actions-externally

Usage of `listenToLiveEvents` function is now documented in more detail in the readme file.
