### PR TITLE
Forward the ref callback to the main element that wraps live blogs

### DIFF
--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -35,7 +35,7 @@ const withLiveBlogWrapperActions = withActions({
 	}
 });
 
-const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons, id }) => {
+const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons, id, liveBlogWrapperElementRef }) => {
 	posts.sort((a, b) => {
 		const timestampA = a.publishedDate || a.publishedTimestamp;
 		const timestampB = b.publishedDate || b.publishedTimestamp;
@@ -60,7 +60,7 @@ const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons, id }) =
 	);
 
 	return (
-		<div className='x-live-blog-wrapper' data-live-blog-wrapper-id={id}>
+		<div className='x-live-blog-wrapper' data-live-blog-wrapper-id={id} ref={liveBlogWrapperElementRef}>
 			{postElements}
 		</div>
 	);


### PR DESCRIPTION
To initialise Origami components on the live blog posts, FT app needs a reference to the DOM element that wraps the posts.

We add a property named `liveBlogWrapperElementRef` to x-live-blog-wrapper for this purpose.

This will be used in the ft-app like the following:

```javascript
// live blog component in the ft-app

import { createRef } from 'preact';

constructor () {
    this.liveBlogRef = createRef();
}

render () {
    return (<LiveBlogWrapper {...props} liveBlogWrapperElementRef={this.liveBlogRef} />)
}

componentDidMount () {
    const dateElements = this.liveBlogRef.current.querySelectorAll('query-for-o-date-elements');
    // init oDate for each date element
}
```
