### PR TITLE
Fix bugs with triggering live blog wrapper actions

### DIFF
--- a/components/x-live-blog-wrapper/src/LiveEventListener.js
+++ b/components/x-live-blog-wrapper/src/LiveEventListener.js
@@ -31,7 +31,9 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 			// If no 'actions' argument is passed when calling listenToLiveBlogEvents
 			// function, we assume the component is rendered at the server side and trigger
 			// the actions using this method.
-			wrapper.dispatchEvent(new CustomEvent('x-interaction.trigger-action', { detail: { action, args } }))
+			wrapper.dispatchEvent(
+				new CustomEvent('x-interaction.trigger-action', { detail: { action, args }, bubbles: true })
+			)
 		}
 	}
 

--- a/components/x-live-blog-wrapper/src/LiveEventListener.js
+++ b/components/x-live-blog-wrapper/src/LiveEventListener.js
@@ -1,7 +1,7 @@
 const parsePost = (event) => {
 	const post = JSON.parse(event.data)
 
-	if (!post || !post.id) {
+	if (!post || !post.postId) {
 		return
 	}
 
@@ -98,8 +98,9 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 			return
 		}
 
-		invokeAction('deletePost', [post.id])
-		dispatchLiveUpdateEvent('LiveBlogWrapper.DELETE_POST', { postId: post.id })
+		const postId = post.postId
+		invokeAction('deletePost', [postId])
+		dispatchLiveUpdateEvent('LiveBlogWrapper.DELETE_POST', { postId })
 	})
 }
 


### PR DESCRIPTION
I am in the process of rendering live updates to FT.com. While doing this, I came across a couple of bugs which prevented us from triggering the actions to create, update and delete a post. I broke up the fixes into separate commits and explained the "why" in the commit message. But long story short, we were using the wrong property name for accessing the post ID and we weren't bubbling an event to the parent when we should have been.

We are now able to render a live update to FT.com:

![image](https://user-images.githubusercontent.com/30316203/98830176-007ba500-2432-11eb-80e1-f80527de13b7.png)
