### PR TITLE
Remove snyk from publish step in CircleCI temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,6 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/x-dash
       - run:
           name: Bump version
           command: npx athloi version ${CIRCLE_TAG}


### PR DESCRIPTION
Snyk job fails with a generic error. There is no way of debugging this.

Currently the live blogs work is blocked by this.
