### PR TITLE
Update x-live-blog-post arguments

### DIFF
--- a/components/x-live-blog-post/readme.md
+++ b/components/x-live-blog-post/readme.md
@@ -36,12 +36,18 @@ All `x-` components are designed to be compatible with a variety of runtimes, no
 
 ### Properties
 
+Deprecated properties should only be used when data comes from the Wordpress CMS.
+Once we decommission live blogs powered by Wordpress these properties can be removed.
+
 Feature             | Type   | Notes
 --------------------|--------|----------------------------
-`postId`            | String | Unique id to reference the content
+`id`                | String | Unique id to reference the content
+`postId`            | String | Deprecated - Unique id to reference the content
 `title`             | String | Title of the content
-`content`           | String | Body of the content
+`bodyHTML`          | String | Body of the content
+`content`           | String | Deprecated - Body of the content
 `isBreakingNews`    | Bool   | When `true` displays "breaking news" tag
-`publishedTimestamp`| String | ISO timestamp of publish date
+`publishedDate`     | String | ISO timestamp of publish date
+`publishedTimestamp`| String | Deprecated - ISO timestamp of publish date
 `articleUrl`        | String | Url of the main article that includes this post
 `showShareButtons`  | Bool   | default: `false` - Shows social media share buttons when `true`

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -5,10 +5,13 @@ import styles from './LiveBlogPost.scss';
 
 const LiveBlogPost = (props) => {
 	const {
-		postId,
+		id,
+		postId, // Remove once wordpress is no longer in use
 		title,
-		content,
-		publishedTimestamp,
+		content, // Remove once wordpress is no longer in use
+		bodyHTML,
+		publishedTimestamp, // Remove once wordpress is no longer in use
+		publishedDate,
 		isBreakingNews,
 		articleUrl,
 		showShareButtons = false,
@@ -17,13 +20,13 @@ const LiveBlogPost = (props) => {
 	return (
 		<article className={styles['live-blog-post']} data-trackable="live-post">
 			<div className="live-blog-post__meta">
-				<Timestamp publishedTimestamp={publishedTimestamp} />
+				<Timestamp publishedTimestamp={publishedDate || publishedTimestamp} />
 			</div>
 			{isBreakingNews && <div className={styles['live-blog-post__breaking-news']}>Breaking news</div>}
 			{title && <h1 className={styles['live-blog-post__title']}>{title}</h1>}
-			<div className={styles['live-blog-post__body']} dangerouslySetInnerHTML={{ __html: content }} />
+			<div className={styles['live-blog-post__body']} dangerouslySetInnerHTML={{ __html: bodyHTML || content }} />
 			{showShareButtons &&
-			<ShareButtons postId={postId} articleUrl={articleUrl} title={title} />}
+			<ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
 		</article>
 	);
 };

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -3,7 +3,7 @@ const { mount } = require('@financial-times/x-test-utils/enzyme');
 
 import { LiveBlogPost } from '../LiveBlogPost';
 
-const breakingNews = {
+const breakingNewsWordpress = {
 	postId: '12345',
 	title: 'Test',
 	content: '<p>Test</p>',
@@ -13,7 +13,7 @@ const breakingNews = {
 	showShareButtons: true
 };
 
-const regularPost = {
+const regularPostWordpress = {
 	postId: '12345',
 	title: 'Test title',
 	content: '<p><i>Test body</i></p>',
@@ -23,57 +23,134 @@ const regularPost = {
 	showShareButtons: true
 }
 
+const breakingNewsSpark = {
+	id: '12345',
+	title: 'Test',
+	bodyHTML: '<p>Test</p>',
+	publishedDate: new Date().toISOString(),
+	isBreakingNews: true,
+	articleUrl: 'Https://www.ft.com',
+	showShareButtons: true
+};
+
+const regularPostSpark = {
+	id: '12345',
+	title: 'Test title',
+	bodyHTML: '<p><i>Test body</i></p>',
+	publishedDate: new Date().toISOString(),
+	isBreakingNews: false,
+	articleUrl: 'Https://www.ft.com',
+	showShareButtons: true
+}
+
 describe('x-live-blog-post', () => {
-	describe('title property exists', () => {
-		it('renders title', () => {
-			const liveBlogPost = mount(<LiveBlogPost {...regularPost} />);
+	describe('Spark cms', () => {
+		describe('title property exists', () => {
+			it('renders title', () => {
+				const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />);
 
-			expect(liveBlogPost.html()).toContain('Test title');
-			expect(liveBlogPost.html()).toContain('</h1>');
+				expect(liveBlogPost.html()).toContain('Test title');
+				expect(liveBlogPost.html()).toContain('</h1>');
+			});
+		});
+
+		describe('title property is missing', () => {
+			let postWithoutTitle = Object.assign({}, regularPostSpark);
+
+			beforeAll(() => {
+				delete postWithoutTitle.title
+			});
+
+			it('skips rendering of the title', () => {
+				const liveBlogPost = mount(<LiveBlogPost {...postWithoutTitle} />);
+
+				expect(liveBlogPost.html()).not.toContain('</h1>');
+			});
+		});
+
+		it('renders timestamp', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />);
+
+			expect(liveBlogPost.html()).toContain(regularPostSpark.publishedTimestamp);
+		});
+
+		it('renders sharing buttons', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />);
+
+			expect(liveBlogPost.html()).toContain('o-share__icon--linkedin');
+		});
+
+		it('renders breaking news tag when the post is a breaking news', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...breakingNewsSpark} />);
+
+			expect(liveBlogPost.html()).toContain('Breaking news');
+		});
+
+		it('does not render breaking news tag when the post is not breaking news', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />);
+
+			expect(liveBlogPost.html()).not.toContain('Breaking news');
+		});
+
+		it('does not escape content html', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />);
+
+			expect(liveBlogPost.html()).toContain('<p><i>Test body</i></p>');
 		});
 	});
 
-	describe('title property is missing', () => {
-		let postWithoutTitle = Object.assign({}, regularPost);
+	describe('Wordpress cms', () => {
+		describe('title property exists', () => {
+			it('renders title', () => {
+				const liveBlogPost = mount(<LiveBlogPost {...regularPostWordpress} />);
 
-		beforeAll(() => {
-			delete postWithoutTitle.title
+				expect(liveBlogPost.html()).toContain('Test title');
+				expect(liveBlogPost.html()).toContain('</h1>');
+			});
 		});
 
-		it('skips rendering of the title', () => {
-			const liveBlogPost = mount(<LiveBlogPost {...postWithoutTitle} />);
+		describe('title property is missing', () => {
+			let postWithoutTitle = Object.assign({}, regularPostWordpress);
 
-			expect(liveBlogPost.html()).not.toContain('</h1>');
+			beforeAll(() => {
+				delete postWithoutTitle.title
+			});
+
+			it('skips rendering of the title', () => {
+				const liveBlogPost = mount(<LiveBlogPost {...postWithoutTitle} />);
+
+				expect(liveBlogPost.html()).not.toContain('</h1>');
+			});
 		});
-	});
 
-	it('renders timestamp', () => {
-		const liveBlogPost = mount(<LiveBlogPost {...regularPost} />);
+		it('renders timestamp', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostWordpress} />);
 
-		expect(liveBlogPost.html()).toContain(regularPost.publishedTimestamp);
-	});
+			expect(liveBlogPost.html()).toContain(regularPostWordpress.publishedTimestamp);
+		});
 
-	it('renders sharing buttons', () => {
-		const liveBlogPost = mount(<LiveBlogPost {...regularPost} />);
+		it('renders sharing buttons', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostWordpress} />);
 
-		expect(liveBlogPost.html()).toContain('o-share__icon--linkedin');
-	});
+			expect(liveBlogPost.html()).toContain('o-share__icon--linkedin');
+		});
 
-	it('renders breaking news tag when the post is a breaking news', () => {
-		const liveBlogPost = mount(<LiveBlogPost {...breakingNews} />);
+		it('renders breaking news tag when the post is a breaking news', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...breakingNewsWordpress} />);
 
-		expect(liveBlogPost.html()).toContain('Breaking news');
-	});
+			expect(liveBlogPost.html()).toContain('Breaking news');
+		});
 
-	it('does not render breaking news tag when the post is not breaking news', () => {
-		const liveBlogPost = mount(<LiveBlogPost {...regularPost} />);
+		it('does not render breaking news tag when the post is not breaking news', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostWordpress} />);
 
-		expect(liveBlogPost.html()).not.toContain('Breaking news');
-	});
+			expect(liveBlogPost.html()).not.toContain('Breaking news');
+		});
 
-	it('does not escape content html', () => {
-		const liveBlogPost = mount(<LiveBlogPost {...regularPost} />);
+		it('does not escape content html', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostWordpress} />);
 
-		expect(liveBlogPost.html()).toContain('<p><i>Test body</i></p>');
+			expect(liveBlogPost.html()).toContain('<p><i>Test body</i></p>');
+		});
 	});
 });

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -155,7 +155,7 @@ describe('x-live-blog-post', () => {
 	});
 
 	it('adds a data-x-component attribute', () => {
-		const liveBlogPost = mount(<LiveBlogPost {...regularPost} />);
+		const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />);
 
 		expect(liveBlogPost.html()).toContain('data-x-component="live-blog-post"');
 	});

--- a/components/x-live-blog-post/storybook/index.jsx
+++ b/components/x-live-blog-post/storybook/index.jsx
@@ -4,20 +4,20 @@ import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 import { LiveBlogPost } from '../src/LiveBlogPost';
 
 const defaultProps = {
-	postId: 12345,
+	id: 12345,
 	title: 'Turkey’s virus deaths may be 25% higher than official figure',
-	content: '<p>Turkey&#x2019;s death toll from coronavirus could be as much as 25 per cent higher than the government&#x2019;s official tally, adding the country of 83m people to the raft of nations that have struggled to accurately capture the impact of the pandemic.</p>\n<p>Ankara has previously rejected suggestions that municipal data from Istanbul, the epicentre of the country&#x2019;s Covid-19 outbreak, showed that there were more deaths from the disease than reported.</p>\n<p>But an analysis of individual death records by the Financial Times raises questions about the Turkish government&#x2019;s explanation for a spike in all-cause mortality in the city of almost 16m people.</p>\n<p><a href="https://www.ft.com/content/80bb222c-b6eb-40ea-8014-563cbe9e0117" target="_blank">Read the article here</a></p>\n<p><img class="picture" src="http://blogs.ft.com/the-world/files/2020/05/istanbul_excess_morts_l.jpg"></p>',
+	bodyHTML: '<p>Turkey&#x2019;s death toll from coronavirus could be as much as 25 per cent higher than the government&#x2019;s official tally, adding the country of 83m people to the raft of nations that have struggled to accurately capture the impact of the pandemic.</p>\n<p>Ankara has previously rejected suggestions that municipal data from Istanbul, the epicentre of the country&#x2019;s Covid-19 outbreak, showed that there were more deaths from the disease than reported.</p>\n<p>But an analysis of individual death records by the Financial Times raises questions about the Turkish government&#x2019;s explanation for a spike in all-cause mortality in the city of almost 16m people.</p>\n<p><a href="https://www.ft.com/content/80bb222c-b6eb-40ea-8014-563cbe9e0117" target="_blank">Read the article here</a></p>\n<p><img class="picture" src="http://blogs.ft.com/the-world/files/2020/05/istanbul_excess_morts_l.jpg"></p>',
 	isBreakingNews: false,
-	publishedTimestamp: '2020-05-13T18:52:28.000Z',
+	publishedDate: '2020-05-13T18:52:28.000Z',
 	articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
 	showShareButtons: true,
 };
 
 const toggleTitle = () => text('Title', defaultProps.title);
 const toggleShowBreakingNews = () => boolean('Show breaking news', defaultProps.isBreakingNews);
-const toggleContent = () => text('Content', defaultProps.content);
-const togglePostId = () => text('Post ID', defaultProps.postId);
-const togglePublishedTimestamp = () => text('Published timestamp', defaultProps.publishedTimestamp);
+const toggleContent = () => text('Body HTML', defaultProps.bodyHTML);
+const togglePostId = () => text('ID', defaultProps.id);
+const togglePublishedTimestamp = () => text('Published date', defaultProps.publishedDate);
 const toggleArticleUrl = () => text('Article URL', defaultProps.articleUrl);
 const toggleShowShareButtons = () => boolean('Show share buttons', defaultProps.showShareButtons);
 
@@ -32,9 +32,9 @@ storiesOf('x-live-blog-post', module)
 		const knobs = {
 			title: toggleTitle(),
 			isBreakingNews: toggleShowBreakingNews(),
-			content: toggleContent(),
-			postId: togglePostId(),
-			publishedTimestamp: togglePublishedTimestamp(),
+			bodyHTML: toggleContent(),
+			id: togglePostId(),
+			publishedDate: togglePublishedTimestamp(),
 			articleUrl: toggleArticleUrl(),
 			showShareButtons: toggleShowShareButtons(),
 		};


### PR DESCRIPTION
This component was originally produced whilst we were receiving data
from the wordpress cms and we didn't have a schema for the Spark CMS
yet.

Whilst we are running both systems side by side I have added some new
arguments that will in the longer term replace some of the old
arguments.

I have made this change within the x-dash component to avoid having to
map property names in the systems that use this component.

This allows us to release this change as a minor release rather than a
major breaking change and then release a major when we remove these
arguments in the future.

**Argument mapping**

New argument      | Old argument 
------------------|---------------
`id`                        | `postId`
`bodyHTML`        | `content`
`publishedDate ` | `publishedTimestamp`