### PR TITLE
Check for existence of image as soon as image teaser function starts

### DIFF
--- a/components/x-teaser/__fixtures__/article-with-missing-image-url.json
+++ b/components/x-teaser/__fixtures__/article-with-missing-image-url.json
@@ -1,0 +1,34 @@
+{
+  "type": "article",
+  "id": "",
+  "url": "#",
+  "title": "Inside charity fundraiser where hostesses are put on show",
+  "altTitle": "Men Only, the charity fundraiser with hostesses on show",
+  "standfirst": "FT investigation finds groping and sexual harassment at secretive black-tie dinner",
+  "altStandfirst": "Groping and sexual harassment at black-tie dinner charity event",
+  "publishedDate": "2018-01-23T15:07:00.000Z",
+  "firstPublishedDate": "2018-01-23T13:53:00.000Z",
+  "metaPrefixText": "",
+  "metaSuffixText": "",
+  "metaLink": {
+    "url": "#",
+    "prefLabel": "Sexual misconduct allegations"
+  },
+  "metaAltLink": {
+    "url": "#",
+    "prefLabel": "FT Investigations"
+  },
+  "image": {
+    "width": 2048,
+    "height": 1152
+  },
+  "indicators": {
+    "isEditorsChoice": true
+  },
+  "status": "",
+  "headshotTint": "",
+  "accessLevel": "free",
+  "theme": "",
+  "parentTheme": "",
+  "modifiers": ""
+}

--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -120,6 +120,41 @@ exports[`x-teaser / snapshots renders a Hero teaser with article-with-data-image
 </div>
 `;
 
+exports[`x-teaser / snapshots renders a Hero teaser with article-with-missing-image-url data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--hero o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`x-teaser / snapshots renders a Hero teaser with contentPackage data 1`] = `
 <div
   className="o-teaser o-teaser--package o-teaser--hero o-teaser--centre o-teaser--has-image js-teaser"
@@ -592,6 +627,53 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with article data 1`] 
 `;
 
 exports[`x-teaser / snapshots renders a HeroNarrow teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--hero o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
+  </div>
+</div>
+`;
+
+exports[`x-teaser / snapshots renders a HeroNarrow teaser with article-with-missing-image-url data 1`] = `
 <div
   className="o-teaser o-teaser--article o-teaser--hero o-teaser--highlight js-teaser"
   data-id=""
@@ -1116,6 +1198,41 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with article-with-dat
 </div>
 `;
 
+exports[`x-teaser / snapshots renders a HeroOverlay teaser with article-with-missing-image-url data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--hero o-teaser--hero-image o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`x-teaser / snapshots renders a HeroOverlay teaser with contentPackage data 1`] = `
 <div
   className="o-teaser o-teaser--package o-teaser--hero o-teaser--hero-image o-teaser--has-image js-teaser"
@@ -1576,6 +1693,41 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with article data 1`] =
 `;
 
 exports[`x-teaser / snapshots renders a HeroVideo teaser with article-with-data-image data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--hero o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`x-teaser / snapshots renders a HeroVideo teaser with article-with-missing-image-url data 1`] = `
 <div
   className="o-teaser o-teaser--article o-teaser--hero o-teaser--highlight js-teaser"
   data-id=""
@@ -2080,6 +2232,53 @@ exports[`x-teaser / snapshots renders a Large teaser with article-with-data-imag
         />
       </div>
     </a>
+  </div>
+</div>
+`;
+
+exports[`x-teaser / snapshots renders a Large teaser with article-with-missing-image-url data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--large o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
   </div>
 </div>
 `;
@@ -2662,6 +2861,41 @@ exports[`x-teaser / snapshots renders a Small teaser with article-with-data-imag
 </div>
 `;
 
+exports[`x-teaser / snapshots renders a Small teaser with article-with-missing-image-url data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--small o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`x-teaser / snapshots renders a Small teaser with contentPackage data 1`] = `
 <div
   className="o-teaser o-teaser--package o-teaser--small o-teaser--centre js-teaser"
@@ -3076,6 +3310,53 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with article-with-data
         />
       </div>
     </a>
+  </div>
+</div>
+`;
+
+exports[`x-teaser / snapshots renders a SmallHeavy teaser with article-with-missing-image-url data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--small o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
   </div>
 </div>
 `;
@@ -3682,6 +3963,53 @@ exports[`x-teaser / snapshots renders a TopStory teaser with article-with-data-i
 </div>
 `;
 
+exports[`x-teaser / snapshots renders a TopStory teaser with article-with-missing-image-url data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--top-story o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
+  </div>
+</div>
+`;
+
 exports[`x-teaser / snapshots renders a TopStory teaser with contentPackage data 1`] = `
 <div
   className="o-teaser o-teaser--package o-teaser--top-story o-teaser--centre js-teaser"
@@ -4217,6 +4545,53 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article-wi
         />
       </div>
     </a>
+  </div>
+</div>
+`;
+
+exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with article-with-missing-image-url data 1`] = `
+<div
+  className="o-teaser o-teaser--article o-teaser--top-story o-teaser--landscape o-teaser--highlight js-teaser"
+  data-id=""
+>
+  <div
+    className="o-teaser__content"
+  >
+    <div
+      className="o-teaser__meta"
+    >
+      <a
+        aria-label="Category: Sexual misconduct allegations"
+        className="o-teaser__tag"
+        data-trackable="teaser-tag"
+        href="#"
+      >
+        Sexual misconduct allegations
+      </a>
+    </div>
+    <div
+      className="o-teaser__heading"
+    >
+      <a
+        className="js-teaser-heading-link"
+        data-trackable="heading-link"
+        href="#"
+      >
+        Inside charity fundraiser where hostesses are put on show
+      </a>
+    </div>
+    <p
+      className="o-teaser__standfirst"
+    >
+      <a
+        className="js-teaser-standfirst-link"
+        data-trackable="standfirst-link"
+        href="#"
+        tabIndex={-1}
+      >
+        FT investigation finds groping and sexual harassment at secretive black-tie dinner
+      </a>
+    </p>
   </div>
 </div>
 `;

--- a/components/x-teaser/__tests__/snapshots.test.js
+++ b/components/x-teaser/__tests__/snapshots.test.js
@@ -5,6 +5,7 @@ const { Teaser, presets } = require('../')
 const storyData = {
 	article: require('../__fixtures__/article.json'),
 	'article-with-data-image': require('../__fixtures__/article-with-data-image.json'),
+	'article-with-missing-image-url': require('../__fixtures__/article-with-missing-image-url.json'),
 	opinion: require('../__fixtures__/opinion.json'),
 	contentPackage: require('../__fixtures__/content-package.json'),
 	packageItem: require('../__fixtures__/package-item.json'),

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -27,28 +27,27 @@ const LazyImage = ({ src, lazyLoad }) => {
 export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, imageHighestQuality, ...props }) => {
 	if (!image || (image && !image.url)) {
 		return null
-	} else {
-		const displayUrl = relativeUrl || url
-		const useImageService = !(image.url.startsWith('data:') || image.url.startsWith('blob:'))
-		const options = imageSize === 'XXL' && imageHighestQuality ? { quality: 'highest' } : {}
-		const imageSrc = useImageService ? imageService(image.url, ImageSizes[imageSize], options) : image.url
-		const ImageComponent = imageLazyLoad ? LazyImage : NormalImage
-
-		return (
-			<div className="o-teaser__image-container js-teaser-image-container">
-				<Link
-					{...props}
-					url={displayUrl}
-					attrs={{
-						'data-trackable': 'image-link',
-						tabIndex: '-1',
-						'aria-hidden': 'true'
-					}}>
-					<div className="o-teaser__image-placeholder" style={{ paddingBottom: aspectRatio(image) }}>
-						<ImageComponent src={imageSrc} lazyLoad={imageLazyLoad} />
-					</div>
-				</Link>
-			</div>
-		)
 	}
+	const displayUrl = relativeUrl || url
+	const useImageService = !(image.url.startsWith('data:') || image.url.startsWith('blob:'))
+	const options = imageSize === 'XXL' && imageHighestQuality ? { quality: 'highest' } : {}
+	const imageSrc = useImageService ? imageService(image.url, ImageSizes[imageSize], options) : image.url
+	const ImageComponent = imageLazyLoad ? LazyImage : NormalImage
+
+	return (
+		<div className="o-teaser__image-container js-teaser-image-container">
+			<Link
+				{...props}
+				url={displayUrl}
+				attrs={{
+					'data-trackable': 'image-link',
+					tabIndex: '-1',
+					'aria-hidden': 'true'
+				}}>
+				<div className="o-teaser__image-placeholder" style={{ paddingBottom: aspectRatio(image) }}>
+					<ImageComponent src={imageSrc} lazyLoad={imageLazyLoad} />
+				</div>
+			</Link>
+		</div>
+	)
 }

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -25,7 +25,7 @@ const LazyImage = ({ src, lazyLoad }) => {
 }
 
 export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, imageHighestQuality, ...props }) => {
-	if (!image) {
+	if (!image || (image && !image.url)) {
 		return null
 	} else {
 		const displayUrl = relativeUrl || url

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -25,7 +25,9 @@ const LazyImage = ({ src, lazyLoad }) => {
 }
 
 export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, imageHighestQuality, ...props }) => {
-	if (image) {
+	if (!image) {
+		return null
+	} else {
 		const displayUrl = relativeUrl || url
 		const useImageService = !(image.url.startsWith('data:') || image.url.startsWith('blob:'))
 		const options = imageSize === 'XXL' && imageHighestQuality ? { quality: 'highest' } : {}
@@ -48,7 +50,5 @@ export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, imageHighes
 				</Link>
 			</div>
 		)
-	} else {
-		return null
 	}
 }

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -25,26 +25,30 @@ const LazyImage = ({ src, lazyLoad }) => {
 }
 
 export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, imageHighestQuality, ...props }) => {
-	const displayUrl = relativeUrl || url
-	const useImageService = !(image.url.startsWith('data:') || image.url.startsWith('blob:'))
-	const options = imageSize === 'XXL' && imageHighestQuality ? { quality: 'highest' } : {}
-	const imageSrc = useImageService ? imageService(image.url, ImageSizes[imageSize], options) : image.url
-	const ImageComponent = imageLazyLoad ? LazyImage : NormalImage
+	if (image) {
+		const displayUrl = relativeUrl || url
+		const useImageService = !(image.url.startsWith('data:') || image.url.startsWith('blob:'))
+		const options = imageSize === 'XXL' && imageHighestQuality ? { quality: 'highest' } : {}
+		const imageSrc = useImageService ? imageService(image.url, ImageSizes[imageSize], options) : image.url
+		const ImageComponent = imageLazyLoad ? LazyImage : NormalImage
 
-	return image ? (
-		<div className="o-teaser__image-container js-teaser-image-container">
-			<Link
-				{...props}
-				url={displayUrl}
-				attrs={{
-					'data-trackable': 'image-link',
-					tabIndex: '-1',
-					'aria-hidden': 'true'
-				}}>
-				<div className="o-teaser__image-placeholder" style={{ paddingBottom: aspectRatio(image) }}>
-					<ImageComponent src={imageSrc} lazyLoad={imageLazyLoad} />
-				</div>
-			</Link>
-		</div>
-	) : null
+		return (
+			<div className="o-teaser__image-container js-teaser-image-container">
+				<Link
+					{...props}
+					url={displayUrl}
+					attrs={{
+						'data-trackable': 'image-link',
+						tabIndex: '-1',
+						'aria-hidden': 'true'
+					}}>
+					<div className="o-teaser__image-placeholder" style={{ paddingBottom: aspectRatio(image) }}>
+						<ImageComponent src={imageSrc} lazyLoad={imageLazyLoad} />
+					</div>
+				</Link>
+			</div>
+		)
+	} else {
+		return null
+	}
 }


### PR DESCRIPTION
Check for existence of `image` as soon as image teaser function starts so that the line
```js
const useImageService = !(image.url.startsWith('data:') || image.url.startsWith('blob:'))
```
doesn't error if `image` is undefined. This has happened twice on the homepage when a gif has been used as the main image. when this errors on the home page the whole home page returns a 500.

Now when image is null stories render without images rather than the whole page going down:
![image](https://user-images.githubusercontent.com/17846996/105348588-7776ac00-5be0-11eb-9083-f83d548f7330.png)

