### PR TITLE
Revert "Removes snyk monitor task from CircleCI publish step"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/x-dash
       - run:
           name: Bump version
           command: npx athloi version ${CIRCLE_TAG}


### PR DESCRIPTION
#### Reference
- https://financialtimes.atlassian.net/browse/CPP-297

#### Notes
- This reverts commit `71b5bd6e480abe5210939262dc38461a963354a3` and add the `snyk` step back into the CI job.
