### PR TITLE
Bump CircleCI cache keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,24 +22,24 @@ references:
   #
   cache_keys_root: &cache_keys_root
     keys:
-      - cache-root-v2-{{ .Branch }}-{{ checksum "./package.json" }}
+      - cache-root-v3-{{ .Branch }}-{{ checksum "./package.json" }}
 
   cache_keys_docs: &cache_keys_docs
     keys:
-      - cache-docs-v2-{{ .Branch }}-{{ checksum "./web/package.json" }}
+      - cache-docs-v3-{{ .Branch }}-{{ checksum "./web/package.json" }}
 
   #
   # Cache creation
   #
   create_cache_root: &create_cache_root
     save_cache:
-      key: cache-root-v2-{{ .Branch }}-{{ checksum "./package.json" }}
+      key: cache-root-v3-{{ .Branch }}-{{ checksum "./package.json" }}
       paths:
         - ./node_modules/
 
   create_cache_docs: &create_cache_docs
     save_cache:
-      key: cache-docs-v2-{{ .Branch }}-{{ checksum "./web/package.json" }}
+      key: cache-docs-v3-{{ .Branch }}-{{ checksum "./web/package.json" }}
       paths:
         - ./web/node_modules/
 


### PR DESCRIPTION
The [main branch CI workflow](https://app.circleci.com/pipelines/github/Financial-Times/x-dash/3002/workflows/614a78dc-7c0a-4759-8698-2eba4ff7304c/jobs/6205) is currently failing at build stage owing to:

> ERR! Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 12.x
> ERR! This usually happens because your environment has changed since running `npm install`.
> ERR! Run `npm rebuild node-sass` to download the binding for your current environment.

This issue has historically been fixed by bumping the cache keys, which is done in this PR.

---

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/master/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
