### PR TITLE
Removes snyk monitor task from CircleCI publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,6 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/x-dash
       - run:
           name: Bump version
           command: npx athloi version ${CIRCLE_TAG}


### PR DESCRIPTION
This task currently fails for an unknown reason. We have created a support ticket in snyk support and waiting for a response.

Meanwhile, to unblock release of components, we remove this task from the publish step temporarily.

Link to the failing build: https://app.circleci.com/pipelines/github/Financial-Times/x-dash/2785/workflows/32e5bc8f-6e0e-4f9c-bfb6-75a257784bdc/jobs/5806

Link to the Slack conversation with snyk support: https://financialtimes.slack.com/archives/CFZKWHHM0/p1600419469002800
