### PR TITLE
Fix URL error

### DIFF
--- a/components/x-teaser/src/concerns/image-service.js
+++ b/components/x-teaser/src/concerns/image-service.js
@@ -1,4 +1,3 @@
-const { URL, URLSearchParams } = require('url')
 const BASE_URL = 'https://www.ft.com/__origami/service/image/v2/images/raw'
 const OPTIONS = { source: 'next', fit: 'scale-down', dpr: 2 }
 


### PR DESCRIPTION
When attempting to view `x-teaser` in Storybook, I came across a `TypeError: URL is not a constructor` on the page and I see the same error when running `next-front-page` locally. When I remove this line of code, the error disappears and I'm able to view the `x-teaser` stories.

**Storybook**
![image](https://user-images.githubusercontent.com/30316203/100641131-fb25c200-332e-11eb-8f39-bda9545e672b.png)

**local.ft.com:5050**
![image](https://user-images.githubusercontent.com/30316203/100641167-04af2a00-332f-11eb-82e2-99fc49266cef.png)

This line of code was added 2 months ago to restore compatibility with Node v6, see https://github.com/Financial-Times/x-dash/commit/24984503bb33142d544eaeb0fba4751310c21d4b.

Not sure if removing this line of code is the best fix so feedback would be appreciated!