### PR TITLE
CI-479: Only insert posts if they do not already exist, and remove update + delete events

### DIFF
--- a/components/x-live-blog-wrapper/readme.md
+++ b/components/x-live-blog-wrapper/readme.md
@@ -161,7 +161,7 @@ wrapperElement.addEventListener('LiveBlogWrapper.INSERT_POST',
             const { post } = ev.detail;
 
             // post object contains data about a live blog post
-            // post.postId can be used to identify the newly rendered
+            // post.id can be used to identify the newly rendered
             // LiveBlogPost element
       });
 

--- a/components/x-live-blog-wrapper/readme.md
+++ b/components/x-live-blog-wrapper/readme.md
@@ -165,23 +165,6 @@ wrapperElement.addEventListener('LiveBlogWrapper.INSERT_POST',
             // LiveBlogPost element
       });
 
-wrapperElement.addEventListener('LiveBlogWrapper.DELETE_POST',
-      (ev) => {
-            const { postId } = ev.detail;
-
-            // postId can be used to identify the deleted
-            // LiveBlogPost element
-      });
-
-wrapperElement.addEventListener('LiveBlogWrapper.UPDATE_POST',
-      (ev) => {
-            const { post } = ev.detail;
-
-            // post object contains data about a live blog post
-            // post.postId can be used to identify the newly rendered
-            // LiveBlogPost element
-      });
-```
 ### Properties
 
 Feature          | Type   | Notes

--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -10,28 +10,6 @@ const withLiveBlogWrapperActions = withActions({
 
 			return props
 		}
-	},
-
-	updatePost(updated) {
-		return (props) => {
-			const index = props.posts.findIndex((post) => post.id === updated.postId)
-			if (index >= 0) {
-				props.posts[index] = updated
-			}
-
-			return props
-		}
-	},
-
-	deletePost(postId) {
-		return (props) => {
-			const index = props.posts.findIndex((post) => post.id === postId)
-			if (index >= 0) {
-				props.posts.splice(index, 1)
-			}
-
-			return props
-		}
 	}
 })
 

--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -4,9 +4,12 @@ import { withActions } from '@financial-times/x-interaction'
 import { listenToLiveBlogEvents } from './LiveEventListener'
 
 const withLiveBlogWrapperActions = withActions({
-	insertPost(post) {
+	insertPost(newPost) {
 		return (props) => {
-			props.posts.unshift(post)
+			const newPostAlreadyExists = props.posts.find((post) => post.id === newPost.id)
+			if (!newPostAlreadyExists) {
+				props.posts.unshift(newPost)
+			}
 
 			return props
 		}

--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -3,14 +3,16 @@ import { LiveBlogPost } from '@financial-times/x-live-blog-post'
 import { withActions } from '@financial-times/x-interaction'
 import { listenToLiveBlogEvents } from './LiveEventListener'
 import { normalisePost } from './normalisePost'
+import { dispatchEvent } from './dispatchEvent'
 
 const withLiveBlogWrapperActions = withActions({
-	insertPost(newPost) {
+	insertPost(newPost, wrapper) {
 		return (props) => {
 			const normalisedNewPost = normalisePost(newPost)
 			const newPostAlreadyExists = props.posts.find((post) => post.id === normalisedNewPost.id)
 			if (!newPostAlreadyExists) {
 				props.posts.unshift(normalisedNewPost)
+				dispatchEvent(wrapper, 'LiveBlogWrapper.INSERT_POST', { post: normalisedNewPost })
 			}
 
 			return props

--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -2,13 +2,15 @@ import { h } from '@financial-times/x-engine'
 import { LiveBlogPost } from '@financial-times/x-live-blog-post'
 import { withActions } from '@financial-times/x-interaction'
 import { listenToLiveBlogEvents } from './LiveEventListener'
+import { normalisePost } from './normalisePost'
 
 const withLiveBlogWrapperActions = withActions({
 	insertPost(newPost) {
 		return (props) => {
-			const newPostAlreadyExists = props.posts.find((post) => post.id === newPost.id)
+			const normalisedNewPost = normalisePost(newPost)
+			const newPostAlreadyExists = props.posts.find((post) => post.id === normalisedNewPost.id)
 			if (!newPostAlreadyExists) {
-				props.posts.unshift(newPost)
+				props.posts.unshift(normalisedNewPost)
 			}
 
 			return props

--- a/components/x-live-blog-wrapper/src/LiveEventListener.js
+++ b/components/x-live-blog-wrapper/src/LiveEventListener.js
@@ -1,11 +1,14 @@
+import { normalisePost } from './normalisePost'
+
 const parsePost = (event) => {
 	const post = JSON.parse(event.data)
+	const normalisedPost = normalisePost(post)
 
-	if (!post || !post.postId) {
+	if (!normalisedPost || !normalisedPost.id) {
 		return
 	}
 
-	return post
+	return normalisedPost
 }
 
 const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid, actions }) => {

--- a/components/x-live-blog-wrapper/src/LiveEventListener.js
+++ b/components/x-live-blog-wrapper/src/LiveEventListener.js
@@ -40,36 +40,6 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 		}
 	}
 
-	const dispatchLiveUpdateEvent = (eventType, data) => {
-		/*
-		We dispatch live update events to notify the consuming app about added / updated posts.
-
-		Consuming app uses these events to execute tasks like initialising Origami components
-		on the updated elements.
-
-		We want the rendering of the updates in the DOM to finish before dispatching this event,
-		because the consumer needs to reference the updated DOM elements.
-
-		If we dispatch the event in the same event loop with DOM element updates, consumer app
-		will handle the event before the updates are complete.
-
-		window.setTimeout(fn, 0) will defer the execution of the inner function until the
-		current event loop completes, which is enough time for the DOM updates to finish.
-
-		More information can be found in MDN setTimeout documentation. Please refer to
-		"Late timeouts" heading in this page:
-		https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Late_timeouts
-
-		> ... the timeout can also fire later when the page (or the OS/browser itself) is busy
-		> with other tasks. One important case to note is that the function or code snippet
-		> cannot be executed until the thread that called setTimeout() has terminated.
-		> ...
-		> This is because even though setTimeout was called with a delay of zero, it's placed on
-		> a queue and scheduled to run at the next opportunity; not immediately.
-		 */
-		window.setTimeout(() => wrapper.dispatchEvent(new CustomEvent(eventType, { detail: data })), 0)
-	}
-
 	// Allow `next-live-event-api` endpoint URL to be set in development.
 	const baseUrl =
 		typeof LIVE_EVENT_API_URL !== 'undefined' ? LIVE_EVENT_API_URL : 'https://next-live-event.ft.com' // eslint-disable-line no-undef
@@ -85,8 +55,7 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 			return
 		}
 
-		invokeAction('insertPost', [post])
-		dispatchLiveUpdateEvent('LiveBlogWrapper.INSERT_POST', { post })
+		invokeAction('insertPost', [post, wrapper])
 	})
 }
 

--- a/components/x-live-blog-wrapper/src/LiveEventListener.js
+++ b/components/x-live-blog-wrapper/src/LiveEventListener.js
@@ -85,29 +85,6 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 		invokeAction('insertPost', [post])
 		dispatchLiveUpdateEvent('LiveBlogWrapper.INSERT_POST', { post })
 	})
-
-	eventSource.addEventListener('update-post', (event) => {
-		const post = parsePost(event)
-
-		if (!post) {
-			return
-		}
-
-		invokeAction('updatePost', [post])
-		dispatchLiveUpdateEvent('LiveBlogWrapper.UPDATE_POST', { post })
-	})
-
-	eventSource.addEventListener('delete-post', (event) => {
-		const post = parsePost(event)
-
-		if (!post) {
-			return
-		}
-
-		const postId = post.postId
-		invokeAction('deletePost', [postId])
-		dispatchLiveUpdateEvent('LiveBlogWrapper.DELETE_POST', { postId })
-	})
 }
 
 export { listenToLiveBlogEvents }

--- a/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
+++ b/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
@@ -73,27 +73,4 @@ describe('liveBlogWrapperActions', () => {
 		expect(posts.length).toEqual(3)
 		expect(posts[0].id).toEqual('3')
 	})
-
-	it('updates a post', () => {
-		const updatedPost2 = {
-			postId: '2',
-			title: 'Updated title'
-		}
-
-		// updatePost function returns another function that takes the list of component props
-		// as an argument and returns the updated props.
-		actions.updatePost(updatedPost2)({ posts })
-
-		expect(posts.length).toEqual(2)
-		expect(posts[1].title).toEqual('Updated title')
-	})
-
-	it('deletes a post', () => {
-		// deletePost function returns another function that takes the list of component props
-		// as an argument and returns the updated props.
-		actions.deletePost('1')({ posts })
-
-		expect(posts.length).toEqual(1)
-		expect(posts[0].id).toEqual('2')
-	})
 })

--- a/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
+++ b/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
@@ -73,4 +73,16 @@ describe('liveBlogWrapperActions', () => {
 		expect(posts.length).toEqual(3)
 		expect(posts[0].id).toEqual('3')
 	})
+
+	it('does not insert a new post if a duplicate', () => {
+		// Clone an existing post to check if gets inserted again.
+		const duplicatePost = { ...posts[0] }
+
+		// insertPost function returns another function that takes the list of component props
+		// as an argument and returns the updated props.
+		actions.insertPost(duplicatePost)({ posts })
+
+		expect(posts.length).toEqual(2)
+		expect(posts[0].id).toEqual('1')
+	})
 })

--- a/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
+++ b/components/x-live-blog-wrapper/src/__tests__/LiveBlogWrapper.test.jsx
@@ -3,6 +3,9 @@ const { mount } = require('@financial-times/x-test-utils/enzyme')
 
 import { LiveBlogWrapper } from '../LiveBlogWrapper'
 
+import { dispatchEvent } from '../dispatchEvent'
+jest.mock('../dispatchEvent')
+
 const post1 = {
 	id: '1',
 	title: 'Post 1 Title',
@@ -61,17 +64,26 @@ describe('liveBlogWrapperActions', () => {
 		actions = liveBlogWrapper.props.actions
 	})
 
+	afterEach(() => {
+		dispatchEvent.mockReset()
+	})
+
 	it('inserts a new post to the top of the list', () => {
+		const target = 'target'
 		const post3 = {
 			id: '3'
 		}
 
 		// insertPost function returns another function that takes the list of component props
 		// as an argument and returns the updated props.
-		actions.insertPost(post3)({ posts })
+		actions.insertPost(post3, target)({ posts })
 
 		expect(posts.length).toEqual(3)
 		expect(posts[0].id).toEqual('3')
+
+		expect(dispatchEvent).toHaveBeenCalledWith('target', 'LiveBlogWrapper.INSERT_POST', {
+			post: post3
+		})
 	})
 
 	it('does not insert a new post if a duplicate', () => {
@@ -84,5 +96,7 @@ describe('liveBlogWrapperActions', () => {
 
 		expect(posts.length).toEqual(2)
 		expect(posts[0].id).toEqual('1')
+
+		expect(dispatchEvent).not.toHaveBeenCalled()
 	})
 })

--- a/components/x-live-blog-wrapper/src/__tests__/LiveEventListener.test.js
+++ b/components/x-live-blog-wrapper/src/__tests__/LiveEventListener.test.js
@@ -1,0 +1,90 @@
+import { listenToLiveBlogEvents } from '../LiveEventListener'
+
+const addEventListenerMock = jest.fn()
+const EventSourceMock = jest.fn(() => {
+	return {
+		addEventListener: addEventListenerMock
+	}
+})
+global.EventSource = EventSourceMock
+
+const dispatchEventMock = jest.fn()
+jest.spyOn(document, 'querySelector').mockImplementation(() => {
+	return {
+		dispatchEvent: dispatchEventMock
+	}
+})
+
+describe('liveEventListener', () => {
+	describe('EventSource', () => {
+		it('should default to the live URL', () => {
+			listenToLiveBlogEvents({})
+			expect(EventSourceMock).toHaveBeenCalledWith('https://next-live-event.ft.com/v2/liveblog/undefined', {
+				withCredentials: true
+			})
+		})
+
+		it('should allow baseUrl to be overriden for testing', () => {
+			global.LIVE_EVENT_API_URL = 'http://localhost:5000'
+			listenToLiveBlogEvents({})
+			expect(EventSourceMock).toHaveBeenCalledWith('http://localhost:5000/v2/liveblog/undefined', {
+				withCredentials: true
+			})
+			delete global.LIVE_EVENT_API_URL
+		})
+
+		it('should use the liveBlogPackageUuid as a source', () => {
+			listenToLiveBlogEvents({ liveBlogPackageUuid: 1234 })
+			expect(EventSourceMock).toHaveBeenCalledWith('https://next-live-event.ft.com/v2/liveblog/1234', {
+				withCredentials: true
+			})
+		})
+	})
+
+	describe('listening to events', () => {
+		afterAll(() => {
+			addEventListenerMock.mockReset()
+			dispatchEventMock.mockReset()
+		})
+		it('throws exception if no stringified data', () => {
+			addEventListenerMock.mockImplementation((event, handler) => {
+				handler({})
+			})
+			expect(() => {
+				listenToLiveBlogEvents({})
+			}).toThrow('Unexpected token')
+		})
+		it('if actions are supplied, they should be called', () => {
+			addEventListenerMock.mockImplementation((event, handler) => {
+				handler({
+					data: JSON.stringify({
+						id: 1234
+					})
+				})
+			})
+			listenToLiveBlogEvents({
+				actions: {
+					insertPost: (event, wrapper) => {
+						expect(wrapper).toEqual({
+							dispatchEvent: dispatchEventMock
+						})
+						expect(event).toEqual({
+							id: 1234
+						})
+					}
+				}
+			})
+		})
+		it('if no actions supplied, then an event should be dispatched', () => {
+			addEventListenerMock.mockImplementation((event, handler) => {
+				handler({
+					data: JSON.stringify({
+						id: 1234
+					})
+				})
+			})
+			listenToLiveBlogEvents({})
+			expect(dispatchEventMock).toHaveBeenCalled()
+		})
+	})
+})

--- a/components/x-live-blog-wrapper/src/__tests__/dispatchEvent.test.js
+++ b/components/x-live-blog-wrapper/src/__tests__/dispatchEvent.test.js
@@ -1,0 +1,41 @@
+import { dispatchEvent } from '../dispatchEvent'
+
+const CustomEventMock = jest.fn()
+global.CustomEvent = CustomEventMock
+
+const dispatchEventMock = jest.fn(() => {})
+
+describe('dispatchEvent', () => {
+	beforeAll(() => {
+		jest.useFakeTimers()
+	})
+	afterAll(() => {
+		dispatchEventMock.mockReset()
+		CustomEventMock.mockReset()
+		jest.useRealTimers()
+	})
+	it('does nothing if ran on the server with no window', () => {
+		const originalWindow = global.window
+		delete global.window
+		dispatchEvent()
+		jest.runAllTimers()
+		expect(dispatchEventMock).not.toHaveBeenCalled()
+		expect(CustomEventMock).not.toHaveBeenCalled()
+		global.window = originalWindow
+	})
+	it('does loads if window', () => {
+		const target = {
+			dispatchEvent: dispatchEventMock
+		}
+		dispatchEvent(target, 'test', {
+			foo: 'bar'
+		})
+		jest.runAllTimers()
+		expect(dispatchEventMock).toHaveBeenCalled()
+		expect(CustomEventMock).toHaveBeenCalledWith('test', {
+			detail: {
+				foo: 'bar'
+			}
+		})
+	})
+})

--- a/components/x-live-blog-wrapper/src/__tests__/normalisePost.test.js
+++ b/components/x-live-blog-wrapper/src/__tests__/normalisePost.test.js
@@ -1,0 +1,28 @@
+import { normalisePost } from '../normalisePost'
+
+describe('normalisePost', () => {
+	it('does nothing if no post', () => {
+		expect(normalisePost({})).toEqual({})
+	})
+	it('does not change id property if id property exists', () => {
+		expect(
+			normalisePost({
+				id: 123,
+				postId: 456
+			})
+		).toEqual({
+			id: 123,
+			postId: 456
+		})
+	})
+	it('adds id property if doesnt it exist but postId property does', () => {
+		expect(
+			normalisePost({
+				postId: 456
+			})
+		).toEqual({
+			id: 456,
+			postId: 456
+		})
+	})
+})

--- a/components/x-live-blog-wrapper/src/dispatchEvent.js
+++ b/components/x-live-blog-wrapper/src/dispatchEvent.js
@@ -1,0 +1,34 @@
+/*
+We dispatch live update events to notify the consuming app about added / updated posts.
+
+Consuming app uses these events to execute tasks like initialising Origami components
+on the updated elements.
+
+We want the rendering of the updates in the DOM to finish before dispatching this event,
+because the consumer needs to reference the updated DOM elements.
+
+If we dispatch the event in the same event loop with DOM element updates, consumer app
+will handle the event before the updates are complete.
+
+window.setTimeout(fn, 0) will defer the execution of the inner function until the
+current event loop completes, which is enough time for the DOM updates to finish.
+
+More information can be found in MDN setTimeout documentation. Please refer to
+"Late timeouts" heading in this page:
+https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Late_timeouts
+
+> ... the timeout can also fire later when the page (or the OS/browser itself) is busy
+> with other tasks. One important case to note is that the function or code snippet
+> cannot be executed until the thread that called setTimeout() has terminated.
+> ...
+> This is because even though setTimeout was called with a delay of zero, it's placed on
+> a queue and scheduled to run at the next opportunity; not immediately.
+*/
+const dispatchEvent = (target, eventType, data) => {
+	if (typeof window === 'undefined') {
+		return
+	}
+	window.setTimeout(() => target.dispatchEvent(new CustomEvent(eventType, { detail: data })), 0)
+}
+
+export { dispatchEvent }

--- a/components/x-live-blog-wrapper/src/normalisePost.js
+++ b/components/x-live-blog-wrapper/src/normalisePost.js
@@ -1,0 +1,9 @@
+// Remove this helper when we no longer need to handle incoming WordPress events.
+const normalisePost = (post) => {
+	if (post && !post.id && post.postId) {
+		post.id = post.postId
+	}
+	return post
+}
+
+export { normalisePost }


### PR DESCRIPTION
If updates that come from the pipeline include duplicate we want to make sure our users only see one post.
We can do this by checking for the existence of a post with the same ID.

We also need to move our external events so they fire only when there's been an update.

I have also written tests for some of the existing logic in this component to try to increase the confidence I have with changing it.

Best viewed commit by commit