### PR TITLE
CI-392 Fix bug with accessing post ID

### DIFF
--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -14,7 +14,7 @@ const withLiveBlogWrapperActions = withActions({
 
 	updatePost(updated) {
 		return (props) => {
-			const index = props.posts.findIndex((post) => post.id === updated.id)
+			const index = props.posts.findIndex((post) => post.id === updated.postId)
 			if (index >= 0) {
 				props.posts[index] = updated
 			}

--- a/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
+++ b/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
@@ -72,7 +72,7 @@ describe('liveBlogWrapperActions', () => {
 
 	it('updates a post', () => {
 		const updatedPost2 = {
-			id: '2',
+			postId: '2',
 			title: 'Updated title'
 		}
 


### PR DESCRIPTION
I forgot to update how we access post ID in this commit: https://github.com/Financial-Times/x-dash/pull/551/commits/be96eb0e44b6b0ef70a3112716fc768b302daf36.

Essentially, `next-live-blog-trigger` renamed the post ID property from `id` to `postId` which means when we receive the event, we need to access the post id as `updated.postId`. 

I tested this out in `next-article` and the most recent blog post was successfully deleted.

Before
![image](https://user-images.githubusercontent.com/30316203/99261154-3c3cb300-2814-11eb-8cbd-561f34b42b64.png)

After
![image](https://user-images.githubusercontent.com/30316203/99261236-54accd80-2814-11eb-817a-04e068cc58df.png)
