### PR TITLE
CPP-442 Upgrade GitHub repos from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,10 @@ references:
     branches:
       ignore: /.*/
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
       only:
-        - master
+        - main
 
 jobs:
 
@@ -188,7 +188,7 @@ workflows:
             - build
       - deploy:
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
           requires:
             - test
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/master/contribution.md) before submitting.
+If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.
 
 ## If you're creating a component:
 

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,6 @@
 _extends: github-apps-config-next
 branches:
-  - name: master
+  - name: main
     protection:
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/components/x-follow-button/readme.md
+++ b/components/x-follow-button/readme.md
@@ -1,6 +1,6 @@
 # x-follow-button
 
-This module provides a template for myFT follow topic button, and is intended to replace the legacy handlebars component in [n-myft-ui](https://github.com/Financial-Times/n-myft-ui/tree/master/components/follow-button).
+This module provides a template for myFT follow topic button, and is intended to replace the legacy handlebars component in [n-myft-ui](https://github.com/Financial-Times/n-myft-ui/tree/HEAD/components/follow-button).
 
 ## Installation
 
@@ -40,4 +40,4 @@ Property           | Value
 It is up to the consumer of this component to listen for the `x-follow-button` event, and use this data, along with the user's ID, and carry out the appropriate action.
 
 For example, if using `next-myft-client` to carry out the follow/unfollow action, n-myft-ui provides a x-button-interaction component for this:
-https://github.com/Financial-Times/n-myft-ui/blob/master/components/x-button-integration/index.js
+https://github.com/Financial-Times/n-myft-ui/blob/HEAD/components/x-button-integration/index.js

--- a/components/x-gift-article/readme.md
+++ b/components/x-gift-article/readme.md
@@ -65,7 +65,7 @@ All `x-` components are designed to be compatible with a variety of runtimes, no
 
 [jsx-wtf]: https://jasonformat.com/wtf-is-jsx/
 [interaction]: /components/x-interaction#triggering-actions-externally
-[engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[engine]: https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine
 
 ### Properties
 

--- a/components/x-interaction/package.json
+++ b/components/x-interaction/package.json
@@ -27,7 +27,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/components/x-interaction",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-interaction",
   "engines": {
     "node": "12.x"
   },

--- a/components/x-live-blog-post/package.json
+++ b/components/x-live-blog-post/package.json
@@ -29,7 +29,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/components/x-live-blog-post",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-live-blog-post",
   "engines": {
     "node": "12.x"
   },

--- a/components/x-live-blog-post/readme.md
+++ b/components/x-live-blog-post/readme.md
@@ -13,7 +13,7 @@ npm install --save @financial-times/x-live-blog-post
 
 The [`x-engine`][engine] module is used to inject your chosen runtime into the component. Please read the `x-engine` documentation first if you are consuming `x-` components for the first time in your application.
 
-[engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[engine]: https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine
 
 
 ## Usage

--- a/components/x-live-blog-wrapper/package.json
+++ b/components/x-live-blog-wrapper/package.json
@@ -27,7 +27,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/components/x-live-blog-wrapper",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-live-blog-wrapper",
   "engines": {
     "node": "12.x"
   },

--- a/components/x-live-blog-wrapper/readme.md
+++ b/components/x-live-blog-wrapper/readme.md
@@ -13,7 +13,7 @@ npm install --save @financial-times/x-live-blog-wrapper
 
 The [`x-engine`][engine] module is used to inject your chosen runtime into the component. Please read the `x-engine` documentation first if you are consuming `x-` components for the first time in your application.
 
-[engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[engine]: https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine
 
 
 ## Usage

--- a/components/x-live-blog-wrapper/src/LiveEventListener.js
+++ b/components/x-live-blog-wrapper/src/LiveEventListener.js
@@ -24,7 +24,7 @@ const listenToLiveBlogEvents = ({ liveBlogWrapperElementId, liveBlogPackageUuid,
 			// argument is defined.
 			//
 			// For more information:
-			// https://github.com/Financial-Times/x-dash/tree/master/components/x-interaction#triggering-actions-externally
+			// https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-interaction#triggering-actions-externally
 			actions[action](...args)
 		} else {
 			// When the component is rendered at the server side, we don't have a reference to

--- a/components/x-podcast-launchers/package.json
+++ b/components/x-podcast-launchers/package.json
@@ -31,7 +31,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/components/x-podcastlaunchers",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-podcastlaunchers",
   "engines": {
     "node": "12.x"
   },

--- a/components/x-podcast-launchers/readme.md
+++ b/components/x-podcast-launchers/readme.md
@@ -19,7 +19,7 @@ npm install --save @financial-times/x-podcast-launchers
 
 The [`x-engine`][engine] module is used to inject your chosen runtime into the component. Please read the `x-engine` documentation first if you are consuming `x-` components for the first time in your application.
 
-[engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[engine]: https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine
 
 ## Styling
 

--- a/components/x-privacy-manager/package.json
+++ b/components/x-privacy-manager/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/components/x-privacy-manager",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-privacy-manager",
   "engines": {
     "node": "12.x"
   },

--- a/components/x-privacy-manager/readme.md
+++ b/components/x-privacy-manager/readme.md
@@ -16,7 +16,7 @@ npm install --save @financial-times/x-privacy-manager
 
 The [`x-engine`][engine] module is used to inject your chosen runtime into the component. Please read the `x-engine` documentation first if you are consuming `x-` components for the first time in your application.
 
-[engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[engine]: https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine
 
 
 ## Usage

--- a/components/x-teaser-timeline/package.json
+++ b/components/x-teaser-timeline/package.json
@@ -33,7 +33,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/components/x-teaser-timeline",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-teaser-timeline",
   "engines": {
     "node": "12.x"
   },

--- a/components/x-teaser-timeline/readme.md
+++ b/components/x-teaser-timeline/readme.md
@@ -13,7 +13,7 @@ npm install --save @financial-times/x-teaser-timeline
 
 The [`x-engine`][engine] module is used to inject your chosen runtime into the component. Please read the `x-engine` documentation first if you are consuming `x-` components for the first time in your application.
 
-[engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[engine]: https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine
 
 ## Other dependencies
 
@@ -27,7 +27,7 @@ $o-teaser-is-silent: true;
 @include oTeaser(('default', 'images', 'timestamp'), ('small'));
 ```
 
-See the [x-teaser](https://github.com/Financial-Times/x-dash/tree/master/components/x-teaser) documentation.
+See the [x-teaser](https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-teaser) documentation.
 
 ## Usage
 

--- a/components/x-teaser/package.json
+++ b/components/x-teaser/package.json
@@ -27,7 +27,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/components/x-teaser",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-teaser",
   "engines": {
     "node": "12.x"
   },

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -13,7 +13,7 @@ bower install --save o-teaser
 
 The [`x-engine`][engine] module is used to inject your chosen runtime into the component. Please read the `x-engine` documentation first if you are consuming `x-` components for the first time in your application.
 
-[engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[engine]: https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine
 
 ## Concepts
 

--- a/contribution.md
+++ b/contribution.md
@@ -85,9 +85,9 @@ Please do! All of the code in `x-dash` is peer-reviewed by members of The App an
 
 This project follows a workflow designed around project releases. It is less strict than [Gitflow] but we encourage the separation of stable, development, and experimental branches in order to follow a scheduled release cycle.
 
-- The `master` branch is for the current stable release. Bugfixes are merged into this branch.
-- The `development` branch is for upcoming major or minor releases. This branch tracks `master` and new features are merged into it.
-- Branches for new features should track and raise pull requests against the `development` branch or `master` branch if there are not any upcoming releases planned.
+- The `main` branch is for the current stable release. Bugfixes are merged into this branch.
+- The `development` branch is for upcoming major or minor releases. This branch tracks `main` and new features are merged into it.
+- Branches for new features should track and raise pull requests against the `development` branch or `main` branch if there are not any upcoming releases planned.
 
 [Gitflow]: https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow
 

--- a/docs/components/overview.md
+++ b/docs/components/overview.md
@@ -55,7 +55,7 @@ In addition it is encouraged to write unit tests for interactive or complex comp
 
 ## Publishing
 
-All x-dash components and packages will be published on the [npm registry] under the `@financial-times` organisation. Components in the `master` or current `development` branches of x-dash will all be published concurrently with the same version number. Experimental components may be published with an unstable version number using a [prerelease tag].
+All x-dash components and packages will be published on the [npm registry] under the `@financial-times` organisation. Components in the `main` or current `development` branches of x-dash will all be published concurrently with the same version number. Experimental components may be published with an unstable version number using a [prerelease tag].
 
 [npm registry]: https://www.npmjs.com/
 [prerelease tag]: ./release-guidelines.md

--- a/docs/components/release-guidelines.md
+++ b/docs/components/release-guidelines.md
@@ -2,9 +2,9 @@
 
 ## Experimental features
 
-Only stable, well tested components and packages may be present in the master or development branches. _Any publishable code in the master or development branches must have been tested in both The App and FT.com_. This is so we do not release unproven components with a stable version number.
+Only stable, well tested components and packages may be present in the main or development branches. _Any publishable code in the main or development branches must have been tested in both The App and FT.com_. This is so we do not release unproven components with a stable version number.
 
-To develop your component create a new feature branch including your module name, for example if you are building a new tabs component you would create a branch named `feature-x-tabs`. Your component will stay in this branch until it is ready to be merged into the next major or minor release so you are encouraged to merge from or rebase onto the latest development or master branch regularly. You are welcome to raise pull requests against your feature branch if you need to.
+To develop your component create a new feature branch including your module name, for example if you are building a new tabs component you would create a branch named `feature-x-tabs`. Your component will stay in this branch until it is ready to be merged into the next major or minor release so you are encouraged to merge from or rebase onto the latest development or main branch regularly. You are welcome to raise pull requests against your feature branch if you need to.
 
 Because experimental modules will not be included in any stable releases we allow them to be published separately using a pre-1.0.0 version number. You are free to make as many prereleases as you need. To create a prerelease of your experimental module you must create a tag in the format `module-name-v0.x.x`, for example to release the tabs component you would create tag named `x-tabs-v0.0.1` for the latest commit in the `feature-x-tabs` branch.
 
@@ -15,11 +15,11 @@ When your new module is considered stable raise a pull request against the curre
 
 ## Releasing/Versioning
 
-All of our projects are versioned using [Semantic Versioning], you should familiarise yourself with this. The following guide will outline how to tag and release a new version of all projects, it assumes that all the code you wish to release is now on the `master` or main branch.
+All of our projects are versioned using [Semantic Versioning], you should familiarise yourself with this. The following guide will outline how to tag and release a new version of all projects, it assumes that all the code you wish to release is now on the `main` branch.
 
   1. **Review the commits since the last release**. You can find the last release in the git log, or by using the compare feature on GitHub. Make sure you've pulled all of the latest changes.
 
-  2. **Decide on a version**. Work out whether this release is major, minor, or patch level. Major releases are generally planned out; if a breaking change has snuck into `master` without prior-planning it may be worth removing it or attempting to make it backwards-compatible.
+  2. **Decide on a version**. Work out whether this release is major, minor, or patch level. Major releases are generally planned out; if a breaking change has snuck into `main` without prior-planning it may be worth removing it or attempting to make it backwards-compatible.
 
   3. **Add a release**. Create a release using the GitHub UI (note there should be a "v" preceeding the version number). This will automatically kick off a new build and publish each package.
 

--- a/docs/components/stories.md
+++ b/docs/components/stories.md
@@ -99,4 +99,4 @@ module.exports = (data, createKnob) => {
 };
 ```
 
-[Storybook knobs add-on]: https://github.com/storybooks/storybook/tree/master/addons/knobs
+[Storybook knobs add-on]: https://github.com/storybooks/storybook/tree/HEAD/addons/knobs

--- a/docs/components/testing.md
+++ b/docs/components/testing.md
@@ -10,7 +10,7 @@ Snapshot tests are useful for ensuring that you don't accidentally change the ma
 
 x-dash comes with Jest and Enzyme pre-configured, to help save boilerplate and setup when testing your component.
 
-For an example of Jest and Enzyme in use, and standard patterns for writing tests for a component, see the [x-increment tests](https://github.com/Financial-Times/x-dash/tree/master/components/x-increment/__tests__).
+For an example of Jest and Enzyme in use, and standard patterns for writing tests for a component, see the [x-increment tests](https://github.com/Financial-Times/x-dash/tree/HEAD/components/x-increment/__tests__).
 
 ### Setup
 

--- a/docs/get-started/what-is-x-dash.md
+++ b/docs/get-started/what-is-x-dash.md
@@ -29,7 +29,7 @@ With x-dash we have introduced a [monorepo] project structure, new [contribution
 
 
 [monorepo]: https://en.wikipedia.org/wiki/Monorepo
-[contribution guidelines]: https://github.com/Financial-Times/x-dash/blob/master/contribution.md
+[contribution guidelines]: https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md
 [release process]: ../components/release-guidelines.md
 
 

--- a/docs/get-started/working-with-x-dash.md
+++ b/docs/get-started/working-with-x-dash.md
@@ -69,4 +69,4 @@ The best way to ensure you stick to the x-dash code style is to make your work c
 
 [Prettier]: https://prettier.io/
 [ESLint]: https://eslint.org/
-[contribution guide]: https://github.com/Financial-Times/x-dash/blob/master/contribution.md
+[contribution guide]: https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md

--- a/packages/x-engine/package.json
+++ b/packages/x-engine/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine",
   "engines": {
     "node": "12.x"
   },

--- a/packages/x-handlebars/package.json
+++ b/packages/x-handlebars/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/packages/x-handlebars",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-handlebars",
   "engines": {
     "node": "12.x"
   },

--- a/packages/x-handlebars/readme.md
+++ b/packages/x-handlebars/readme.md
@@ -43,7 +43,7 @@ xHandlebars({
 This module will install the [x-engine][x-engine] module as a dependency to perform the rendering of `x-` components. Please refer to the x-engine documentation to setup your application with `x-engine`.
 
 [n-ui]: https://github.com/Financial-Times/n-ui/
-[x-engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[x-engine]: https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine
 
 ## Usage
 

--- a/packages/x-node-jsx/package.json
+++ b/packages/x-node-jsx/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/packages/x-node-jsx",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-node-jsx",
   "engines": {
     "node": "12.x"
   },

--- a/private/blueprints/component/package.json
+++ b/private/blueprints/component/package.json
@@ -22,7 +22,7 @@
     "type" : "git",
     "url" : "https://github.com/Financial-Times/x-dash.git"
   },
-  "homepage": "https://github.com/Financial-Times/x-dash/tree/master/components/{{packageName}}",
+  "homepage": "https://github.com/Financial-Times/x-dash/tree/HEAD/components/{{packageName}}",
   "engines": {
     "node": "12.x"
   },

--- a/private/blueprints/component/readme.md
+++ b/private/blueprints/component/readme.md
@@ -13,7 +13,7 @@ npm install --save @financial-times/{{packageName}}
 
 The [`x-engine`][engine] module is used to inject your chosen runtime into the component. Please read the `x-engine` documentation first if you are consuming `x-` components for the first time in your application.
 
-[engine]: https://github.com/Financial-Times/x-dash/tree/master/packages/x-engine
+[engine]: https://github.com/Financial-Times/x-dash/tree/HEAD/packages/x-engine
 
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 <h1 align="center">
 	<img src="https://user-images.githubusercontent.com/271645/38416861-1e6c6202-398e-11e8-907c-8c199a03988a.png" width="200" alt=""><br>
 	x-dash
-	<a href="https://circleci.com/gh/Financial-Times/x-dash/tree/master">
-		<img alt="Build Status" src="https://circleci.com/gh/Financial-Times/x-dash/tree/master.svg?style=svg">
+	<a href="https://circleci.com/gh/Financial-Times/x-dash/tree/main">
+		<img alt="Build Status" src="https://circleci.com/gh/Financial-Times/x-dash/tree/main.svg?style=svg">
 	</a>
 </h1>
 


### PR DESCRIPTION
[Ticket CPP-442 Upgrade GitHub repos from `master` to `main`](https://financialtimes.atlassian.net/browse/CPP-442)<br/><br/>As an organisation we are moving away from the usage of `master` as a central branch and switching it to `main`, this is to avoid using unnecessary language that can be offensive. This PR is for making those changes.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
