### PR TITLE
Revert "CPP-344 use ci helper to publish to github pages"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,8 +171,8 @@ jobs:
           name: Build documentation website
           command: npm run build-docs
       - run:
-          name: shared-helper / publish-github-pages
-          command: .circleci/shared-helpers/helper-publish-github-pages
+          name: Publish GitHub Pages
+          command: ./private/scripts/gh-pages
 
 workflows:
 

--- a/private/scripts/gh-pages
+++ b/private/scripts/gh-pages
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+TARGET_DIR=web/public/*
+TARGET_BRANCH=gh-pages
+TEMP_DIR=tmp
+
+# Set error handling
+set -eu -o pipefail
+
+# Set GitHub user information (the email must match the SSH key provided to Circle)
+git config --global user.email $GITHUB_EMAIL
+git config --global user.name $GITHUB_NAME
+
+# HACK: Add GitHub to known hosts to avoid an interactive prompt when cloning over SSH
+mkdir -p ~/.ssh
+ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
+# Clone only the branch we need so we don't download all of the project history
+git clone $CIRCLE_REPOSITORY_URL $TEMP_DIR --single-branch --branch $TARGET_BRANCH
+
+# Remove all of the files, -q prevents logging every filename
+cd $TEMP_DIR
+git rm -rf .
+cd ..
+
+# Copy contents of target directory to the deployment directory
+cp -R -L $TARGET_DIR $TEMP_DIR
+
+# Copy CI config (which should instruct Circle to ignore this branch)
+cp -r .circleci $TEMP_DIR
+
+cd $TEMP_DIR
+
+# Stage and commit all of the files
+git add -A &> /dev/null
+git commit -m "Automated deployment to GitHub Pages: ${CIRCLE_SHA1}" --allow-empty
+
+# Push to the target branch, staying quiet unless something goes wrong
+git push -q origin $TARGET_BRANCH


### PR DESCRIPTION
Reverts Financial-Times/x-dash#571

[Build fails with permission denied](https://app.circleci.com/pipelines/github/Financial-Times/x-dash/3299/workflows/e4981465-7de0-4607-b179-6e485d00472e/jobs/6631), my guess is that it has something to do with github configuration in the script