### PR TITLE
Add `article--content` class to live blog wrapper

### DIFF
--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -60,7 +60,10 @@ const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons, id, liv
 	);
 
 	return (
-		<div className='x-live-blog-wrapper' data-live-blog-wrapper-id={id} ref={liveBlogWrapperElementRef}>
+		<div
+			className="x-live-blog-wrapper article--content"
+			data-live-blog-wrapper-id={id}
+			ref={liveBlogWrapperElementRef}>
 			{postElements}
 		</div>
 	);


### PR DESCRIPTION
This class is required by the App. It tells `o-topper` where to place the live blog content.

`o-topper` uses grid template areas [here](https://github.com/Financial-Times/o-topper/blob/fb29a5620bda23aa4c3fb1fd81c99f341c12b337/src/scss/_grid.scss#L10) and `ft-app` sets the `grid-area` based on the `article--content` class [here](https://github.com/Financial-Times/ft-app/blob/c6d89334b325edc2dfa625b878c19ba915d0fa4a/lib/css/article/main.scss#L119).

Before
![image](https://user-images.githubusercontent.com/30316203/96013878-ab05a580-0e3d-11eb-9b86-5e900e78271e.png)

After
![image](https://user-images.githubusercontent.com/30316203/96014040-d12b4580-0e3d-11eb-9148-1ea44c07e410.png)


