### PR TITLE
Allow `next-live-event-api` endpoint URL to be overriden

### DIFF
--- a/components/x-live-blog-wrapper/readme.md
+++ b/components/x-live-blog-wrapper/readme.md
@@ -190,3 +190,14 @@ Feature          | Type   | Notes
 `showShareButtons`  | Boolean | if `true` displays social media sharing buttons in posts
 `posts`  | Array | Array of live blog post data
 `id` | String | **(required)** Unique id used for identifying the element in the document.
+
+
+## Configuring the `next-live-event-api` endpoint URL.
+
+If you want to configure the URL for `next-live-event-api`, add the following plugin in your Webpack configuration file:
+
+```javascript
+new webpack.DefinePlugin({
+      LIVE_EVENT_API_URL: JSON.stringify('http://localhost:3003')
+})
+```

--- a/components/x-live-blog-wrapper/src/LiveEventListener.js
+++ b/components/x-live-blog-wrapper/src/LiveEventListener.js
@@ -67,7 +67,11 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 		window.setTimeout(() => wrapper.dispatchEvent(new CustomEvent(eventType, { detail: data })), 0)
 	}
 
-	const eventSource = new EventSource(`https://next-live-event.ft.com/v2/liveblog/${liveBlogPackageUuid}`, {
+	// Allow `next-live-event-api` endpoint URL to be set in development.
+	const baseUrl =
+		typeof LIVE_EVENT_API_URL !== 'undefined' ? LIVE_EVENT_API_URL : 'https://next-live-event.ft.com' // eslint-disable-line no-undef
+
+	const eventSource = new EventSource(`${baseUrl}/v2/liveblog/${liveBlogPackageUuid}`, {
 		withCredentials: true
 	})
 


### PR DESCRIPTION
Make it easier for us to test the component locally.

I tested this locally in `next-article` by building the component locally and configuring the plugin as is documented.