### PR TITLE
Upgrade jest-enzyme dependency ^6.0.4 -> ^7.0.2

### DIFF
--- a/packages/x-test-utils/package.json
+++ b/packages/x-test-utils/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
-    "jest-enzyme": "^6.0.4",
+    "jest-enzyme": "^7.1.2",
     "react": "^16.5.0",
     "react-dom": "^16.5.0"
   }


### PR DESCRIPTION
This PR https://github.com/Financial-Times/x-dash/pull/528 is proposing to remove the `npx snyk monitor --org=customer-products --project-name=Financial-Times/x-dash` command in the CI process until we can resolve the issue (for which we have a support ticket raised with Snyk).

If merged, it might not be a bad idea to do so where the repo is in a state that has no outstanding Snyk issues - there is currently one for which Snyk has recommended upgraded `jest-enzyme` to v7.

![app snyk io_org_financial-times_project_e1ef2b77-b6f7-4844-8b9d-4832bf8d2703](https://user-images.githubusercontent.com/10484515/93749322-a27ccf00-fbf1-11ea-9c46-170f36af4e20.png)

The breaking change in v7 of `jest-enzyme` (detailed in its [Releases](https://github.com/FormidableLabs/enzyme-matchers/releases) page) was renaming `toHaveTagName` to `toHaveDisplayName`, but this repo does not include `toHaveTagName` and so is unaffected.