### PR TITLE
ACC-749 x-gift-article improvements wrapped in a flag

### DIFF
--- a/components/x-gift-article/readme.md
+++ b/components/x-gift-article/readme.md
@@ -77,3 +77,6 @@ Property                  | Type    | Required | Note
 `nativeShare`             | Boolean | no       | This is a property for App to display Native Sharing.
 `apiProtocol`             | String  | no       | The protocol to use when making requests to the gift article and URL shortening services. Ignored if `apiDomain` is not set.
 `apiDomain`               | String  | no       | The domain to use when making requests to the gift article and URL shortening services.
+
+###
+`isArticleSharingUxUpdates` boolean has been added as part of ACC-749 to enable AB testing of the impact of minor UX improvements to x-gift-article. Once AB testing is done, and decision to keep / remove has been made, the changes made in https://github.com/Financial-Times/x-dash/pull/579 need to be ditched or baked in as default. 

--- a/components/x-gift-article/src/CopyConfirmation.jsx
+++ b/components/x-gift-article/src/CopyConfirmation.jsx
@@ -9,12 +9,12 @@ const confirmationClassNames = [
 	styles['copy-confirmation']
 ].join(' ')
 
-export default ({ hideCopyConfirmation, isTestVariant }) => (
+export default ({ hideCopyConfirmation, isArticleSharingUxUpdates }) => (
 	<div className={confirmationClassNames} role="alert">
 		<div className={styles['o-message__container']}>
 			<div className={styles['o-message__content']}>
 				<p className={styles['o-message__content-main']}>
-					{isTestVariant ? (
+					{isArticleSharingUxUpdates ? (
 						<span>The link has been copied to your clipboard</span>
 					) : (
 						<span className={styles['o-message__content-highlight']}>

--- a/components/x-gift-article/src/CopyConfirmation.jsx
+++ b/components/x-gift-article/src/CopyConfirmation.jsx
@@ -9,14 +9,18 @@ const confirmationClassNames = [
 	styles['copy-confirmation']
 ].join(' ')
 
-export default ({ hideCopyConfirmation }) => (
+export default ({ hideCopyConfirmation, isTestVariant }) => (
 	<div className={confirmationClassNames} role="alert">
 		<div className={styles['o-message__container']}>
 			<div className={styles['o-message__content']}>
 				<p className={styles['o-message__content-main']}>
-					<span className={styles['o-message__content-highlight']}>
-						The link has been copied to your clipboard
-					</span>
+					{isTestVariant ? (
+						<span>The link has been copied to your clipboard</span>
+					) : (
+						<span className={styles['o-message__content-highlight']}>
+							The link has been copied to your clipboard
+						</span>
+					)}
 				</p>
 			</div>
 

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -10,11 +10,12 @@ export default (props) => (
 	<div className={styles.container}>
 		<form name="gift-form" className={styles['share-form']}>
 			<div role="group" arialabelledby="gift-article-title">
-				<Title title={props.title} />
+				<Title {...props} />
 
 				{!props.isFreeArticle && (
 					<RadioButtonsSection
 						shareType={props.shareType}
+						isArticleSharingUxUpdates={props.isArticleSharingUxUpdates}
 						showGiftUrlSection={props.actions.showGiftUrlSection}
 						showNonGiftUrlSection={props.actions.showNonGiftUrlSection}
 					/>
@@ -25,7 +26,10 @@ export default (props) => (
 		</form>
 
 		{props.showCopyConfirmation && (
-			<CopyConfirmation hideCopyConfirmation={props.actions.hideCopyConfirmation} />
+			<CopyConfirmation
+				hideCopyConfirmation={props.actions.hideCopyConfirmation}
+				isTestVariant={props.isArticleSharingUxUpdates}
+			/>
 		)}
 
 		{props.showMobileShareLinks && <MobileShareButtons mobileShareLinks={props.mobileShareLinks} />}

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -28,7 +28,7 @@ export default (props) => (
 		{props.showCopyConfirmation && (
 			<CopyConfirmation
 				hideCopyConfirmation={props.actions.hideCopyConfirmation}
-				isTestVariant={props.isArticleSharingUxUpdates}
+				isArticleSharingUxUpdates={props.isArticleSharingUxUpdates}
 			/>
 		)}
 

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -12,6 +12,9 @@ import * as updaters from './lib/updaters'
 const isCopySupported =
 	typeof document !== 'undefined' && document.queryCommandSupported && document.queryCommandSupported('copy')
 
+const todayDate = new Date()
+const monthNow = `${updaters.monthNames[todayDate.getMonth()]}`
+
 const withGiftFormActions = withActions(
 	(initialProps) => {
 		const api = new ApiClient({
@@ -122,10 +125,12 @@ const withGiftFormActions = withActions(
 			title: 'Share this article',
 			giftCredits: undefined,
 			monthlyAllowance: undefined,
+			monthNow: monthNow,
 			showCopyButton: isCopySupported,
 			isGiftUrlCreated: false,
 			isGiftUrlShortened: false,
 			isNonGiftUrlShortened: false,
+			isArticleSharingUxUpdates: false,
 
 			urls: {
 				dummy: 'https://on.ft.com/gift_link',

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -53,6 +53,14 @@ $o-typography-is-silent: true;
 	.share-option-title {
 		@include oNormaliseVisuallyHidden();
 	}
+
+	.o-forms-field{
+		@media only screen and (min-width: 600px) {
+			label[for$="Link"]{
+				margin-bottom: 0;
+			}
+		}	
+	}
 }
 
 @media only screen and (min-width: 600px) {

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -12,8 +12,41 @@ export default ({
 	monthlyAllowance,
 	nextRenewalDateText,
 	redemptionLimit,
-	invalidResponseFromApi
+	invalidResponseFromApi,
+	isArticleSharingUxUpdates
 }) => {
+	if (isArticleSharingUxUpdates) {
+		if (isFreeArticle) {
+			return null
+		}
+
+		if (shareType === ShareType.gift) {
+			if (giftCredits === 0) {
+				return (
+					<div className={messageClassName}>
+						You’ve used all your <strong>gift article credits</strong>
+						<br />
+						You’ll get your next {monthlyAllowance} on <strong>{nextRenewalDateText}</strong>
+					</div>
+				)
+			}
+
+			if (invalidResponseFromApi) {
+				return <div className={messageClassName}>Unable to fetch gift credits. Please try again later</div>
+			}
+
+			return (
+				<div className={messageClassName}>
+					A gift link can be opened up to <strong>{redemptionLimit ? redemptionLimit : 3} times</strong>
+				</div>
+			)
+		}
+
+		if (shareType === ShareType.nonGift) {
+			return <div className={messageClassName}>This link can only be read by existing subscribers</div>
+		}
+	}
+
 	if (isFreeArticle) {
 		return (
 			<div className={messageClassName}>

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -10,7 +10,7 @@ const radioSectionClassNames = [
 	styles['radio-button-section']
 ].join(' ')
 
-export default ({ shareType, showGiftUrlSection, showNonGiftUrlSection }) => (
+export default ({ shareType, showGiftUrlSection, isArticleSharingUxUpdates, showNonGiftUrlSection }) => (
 	<div className={radioSectionClassNames} role="group" aria-labelledby="article-share-options">
 		<span className={styles['share-option-title']} id="article-share-options">
 			Article share options
@@ -24,9 +24,15 @@ export default ({ shareType, showGiftUrlSection, showNonGiftUrlSection }) => (
 				checked={shareType === ShareType.gift}
 				onChange={showGiftUrlSection}
 			/>
-			<span className={styles['o-forms-input__label']}>
-				with <strong>anyone</strong> (uses 1 gift credit)
-			</span>
+			{isArticleSharingUxUpdates ? (
+				<span className={styles['o-forms-input__label']}>
+					Gift to <strong>anyone</strong> (uses <strong>1 credit</strong>)
+				</span>
+			) : (
+				<span className={styles['o-forms-input__label']}>
+					with <strong>anyone</strong> (uses 1 gift credit)
+				</span>
+			)}
 		</label>
 
 		<label htmlFor="nonGiftLink">
@@ -38,9 +44,15 @@ export default ({ shareType, showGiftUrlSection, showNonGiftUrlSection }) => (
 				checked={shareType === ShareType.nonGift}
 				onChange={showNonGiftUrlSection}
 			/>
-			<span className={styles['o-forms-input__label']}>
-				with <strong>other FT subscribers</strong>
-			</span>
+			{isArticleSharingUxUpdates ? (
+				<span className={styles['o-forms-input__label']}>
+					Share with <strong>other FT subscribers</strong>
+				</span>
+			) : (
+				<span className={styles['o-forms-input__label']}>
+					with <strong>other FT subscribers</strong>
+				</span>
+			)}
 		</label>
 	</div>
 )

--- a/components/x-gift-article/src/Title.jsx
+++ b/components/x-gift-article/src/Title.jsx
@@ -3,8 +3,31 @@ import styles from './GiftArticle.scss'
 
 const titleClassNames = [styles.title].join(' ')
 
-export default ({ title }) => (
-	<div className={titleClassNames} id="gift-article-title">
-		{title}
-	</div>
-)
+export default ({
+	giftCredits,
+	monthlyAllowance,
+	monthNow,
+	isFreeArticle,
+	isArticleSharingUxUpdates,
+	title = ''
+}) => {
+	if (isArticleSharingUxUpdates) {
+		if (title !== 'Share on Social') {
+			if (isFreeArticle) {
+				title = 'This article is free for anyone to read'
+			} else {
+				title = `You have ${giftCredits} out of ${monthlyAllowance} gift credits left in ${monthNow}`
+			}
+		}
+
+		return (
+			<div className={titleClassNames} id="gift-article-title">
+				{title}
+			</div>
+		)
+	} else {
+		;<div className={titleClassNames} id="gift-article-title">
+			{title}
+		</div>
+	}
+}

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -21,6 +21,7 @@ export default ({
 	showCopyButton,
 	nativeShare,
 	invalidResponseFromApi,
+	isArticleSharingUxUpdates,
 	actions
 }) => {
 	const hideUrlShareElements = giftCredits === 0 && shareType === ShareType.gift
@@ -51,7 +52,8 @@ export default ({
 					monthlyAllowance,
 					nextRenewalDateText,
 					redemptionLimit,
-					invalidResponseFromApi
+					invalidResponseFromApi,
+					isArticleSharingUxUpdates
 				}}
 			/>
 

--- a/components/x-gift-article/src/lib/updaters.js
+++ b/components/x-gift-article/src/lib/updaters.js
@@ -1,7 +1,7 @@
 import { createMailtoUrl } from './share-link-actions'
 import { ShareType, UrlType } from './constants'
 
-const monthNames = [
+export const monthNames = [
 	'January',
 	'February',
 	'March',


### PR DESCRIPTION
This PR is https://github.com/Financial-Times/x-dash/pull/578 wrapped in a flag so that we can run an AB test. 

![Screenshot 2021-01-21 at 11 43 54](https://user-images.githubusercontent.com/31079643/105985212-142ec300-6093-11eb-88f5-e60de698a275.png)
![Screenshot 2021-01-21 at 11 27 27](https://user-images.githubusercontent.com/31079643/105985215-155ff000-6093-11eb-8d4a-def48a88cf5e.png)

This PR is one of many steps to get the AB test rolled out:

- [x] create a flag in flags API, with the status off
- [ ] merge a PR in next-article that passes the flag status to x-gift-article - https://github.com/Financial-Times/next-article/pull/4117
- [ ] merge this PR, release it, make sure the release propagates where needed
- [ ] run a manual QA with flag on in toggler to make sure it all works as intended
- [ ] turn the AB test on

