### PR TITLE
CPP-351 Editing x-dash components does not update Storybook

### DIFF
--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -1,4 +1,4 @@
-@import 'src/lib/variables';
+@import './lib/variables';
 @import 'o-normalise/main';
 
 $o-buttons-is-silent: true;

--- a/components/x-gift-article/src/MobileShareButtons.scss
+++ b/components/x-gift-article/src/MobileShareButtons.scss
@@ -1,4 +1,4 @@
-@import 'src/lib/variables';
+@import './lib/variables';
 
 @mixin shareButton($social-media-name, $background-color) {
 	&,

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -1,4 +1,4 @@
-const { GiftArticle } = require('../dist/GiftArticle.cjs')
+import { GiftArticle } from '../src/GiftArticle'
 import fetchMock from 'fetch-mock'
 import React from 'react'
 import { Helmet } from 'react-helmet'

--- a/components/x-podcast-launchers/storybook/index.jsx
+++ b/components/x-podcast-launchers/storybook/index.jsx
@@ -1,4 +1,4 @@
-const { PodcastLaunchers } = require('../dist/PodcastLaunchers.cjs')
+import { PodcastLaunchers } from '../src/PodcastLaunchers'
 const { brand } = require('@financial-times/n-concept-ids')
 import React from 'react'
 import { Helmet } from 'react-helmet'

--- a/components/x-podcast-launchers/storybook/index.jsx
+++ b/components/x-podcast-launchers/storybook/index.jsx
@@ -1,5 +1,5 @@
 import { PodcastLaunchers } from '../src/PodcastLaunchers'
-const { brand } = require('@financial-times/n-concept-ids')
+import { brand } from '@financial-times/n-concept-ids'
 import React from 'react'
 import { Helmet } from 'react-helmet'
 import BuildService from '../../../.storybook/build-service'

--- a/components/x-styling-demo/storybook/index.jsx
+++ b/components/x-styling-demo/storybook/index.jsx
@@ -1,4 +1,4 @@
-const { Button } = require('../dist/Button.cjs')
+import { Button } from '../src/Button'
 import React from 'react'
 import { Helmet } from 'react-helmet'
 

--- a/components/x-teaser-timeline/bower.json
+++ b/components/x-teaser-timeline/bower.json
@@ -3,8 +3,8 @@
   "private": true,
   "main": "dist/TeaserTimeline.es5.js",
   "dependencies": {
-    "o-colors": "^4.7.2",
-    "o-grid": "4.4.4",
-    "o-typography": "^5.7.5"
+    "o-typography": "^6.4.5",
+    "o-colors": "^5.3.0",
+    "o-grid": "^5.2.9"
   }
 }

--- a/components/x-teaser-timeline/src/TeaserTimeline.scss
+++ b/components/x-teaser-timeline/src/TeaserTimeline.scss
@@ -46,7 +46,7 @@
 .item {
 	display: flex;
 	justify-content: space-between;
-	border-bottom: 1px solid oColorsGetPaletteColor('black-20');
+	border-bottom: 1px solid oColorsByName('black-20');
 	margin-bottom: oSpacingByName('s2');
 
 	:global {

--- a/components/x-teaser-timeline/src/TeaserTimeline.scss
+++ b/components/x-teaser-timeline/src/TeaserTimeline.scss
@@ -20,8 +20,9 @@
 }
 
 .itemGroup__heading {
-	@include oTypographySansBold($scale: 1);
-	@include oTypographyMargin($top: 2, $bottom: 2);
+	@include oTypographySans($scale: 1, $weight: 'bold');
+	margin-top: oSpacingByName('s2');
+	margin-bottom: oSpacingByName('s2');
 
 	@include oGridRespondTo($from: M) {
 		grid-area: heading;
@@ -33,7 +34,7 @@
 .itemGroup__items {
 	list-style-type: none;
 	padding: 0;
-	@include oTypographyMargin($top: 2);
+	margin-top: oSpacingByName('s2');
 
 	@include oGridRespondTo($from: M) {
 		grid-area: articles;
@@ -46,12 +47,12 @@
 	display: flex;
 	justify-content: space-between;
 	border-bottom: 1px solid oColorsGetPaletteColor('black-20');
-	@include oTypographyMargin($bottom: 2);
+	margin-bottom: oSpacingByName('s2');
 
 	:global {
 		.o-teaser--timeline-teaser {
 			border-bottom: 0;
-			@include oTypographyPadding($bottom: 0);
+			padding-bottom: 0;
 		}
 	}
 }

--- a/components/x-teaser-timeline/storybook/index.jsx
+++ b/components/x-teaser-timeline/storybook/index.jsx
@@ -1,5 +1,5 @@
-const { TeaserTimeline } = require('../dist/TeaserTimeline.cjs')
 import React from 'react'
+import { TeaserTimeline } from '../src/TeaserTimeline'
 import { Helmet } from 'react-helmet'
 import BuildService from '../../../.storybook/build-service'
 const { args, argTypes } = require('./timeline')

--- a/components/x-teaser/storybook/index.jsx
+++ b/components/x-teaser/storybook/index.jsx
@@ -1,4 +1,4 @@
-const { Teaser } = require('../')
+import { Teaser } from '../src/Teaser'
 import React from 'react'
 import BuildService from '../../../.storybook/build-service'
 


### PR DESCRIPTION
[Ticket CPP-351](https://financialtimes.atlassian.net/browse/CPP-351)

When Webpack rebuilds on changes it checks files ending with `.jsx`, since some Storybook stories were importing components from `/dist` files ending in `.cjs`, these were not getting rebuilt. 

Changing Storybook so that it imports the `.jsx` components instead, made some build errors get thrown, which were fixed by upgrading `o-typography`, `o-grid`, `o-colors`. The changes in `TeaserTimeline.scss` are related to these version upgrades.