### PR TITLE
Remove Snyk monitor command from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,6 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/x-dash --prune-repeated-subdependencies
       - run:
           name: Bump version
           command: npx athloi version ${CIRCLE_TAG}
@@ -139,7 +138,6 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/x-dash --prune-repeated-subdependencies
       - run:
           name: Extract tag name and version number
           command: |


### PR DESCRIPTION
This Snyk command is not currently doing anything (in either of its two appearances). I learned from the Snyk Support Team that the `snyk monitor` command only looks at `dependencies`, not `devDependencies`. The `package.json` in the root dir of this repo only has `devDependencies` and so the command fails because it cannot find any `dependencies` to examine.

So there is no net change from removing this command, other than CI builds will no longer fail owing to this Snyk-related failure.

I am currently corresponding with the Snyk Support Team to get a command that will monitor all the `package.json` files in subdirectories (which would be an increase in scope of what the existing code sought to achieve), but ignore the one in the root dir given the problems it is causing us, as well as ignoring the one in the `/private` directory which also fails because its node_modules are not installed as the others are. This is how far I have got:

`npx snyk monitor --org=customer-products --all-projects --exclude=private`

Somehow this is still scoped exclusively to `x-dash` despite not declaring `--project-name=Financial-Times/x-dash`, which is useful given that the combination of the `project-name` and `all-projects` flags is currently not supported.

However, this command still tries to monitor the root dir `package.json` (and so fails the CI workflow on that basis). I have tried the following to exclude that file too, but all these attempts failed for the described reasons:
- `--exclude=.,private` results in `Internal error (reference: 3b3cea61-008d-4b5e-8288-ae84875fc843)` (i.e. the original error that caused us to start removing this Snyk command)

- `--exclude=package.json,private` does not throw an error but it is only monitoring one of the subdirectories' package.json (and it seems relevant that this is the only subdirectory that has a package-lock.json, indicating that this command ignores all `package.json` files and only examines `package-lock.json` files).

- `--exclude=./package.json,private` results in error `The --exclude argument must be a comma separated list of directory names and cannot contain a path.`

I am waiting to hear back from the Snyk Support Team as to how to exclude the root dir `package.json` file.

---

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/master/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
