### PR TITLE
Remove Snyk command from CircleCI publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,6 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/x-dash --prune-repeated-subdependencies
       - run:
           name: Bump version
           command: npx athloi version ${CIRCLE_TAG}


### PR DESCRIPTION
A Snyk error is preventing me from releasing a [new version of `x-dash`](https://github.com/Financial-Times/x-dash/pull/551). We thought this error was resolved but it looks not to be the case. Andy has reported the issue to Snyk again and we are waiting on them. Because we don't know if there will be a fix soon, I am going to remove the Snyk command, publish a new release and then re-add the Snyk command.

See more info here: https://financialtimes.slack.com/archives/C3TJ6KXEU/p1605111138223300