### PR TITLE
Add n-content-body class to live blog post body

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -27,7 +27,7 @@ const LiveBlogPost = (props) => {
 			</div>
 			{isBreakingNews && <div className={styles['live-blog-post__breaking-news']}>Breaking news</div>}
 			{title && <h1 className={styles['live-blog-post__title']}>{title}</h1>}
-			<div className={styles['live-blog-post__body']} dangerouslySetInnerHTML={{ __html: bodyHTML || content }} />
+			<div className={`${styles['live-blog-post__body']} n-content-body`} dangerouslySetInnerHTML={{ __html: bodyHTML || content }} />
 			{showShareButtons &&
 			<ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
 		</article>

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -387,7 +387,6 @@ exports[`x-teaser / snapshots renders a Hero teaser with promoted data 1`] = `
       >
         Paid post
       </span>
-       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -870,7 +869,6 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with promoted data 1`]
       >
         Paid post
       </span>
-       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -1392,7 +1390,6 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with promoted data 1`
       >
         Paid post
       </span>
-       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -1803,7 +1800,6 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with promoted data 1`] 
       >
         Paid post
       </span>
-       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -2417,7 +2413,6 @@ exports[`x-teaser / snapshots renders a Large teaser with promoted data 1`] = `
       >
         Paid post
       </span>
-       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -2864,7 +2859,6 @@ exports[`x-teaser / snapshots renders a Small teaser with promoted data 1`] = `
       >
         Paid post
       </span>
-       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -3422,7 +3416,6 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with promoted data 1`]
       >
         Paid post
       </span>
-       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -3941,7 +3934,6 @@ exports[`x-teaser / snapshots renders a TopStory teaser with promoted data 1`] =
       >
         Paid post
       </span>
-       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -4572,7 +4564,6 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with promoted d
       >
         Paid post
       </span>
-       by
       <span
         className="o-teaser__promoted-by"
       >

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -387,6 +387,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with promoted data 1`] = `
       >
         Paid post
       </span>
+       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -869,6 +870,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with promoted data 1`]
       >
         Paid post
       </span>
+       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -1390,6 +1392,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with promoted data 1`
       >
         Paid post
       </span>
+       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -1800,6 +1803,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with promoted data 1`] 
       >
         Paid post
       </span>
+       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -2413,6 +2417,7 @@ exports[`x-teaser / snapshots renders a Large teaser with promoted data 1`] = `
       >
         Paid post
       </span>
+       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -2859,6 +2864,7 @@ exports[`x-teaser / snapshots renders a Small teaser with promoted data 1`] = `
       >
         Paid post
       </span>
+       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -3416,6 +3422,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with promoted data 1`]
       >
         Paid post
       </span>
+       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -3934,6 +3941,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with promoted data 1`] =
       >
         Paid post
       </span>
+       by
       <span
         className="o-teaser__promoted-by"
       >
@@ -4564,6 +4572,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with promoted d
       >
         Paid post
       </span>
+       by
       <span
         className="o-teaser__promoted-by"
       >


### PR DESCRIPTION
Fixes live blog post body styles in the FT App.

**Before:**
<img width="374" alt="Screenshot 2020-10-07 at 11 51 38" src="https://user-images.githubusercontent.com/5130615/95322266-21c9fe00-0894-11eb-9385-266ee31bb807.png">

**After:**
<img width="370" alt="Screenshot 2020-10-07 at 11 55 16" src="https://user-images.githubusercontent.com/5130615/95322278-27bfdf00-0894-11eb-9691-9704aff33220.png">

**Before:**
<img width="370" alt="Screenshot 2020-10-07 at 11 55 46" src="https://user-images.githubusercontent.com/5130615/95322269-2393c180-0894-11eb-94e3-b4d8f2e124c9.png">

**After:**
<img width="375" alt="Screenshot 2020-10-07 at 11 56 02" src="https://user-images.githubusercontent.com/5130615/95322285-2a223900-0894-11eb-99e4-0ae81bba146d.png">




