### PR TITLE
Update breaking news label based on Spark data

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -12,10 +12,13 @@ const LiveBlogPost = (props) => {
 		bodyHTML,
 		publishedTimestamp, // Remove once wordpress is no longer in use
 		publishedDate,
-		isBreakingNews,
+		isBreakingNews, // Remove once wordpress is no longer in use
+		standout = {},
 		articleUrl,
 		showShareButtons = false
 	} = props
+
+	const showBreakingNewsLabel = standout.breakingNews || isBreakingNews
 
 	return (
 		<article
@@ -26,7 +29,7 @@ const LiveBlogPost = (props) => {
 			<div className="live-blog-post__meta">
 				<Timestamp publishedTimestamp={publishedDate || publishedTimestamp} />
 			</div>
-			{isBreakingNews && <div className={styles['live-blog-post__breaking-news']}>Breaking news</div>}
+			{showBreakingNewsLabel && <div className={styles['live-blog-post__breaking-news']}>Breaking news</div>}
 			{title && <h1 className={styles['live-blog-post__title']}>{title}</h1>}
 			<div
 				className={`${styles['live-blog-post__body']} n-content-body article--body`}

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -28,7 +28,9 @@ const breakingNewsSpark = {
 	title: 'Test',
 	bodyHTML: '<p>Test</p>',
 	publishedDate: new Date().toISOString(),
-	isBreakingNews: true,
+	standout: {
+		breakingNews: true
+	},
 	articleUrl: 'Https://www.ft.com',
 	showShareButtons: true
 }

--- a/components/x-live-blog-post/storybook/index.jsx
+++ b/components/x-live-blog-post/storybook/index.jsx
@@ -15,6 +15,9 @@ export const ContentBody = (args) => {
 ContentBody.args = {
 	title: 'Turkey’s virus deaths may be 25% higher than official figure',
 	isBreakingNews: false,
+	standout: {
+		breakingNews: false
+	},
 	bodyHTML:
 		'<p>Turkey&#x2019;s death toll from coronavirus could be as much as 25 per cent higher than the government&#x2019;s official tally, adding the country of 83m people to the raft of nations that have struggled to accurately capture the impact of the pandemic.</p>\n<p>Ankara has previously rejected suggestions that municipal data from Istanbul, the epicentre of the country&#x2019;s Covid-19 outbreak, showed that there were more deaths from the disease than reported.</p>\n<p>But an analysis of individual death records by the Financial Times raises questions about the Turkish government&#x2019;s explanation for a spike in all-cause mortality in the city of almost 16m people.</p>\n<p><a href="https://www.ft.com/content/80bb222c-b6eb-40ea-8014-563cbe9e0117" target="_blank">Read the article here</a></p>\n<p><img class="picture" src="http://blogs.ft.com/the-world/files/2020/05/istanbul_excess_morts_l.jpg"></p>',
 	id: '12345',


### PR DESCRIPTION
The data we get from Spark and UPP for breaking news is `standout.breakingNews`
This change uses that property to render the breaking news label.

For now it also still uses the `isBreakingNews` property that is used for wordpress data.

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/master/contribution.md) before submitting.
