### PR TITLE
Version-agnostic CircleCI container config references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ references:
   #
   # Workspace
   #
-  container_config_node10: &container_config_node10
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
       - image: circleci/node:10.13
@@ -86,7 +86,7 @@ references:
 jobs:
 
   build:
-    <<: *container_config_node10
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -106,7 +106,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node10
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -114,7 +114,7 @@ jobs:
           command: make test
 
   publish:
-    <<: *container_config_node10
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -128,7 +128,7 @@ jobs:
           command: npx athloi publish -- --access=public
 
   prerelease:
-    <<: *container_config_node10
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -153,7 +153,7 @@ jobs:
           command: npx athloi -F ${TARGET_MODULE} publish -- --access=public --tag=pre-release
 
   deploy:
-    <<: *container_config_node10
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - add_ssh_keys:


### PR DESCRIPTION
Make CircleCI container config references version-agnostic, as the references have been known to get confused with the Docker image and get updated while the actual image remains on a different version.<br/><br/>This PR was created using a nori script 🍙<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._