### PR TITLE
Give the x-live-blog-wrapper component a displayName - CI-423

### DIFF
--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -68,6 +68,10 @@ const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons, id, liv
 	)
 }
 
+// A displayName is required for this component
+// This enables the component to work with x-interaction
+BaseLiveBlogWrapper.displayName = 'BaseLiveBlogWrapper'
+
 const LiveBlogWrapper = withLiveBlogWrapperActions(BaseLiveBlogWrapper)
 
 export { LiveBlogWrapper, listenToLiveBlogEvents }

--- a/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
+++ b/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
@@ -24,6 +24,10 @@ const post2 = {
 }
 
 describe('x-live-blog-wrapper', () => {
+	it('has a displayName', () => {
+		expect(LiveBlogWrapper.displayName).toContain('BaseLiveBlogWrapper')
+	})
+
 	it('renders initial posts', () => {
 		const posts = [post1, post2]
 		const liveBlogWrapper = mount(<LiveBlogWrapper posts={posts} />)


### PR DESCRIPTION
Without this the component wouldn't work with x-interaction when the code is transpiled for production.

It was working with development code I believe because it was relying in on the standard Javascript name property of the function.

When the code was transpiled for production the functions were minified the function names were changed or made anonymous.

By hardcoding this displayName as a string it allows x-interaction to register the component and reference it by name.
