### PR TITLE
Add x-live-blog-post node-sass dev dependency

### DIFF
--- a/components/x-live-blog-post/package.json
+++ b/components/x-live-blog-post/package.json
@@ -22,7 +22,8 @@
   "devDependencies": {
     "@financial-times/x-test-utils": "file:../../packages/x-test-utils",
     "@financial-times/x-rollup": "file:../../packages/x-rollup",
-    "bower": "^1.8.8"
+    "bower": "^1.8.8",
+    "node-sass": "^4.9.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The [main branch CI workflow](https://app.circleci.com/pipelines/github/Financial-Times/x-dash/2991/workflows/0c38773c-6007-4b2c-bcd7-5a8c863c0b74/jobs/6201) is currently failing at the build stage owing to:

> ✖ Task failed in components/x-live-blog-post
> ✖ You need to install one of the following packages: "node-sass", "sass" in order to process SASS files

The `x-live-blog-post` component does indeed contain `.scss` files (`./src/LiveBlogPost.scss`).

All other components that include `.scss` files include either `node-sass` or `sass` as a dev dependency, but `x-live-blog-post` does include either.

This PR adds `node-sass` as a dev dependency of the `x-live-blog-post` component.

Until now the build has been passing without this dev dependency. Ostensibly, it only started failing until the Node upgrade (v12) PR: https://github.com/Financial-Times/x-dash/pull/545 in which the Node image used by CircleCI changed from `circleci/node:10.13` to `circleci/node:12`, which might somehow be responsible for the change.

However, before applying adding this dev dependency I could run `make install` locally on Node v12 which would complete the installation with no issues, which is curious, but ultimately it is clear that this component should have a `node-sass`/`sass` dev dependency, so it is worth trying that as a first attempt fix.

---

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/master/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
