### PR TITLE
CPP-419 x-interaction component registration

### DIFF
--- a/components/x-interaction/readme.md
+++ b/components/x-interaction/readme.md
@@ -113,7 +113,35 @@ export const Greeting = greetingActions(BaseGreeting);
 
 When you have an `x-interaction` component rendered by the server, and you want to attach the client-side version of the component to handle the actions, rather than rendering the component manually (which might become unwieldy, especially if you have many components & instances on the page), you can have `x-interaction` manage it for you.
 
-There are two parts to this: serialising and hydrating.
+There are three parts to this: registering the component, serialising and hydrating.
+
+#### Registering the component
+
+To register the component you'll need to call `x-interaction`'s `registerComponent` function, providing the component and its name as arguments.
+
+```jsx
+import {withActions, registerComponent} from '@financial-times/x-interaction';
+
+const greetingActions = withActions({
+	actionOne() {
+		return {greeting: "world"};
+	},
+
+	actionTwo() {
+		return ({greeting}) => ({
+			greeting: greeting.toUpperCase(),
+		});
+	},
+});
+
+const Greeting = greetingActions(({greeting, actions}) => <div>
+	hello {greeting}
+	<button onClick={actions.actionOne}>"world"</button>
+	<button onClick={actions.actionTwo}>uppercase</button>
+</div>);
+
+registerComponent(Greeting, 'Greeting')
+```
 
 #### Serialising
 
@@ -123,12 +151,12 @@ This instance should be passed to every `x-interaction` component you render, as
 
 Finally, after every `x-interaction` component is rendered, you should output the hydration data. `x-interaction` exports a `HydrationData` component, which takes a serialiser as a property and renders a `<script>` tag containing its hydration data, assigned to a global variable that can be picked up by the `x-interaction` client-side runtime. A serialiser cannot be used again after its data has been output by a `HydrationData` component.
 
-Here's a full example of using `Serialiser` and `HydrationData`:
+Here's a full example of using `Serialiser` and `HydrationData` using the `Greeting` component we registered in the previous step.
 
 ```js
 import express from 'express';
+import { Greeting } from './Greeting'
 import { Serialiser, HydrationData } from '@financial-times/x-interaction';
-import { Increment } from '@financial-times/x-increment';
 
 const app = express();
 
@@ -136,7 +164,7 @@ app.get('/', (req, res) => {
 	const serialiser = new Serialiser();
 
 	res.send(`
-		${Increment({ count: 1, serialiser })}
+		${Greeting({ serialiser })}
 		${HydrationData({ serialiser })}
 	`);
 });

--- a/components/x-interaction/src/Hydrate.jsx
+++ b/components/x-interaction/src/Hydrate.jsx
@@ -52,6 +52,12 @@ export function hydrate() {
 
 		const Component = getComponent(component)
 
+		if (!Component) {
+			throw new Error(
+				`x-interaction hydrate was called using unregistered component: ${Component}. please verify you'are registering your component using x-interaction's registerComponent function before attempting to hydrate.`
+			)
+		}
+
 		while (wrapper.firstChild) {
 			wrapper.removeChild(wrapper.firstChild)
 		}

--- a/components/x-interaction/src/Hydrate.jsx
+++ b/components/x-interaction/src/Hydrate.jsx
@@ -1,5 +1,5 @@
 import { h, render, Component } from '@financial-times/x-engine'
-import { getComponent } from './concerns/register-component'
+import { getComponentByName } from './concerns/register-component'
 
 export class HydrationWrapper extends Component {
 	render() {
@@ -50,11 +50,11 @@ export function hydrate() {
 			)
 		}
 
-		const Component = getComponent(component)
+		const Component = getComponentByName(component)
 
 		if (!Component) {
 			throw new Error(
-				`x-interaction hydrate was called using unregistered component: ${Component}. please verify you'are registering your component using x-interaction's registerComponent function before attempting to hydrate.`
+				`x-interaction hydrate was called using unregistered component: ${component}. please verify you're registering your component using x-interaction's registerComponent function before attempting to hydrate.`
 			)
 		}
 

--- a/components/x-interaction/src/Interaction.jsx
+++ b/components/x-interaction/src/Interaction.jsx
@@ -2,7 +2,6 @@ import { h } from '@financial-times/x-engine'
 import { InteractionClass } from './InteractionClass'
 import { InteractionSSR } from './InteractionSSR'
 import wrapComponentName from './concerns/wrap-component-name'
-import { registerComponent } from './concerns/register-component'
 
 // use the class version for clientside and the static version for server
 const Interaction = typeof window !== 'undefined' ? InteractionClass : InteractionSSR
@@ -55,12 +54,10 @@ export const withActions = (getActions, getDefaultState = {}) => (Component) => 
 	// set the displayName of the Enhanced component for debugging
 	wrapComponentName(Component, Enhanced)
 
-	// register the component under its name for later hydration from serialised data
-	registerComponent(Enhanced)
-
 	return Enhanced
 }
 
 export { hydrate } from './Hydrate'
 export { HydrationData } from './HydrationData'
 export { Serialiser } from './concerns/serialiser'
+export { registerComponent } from './concerns/register-component'

--- a/components/x-interaction/src/InteractionSSR.jsx
+++ b/components/x-interaction/src/InteractionSSR.jsx
@@ -1,5 +1,5 @@
 import { h } from '@financial-times/x-engine'
-import getComponentName from './concerns/get-component-name'
+import { getComponentName } from './concerns/register-component'
 import shortId from '@quarterto/short-id'
 
 import { InteractionRender } from './InteractionRender'

--- a/components/x-interaction/src/concerns/get-component-name.js
+++ b/components/x-interaction/src/concerns/get-component-name.js
@@ -1,3 +1,0 @@
-const getComponentName = (Component) => Component.displayName || Component.name || 'Unknown'
-
-export default getComponentName

--- a/components/x-interaction/src/concerns/register-component.js
+++ b/components/x-interaction/src/concerns/register-component.js
@@ -1,9 +1,15 @@
 const registeredComponents = {}
 
-export function registerComponent(component) {
-	registeredComponents[component.wrappedDisplayName] = component
+export function registerComponent(component, name) {
+	const xInteractionName = Symbol('x-interaction-name')
+	component[xInteractionName] = name
+	registeredComponents[name] = component
 }
 
-export function getComponent(name) {
+export function getComponent(component) {
+	const xInteractionSymbol = Object.getOwnPropertySymbols(component).find(
+		(key) => key.toString() === `Symbol(x-interaction-name)`
+	)
+	const name = component[xInteractionSymbol]
 	return registeredComponents[name]
 }

--- a/components/x-interaction/src/concerns/register-component.js
+++ b/components/x-interaction/src/concerns/register-component.js
@@ -1,15 +1,25 @@
 const registeredComponents = {}
+const xInteractionName = Symbol('x-interaction-name')
 
-export function registerComponent(component, name) {
-	const xInteractionName = Symbol('x-interaction-name')
-	component[xInteractionName] = name
-	registeredComponents[name] = component
+export function registerComponent(Component, name) {
+	if (registeredComponents[name]) {
+		throw new Error(
+			`x-interaction a component has already been registered under that name, please use another name.`
+		)
+	}
+	Component[xInteractionName] = name
+	registeredComponents[name] = Component
 }
 
-export function getComponent(component) {
-	const xInteractionSymbol = Object.getOwnPropertySymbols(component).find(
-		(key) => key.toString() === `Symbol(x-interaction-name)`
-	)
-	const name = component[xInteractionSymbol]
+export function getComponent(Component) {
+	const name = Component[xInteractionName]
 	return registeredComponents[name]
+}
+
+export function getComponentByName(name) {
+	return registeredComponents[name]
+}
+
+export function getComponentName(Component) {
+	return Component[xInteractionName] || 'Unknown'
 }

--- a/components/x-interaction/src/concerns/serialiser.js
+++ b/components/x-interaction/src/concerns/serialiser.js
@@ -1,7 +1,6 @@
 import { h, render } from '@financial-times/x-engine'
-import getComponentName from './get-component-name'
 import { HydrationData } from '../HydrationData'
-import { getComponent } from './register-component'
+import { getComponent, getComponentName } from './register-component'
 
 export class Serialiser {
 	constructor() {

--- a/components/x-interaction/src/concerns/serialiser.js
+++ b/components/x-interaction/src/concerns/serialiser.js
@@ -1,6 +1,7 @@
 import { h, render } from '@financial-times/x-engine'
 import getComponentName from './get-component-name'
 import { HydrationData } from '../HydrationData'
+import { getComponent } from './register-component'
 
 export class Serialiser {
 	constructor() {
@@ -9,6 +10,14 @@ export class Serialiser {
 	}
 
 	addData({ id, Component, props }) {
+		const registeredComponent = getComponent(Component)
+
+		if (!registeredComponent) {
+			throw new Error(
+				`a Serialiser's addData was called for an unregistered component. ensure you're registering your component before attempting to output the hydration data`
+			)
+		}
+
 		if (this.destroyed) {
 			throw new Error(
 				`an interaction component was rendered after flushHydrationData was called. ensure you're outputting the hydration data after rendering every component`

--- a/components/x-interaction/src/concerns/wrap-component-name.js
+++ b/components/x-interaction/src/concerns/wrap-component-name.js
@@ -1,4 +1,4 @@
-import getComponentName from './get-component-name'
+import { getComponentName } from './register-component'
 
 function wrapComponentName(Component, Enhanced) {
 	const originalDisplayName = getComponentName(Component)

--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -4,6 +4,7 @@ import { withActions } from '@financial-times/x-interaction'
 import { listenToLiveBlogEvents } from './LiveEventListener'
 import { normalisePost } from './normalisePost'
 import { dispatchEvent } from './dispatchEvent'
+import { registerComponent } from '@financial-times/x-interaction'
 
 const withLiveBlogWrapperActions = withActions({
 	insertPost(newPost, wrapper) {
@@ -53,9 +54,8 @@ const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons, id, liv
 	)
 }
 
-// A displayName is required for this component
 // This enables the component to work with x-interaction
-BaseLiveBlogWrapper.displayName = 'BaseLiveBlogWrapper'
+registerComponent(BaseLiveBlogWrapper, 'BaseLiveBlogWrapper')
 
 const LiveBlogWrapper = withLiveBlogWrapperActions(BaseLiveBlogWrapper)
 


### PR DESCRIPTION
[Ticket CPP-419](https://financialtimes.atlassian.net/browse/CPP-419)

From the ticket description: 
> x-interaction allows you to serialise component data for server-rendered components, and hydrate those components on the client side to enable actions with the client-side version of the component. registering components happens implicitly within x-interaction, and relies on heuristics to determine the component name. these must work the same on the client and server for the component to hydrate properly, which is unreliable, and is more likely to break in production environments than development.

This PR makes x-interaction export an explicit register function instead of implicitly registering. It also sets checks in both server (Serialiser) and client (Hydrate) code to ensure that all components are correctly registered. It also updates the README to reflect this change, (grammar/wording corrections are welcomed).

This has been tested in `next-article` using Live Blog Post content https://local.ft.com:5050/content/b47a8dd0-81dc-4136-807c-c071c75c8fe2

For it to work you'll need to turn the `liveBlogsV2` flag on.

The commits have been made based on the ticket's checklist order, so reviewing this PR by commit could be easier.

-----------------
If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/master/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
