### PR TITLE
Add a data-x-component attribute to live blog post

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -15,7 +15,7 @@ const LiveBlogPost = (props) => {
 	} = props;
 
 	return (
-		<article className={styles['live-blog-post']} data-trackable="live-post">
+		<article className={styles['live-blog-post']} data-trackable="live-post" data-x-component="live-blog-post">
 			<div className="live-blog-post__meta">
 				<Timestamp publishedTimestamp={publishedTimestamp} />
 			</div>

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -76,4 +76,10 @@ describe('x-live-blog-post', () => {
 
 		expect(liveBlogPost.html()).toContain('<p><i>Test body</i></p>');
 	});
+
+	it('adds a data-x-component attribute', () => {
+		const liveBlogPost = mount(<LiveBlogPost {...regularPost} />);
+
+		expect(liveBlogPost.html()).toContain('data-x-component="live-blog-post"');
+	});
 });


### PR DESCRIPTION
Add a `data-component="x-live-blog-post"` to each instance of the
component which can then be used by client side to target the component.

An example for this component is that it adds share buttons but the
parent application is responsible for initilising the o-share. This
allows us to query every post and initilise o-share for that instance.