### PR TITLE
CI-422 Render live blog post author

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -15,7 +15,8 @@ const LiveBlogPost = (props) => {
 		isBreakingNews, // Remove once wordpress is no longer in use
 		standout = {},
 		articleUrl,
-		showShareButtons = false
+		showShareButtons = false,
+		byline
 	} = props
 
 	const showBreakingNewsLabel = standout.breakingNews || isBreakingNews
@@ -31,6 +32,7 @@ const LiveBlogPost = (props) => {
 			</div>
 			{showBreakingNewsLabel && <div className={styles['live-blog-post__breaking-news']}>Breaking news</div>}
 			{title && <h1 className={styles['live-blog-post__title']}>{title}</h1>}
+			{byline && <p className={styles['live-blog-post__byline']}>{byline}</p>}
 			<div
 				className={`${styles['live-blog-post__body']} n-content-body article--body`}
 				dangerouslySetInnerHTML={{ __html: bodyHTML || content }}

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -13,10 +13,18 @@
 .live-blog-post__title {
 	@include oTypographyDisplay($scale: 5);
 	margin-top: oSpacingByName('s4');
+	margin-bottom: oSpacingByName('s2');
 }
 
 .live-blog-post__breaking-news + .live-blog-post__title {
 	margin-top: oSpacingByName('s1');
+}
+
+.live-blog-post__byline {
+	@include oTypographySans($scale: -1, $weight: 'semibold');
+	color: oColorsByName('slate');
+	margin-top: oSpacingByName('s2');
+	margin-bottom: oSpacingByName('s4');
 }
 
 .live-blog-post__body {

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -52,6 +52,7 @@
 	display: block;
 	width: oSpacingByName('s4');
 	border-bottom: 4px solid oColorsMix(black, paper, 90);
+	padding-top: oSpacingByName('s1');
 }
 
 .live-blog-post__share-buttons {

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -13,7 +13,7 @@
 .live-blog-post__title {
 	@include oTypographyDisplay($scale: 5);
 	margin-top: oSpacingByName('s4');
-	margin-bottom: oSpacingByName('s2');
+	margin-bottom: oSpacingByName('s1');
 }
 
 .live-blog-post__breaking-news + .live-blog-post__title {
@@ -22,9 +22,9 @@
 
 .live-blog-post__byline {
 	@include oTypographySans($scale: -1, $weight: 'semibold');
-	color: oColorsByName('slate');
-	margin-top: oSpacingByName('s2');
-	margin-bottom: oSpacingByName('s4');
+	color: oColorsMix(black, paper, 70);
+	margin-top: oSpacingByName('s1');
+	margin-bottom: 20px;
 }
 
 .live-blog-post__body {

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -37,14 +37,12 @@
 }
 
 .live-blog-post__timestamp {
-	@include oTypographySans($scale:0, $weight: 'semibold');
-	font-size: 14px;
+	@include oTypographySans($scale: -1, $weight: 'semibold');
 	text-transform: uppercase;
 }
 
 .live-blog-post__timestamp-exact-time {
-	@include oTypographySans($scale:0, $weight: 'light');
-	font-size: 14px;
+	@include oTypographySans($scale: -1, $weight: 'light');
 	color: oColorsMix(black, paper, 60);
 	padding-left: oSpacingByName('s2');
 }
@@ -61,8 +59,7 @@
 }
 
 .live-blog-post__breaking-news {
-	@include oTypographySans($scale:0);
-	font-size: 12px;
+	@include oTypographySans($scale: -2);
 	color: oColorsByName('crimson');
 	text-transform: uppercase;
 	margin-top: oSpacingByName('s4');

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -7,7 +7,7 @@
 	border-bottom: 1px solid oColorsMix(black, paper, 20);
 	margin-top: oSpacingByName('s8');
 	color: oColorsMix(black, paper, 90);
-  	padding-bottom: oSpacingByName('s8');
+	padding-bottom: oSpacingByName('s8');
 }
 
 .live-blog-post__title {

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -26,6 +26,7 @@ const regularPostWordpress = {
 const breakingNewsSpark = {
 	id: '12345',
 	title: 'Test',
+	byline: 'Test author',
 	bodyHTML: '<p>Test</p>',
 	publishedDate: new Date().toISOString(),
 	standout: {
@@ -38,6 +39,7 @@ const breakingNewsSpark = {
 const regularPostSpark = {
 	id: '12345',
 	title: 'Test title',
+	byline: 'Test author',
 	bodyHTML: '<p><i>Test body</i></p>',
 	publishedDate: new Date().toISOString(),
 	isBreakingNews: false,
@@ -74,6 +76,12 @@ describe('x-live-blog-post', () => {
 			const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />)
 
 			expect(liveBlogPost.html()).toContain(regularPostSpark.publishedTimestamp)
+		})
+
+		it('renders byline', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />)
+
+			expect(liveBlogPost.html()).toContain('Test author')
 		})
 
 		it('renders sharing buttons', () => {

--- a/components/x-live-blog-post/storybook/index.jsx
+++ b/components/x-live-blog-post/storybook/index.jsx
@@ -14,6 +14,7 @@ export const ContentBody = (args) => {
 
 ContentBody.args = {
 	title: 'Turkey’s virus deaths may be 25% higher than official figure',
+	byline: 'George Russell',
 	isBreakingNews: false,
 	standout: {
 		breakingNews: false


### PR DESCRIPTION
In Wordpress, the post author was part of the main body HTML. With Spark, we now have a `byline` field which is used to enter a post author. 

The `byline` property is passed down from `next-article` and `ft-app` to `x-live-blog-wrapper`. Then `x-live-blog-wrapper` passes it down to `x-live-blog-post` which is responsible for rendering the post author.

**FT.com**

I had to do some work in `next-article` to make these changes work, see https://github.com/Financial-Times/next-article/pull/4101.

**App**

I had to do some work in `ft-app-api` to make these changes work, see https://github.com/Financial-Times/ft-app-api/pull/295.

![image](https://user-images.githubusercontent.com/30316203/103632310-05456c80-4f3c-11eb-8d3c-8fbf48895cdf.png)