### PR TITLE
Fix live blog post blockquote styling on FT App

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -27,7 +27,7 @@ const LiveBlogPost = (props) => {
 			</div>
 			{isBreakingNews && <div className={styles['live-blog-post__breaking-news']}>Breaking news</div>}
 			{title && <h1 className={styles['live-blog-post__title']}>{title}</h1>}
-			<div className={`${styles['live-blog-post__body']} n-content-body`} dangerouslySetInnerHTML={{ __html: bodyHTML || content }} />
+			<div className={`${styles['live-blog-post__body']} n-content-body article--body`} dangerouslySetInnerHTML={{ __html: bodyHTML || content }} />
 			{showShareButtons &&
 			<ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
 		</article>


### PR DESCRIPTION
We add `article--body` class to the wrapper div of live blog posts to fix the rendering of blockquotes in the FT App.

Before:
<img width="561" alt="Screenshot 2020-10-09 at 14 56 04" src="https://user-images.githubusercontent.com/5130615/95591749-a0af6a00-0a3f-11eb-8954-c2e5f60a5da6.png">

After:
<img width="575" alt="Screenshot 2020-10-09 at 14 56 24" src="https://user-images.githubusercontent.com/5130615/95591760-a311c400-0a3f-11eb-86e2-3e8a2347f9cd.png">
