### PR TITLE
Fix live-blog-post padding

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -7,6 +7,7 @@
 	border-bottom: 1px solid oColorsMix(black, paper, 20);
 	margin-top: oSpacingByName('s8');
 	color: oColorsMix(black, paper, 90);
+  	padding-bottom: oSpacingByName('s8');
 }
 
 .live-blog-post__title {
@@ -49,7 +50,6 @@
 
 .live-blog-post__share-buttons {
 	margin-top: oSpacingByName('s6');
-	margin-bottom: oSpacingByName('s8');
 }
 
 .live-blog-post__breaking-news {

--- a/components/x-live-blog-wrapper/storybook/index.jsx
+++ b/components/x-live-blog-wrapper/storybook/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { LiveBlogWrapper } from '../src/LiveBlogWrapper';
+import '../../x-live-blog-post/dist/LiveBlogPost.css';
 
 const defaultProps = {
 	message: 'Test',


### PR DESCRIPTION
The bottom padding for the live blog post used to rely on sharing buttons to be visible. In the ft-app we don't display the share buttons in this component and the padding doesn't look right.

This fixes the bottom padding regardless of displaying or hiding the share buttons.

**Before:**
<img width="383" alt="Screenshot 2020-09-21 at 11 48 20" src="https://user-images.githubusercontent.com/5130615/93759093-7f5a1b80-fc01-11ea-884b-3a70d31a423f.png">


**After:**
<img width="400" alt="Screenshot 2020-09-21 at 11 48 43" src="https://user-images.githubusercontent.com/5130615/93759112-87b25680-fc01-11ea-9861-93598594e99d.png">
