### PR TITLE
CI-479: Check for existing posts before inserting new ones.

### DIFF
--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -2,21 +2,28 @@ import { h } from '@financial-times/x-engine'
 import { LiveBlogPost } from '@financial-times/x-live-blog-post'
 import { withActions } from '@financial-times/x-interaction'
 import { listenToLiveBlogEvents } from './LiveEventListener'
+import { dispatchEvent } from './dispatchEvent'
 
 const withLiveBlogWrapperActions = withActions({
-	insertPost(post) {
+	insertPost(newPost) {
 		return (props) => {
-			props.posts.unshift(post)
+			// Check if the new post already exists in the page, so we don't end up with duplicates.
+			const newPostExists = props.posts.find((post) => post.id === newPost.id)
+			if (!newPostExists) {
+				props.posts.unshift(newPost)
+				dispatchEvent('LiveBlogWrapper.INSERT_POST', { post: newPost })
+			}
 
 			return props
 		}
 	},
 
-	updatePost(updated) {
+	updatePost(updatedPost) {
 		return (props) => {
-			const index = props.posts.findIndex((post) => post.id === updated.postId)
+			const index = props.posts.findIndex((post) => post.id === updatedPost.id)
 			if (index >= 0) {
-				props.posts[index] = updated
+				props.posts[index] = updatedPost
+				dispatchEvent('LiveBlogWrapper.UPDATE_POST', { post: updatedPost })
 			}
 
 			return props
@@ -28,6 +35,7 @@ const withLiveBlogWrapperActions = withActions({
 			const index = props.posts.findIndex((post) => post.id === postId)
 			if (index >= 0) {
 				props.posts.splice(index, 1)
+				dispatchEvent('LiveBlogWrapper.DELETE_POST', { postId })
 			}
 
 			return props

--- a/components/x-live-blog-wrapper/src/LiveEventListener.js
+++ b/components/x-live-blog-wrapper/src/LiveEventListener.js
@@ -37,36 +37,6 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 		}
 	}
 
-	const dispatchLiveUpdateEvent = (eventType, data) => {
-		/*
-		We dispatch live update events to notify the consuming app about added / updated posts.
-
-		Consuming app uses these events to execute tasks like initialising Origami components
-		on the updated elements.
-
-		We want the rendering of the updates in the DOM to finish before dispatching this event,
-		because the consumer needs to reference the updated DOM elements.
-
-		If we dispatch the event in the same event loop with DOM element updates, consumer app
-		will handle the event before the updates are complete.
-
-		window.setTimeout(fn, 0) will defer the execution of the inner function until the
-		current event loop completes, which is enough time for the DOM updates to finish.
-
-		More information can be found in MDN setTimeout documentation. Please refer to
-		"Late timeouts" heading in this page:
-		https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Late_timeouts
-
-		> ... the timeout can also fire later when the page (or the OS/browser itself) is busy
-		> with other tasks. One important case to note is that the function or code snippet
-		> cannot be executed until the thread that called setTimeout() has terminated.
-		> ...
-		> This is because even though setTimeout was called with a delay of zero, it's placed on
-		> a queue and scheduled to run at the next opportunity; not immediately.
-		 */
-		window.setTimeout(() => wrapper.dispatchEvent(new CustomEvent(eventType, { detail: data })), 0)
-	}
-
 	// Allow `next-live-event-api` endpoint URL to be set in development.
 	const baseUrl =
 		typeof LIVE_EVENT_API_URL !== 'undefined' ? LIVE_EVENT_API_URL : 'https://next-live-event.ft.com' // eslint-disable-line no-undef
@@ -83,7 +53,6 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 		}
 
 		invokeAction('insertPost', [post])
-		dispatchLiveUpdateEvent('LiveBlogWrapper.INSERT_POST', { post })
 	})
 
 	eventSource.addEventListener('update-post', (event) => {
@@ -94,7 +63,6 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 		}
 
 		invokeAction('updatePost', [post])
-		dispatchLiveUpdateEvent('LiveBlogWrapper.UPDATE_POST', { post })
 	})
 
 	eventSource.addEventListener('delete-post', (event) => {
@@ -104,9 +72,7 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 			return
 		}
 
-		const postId = post.postId
-		invokeAction('deletePost', [postId])
-		dispatchLiveUpdateEvent('LiveBlogWrapper.DELETE_POST', { postId })
+		invokeAction('deletePost', [post.id])
 	})
 }
 

--- a/components/x-live-blog-wrapper/src/dispatchEvent.js
+++ b/components/x-live-blog-wrapper/src/dispatchEvent.js
@@ -1,0 +1,31 @@
+const dispatchEvent = (eventType, data) => {
+	/*
+	We dispatch live update events to notify the consuming app about added / updated posts.
+
+	Consuming app uses these events to execute tasks like initialising Origami components
+	on the updated elements.
+
+	We want the rendering of the updates in the DOM to finish before dispatching this event,
+	because the consumer needs to reference the updated DOM elements.
+
+	If we dispatch the event in the same event loop with DOM element updates, consumer app
+	will handle the event before the updates are complete.
+
+	window.setTimeout(fn, 0) will defer the execution of the inner function until the
+	current event loop completes, which is enough time for the DOM updates to finish.
+
+	More information can be found in MDN setTimeout documentation. Please refer to
+	"Late timeouts" heading in this page:
+	https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Late_timeouts
+
+	> ... the timeout can also fire later when the page (or the OS/browser itself) is busy
+	> with other tasks. One important case to note is that the function or code snippet
+	> cannot be executed until the thread that called setTimeout() has terminated.
+	> ...
+	> This is because even though setTimeout was called with a delay of zero, it's placed on
+	> a queue and scheduled to run at the next opportunity; not immediately.
+		*/
+	window.setTimeout(() => document.dispatchEvent(new CustomEvent(eventType, { detail: data })), 0)
+}
+
+export { dispatchEvent }


### PR DESCRIPTION
We want to make sure that if a new post is received that has an id of one that already exists that we don't add it again, this will stop the user seeing multiples of the same post.

This makes this logic most resilient against issues upstream, for example the event stream sending multiple inserts, or inserts being sent due to race conditions.