### PR TITLE
CPP-464 register wrapper components and allow accessing wrapper components from original component

### DIFF
--- a/components/x-interaction/src/concerns/register-component.js
+++ b/components/x-interaction/src/concerns/register-component.js
@@ -15,6 +15,8 @@ export function registerComponent(Component, name) {
 	}
 
 	Component[xInteractionName] = name
+	// add name to original component so we can access the wrapper from the original
+	Component._wraps.Component[xInteractionName] = name
 	registeredComponents[name] = Component
 }
 

--- a/components/x-interaction/src/concerns/register-component.js
+++ b/components/x-interaction/src/concerns/register-component.js
@@ -7,6 +7,13 @@ export function registerComponent(Component, name) {
 			`x-interaction a component has already been registered under that name, please use another name.`
 		)
 	}
+
+	if (!Component._wraps) {
+		throw new Error(
+			`only x-interaction wrapped components (i.e. the component returned from withActions) can be registered`
+		)
+	}
+
 	Component[xInteractionName] = name
 	registeredComponents[name] = Component
 }

--- a/components/x-interaction/src/concerns/wrap-component-name.js
+++ b/components/x-interaction/src/concerns/wrap-component-name.js
@@ -1,7 +1,5 @@
-import { getComponentName } from './register-component'
-
 function wrapComponentName(Component, Enhanced) {
-	const originalDisplayName = getComponentName(Component)
+	const originalDisplayName = Component.displayName || Component.name
 	Enhanced.displayName = `withActions(${originalDisplayName})`
 	Enhanced.wrappedDisplayName = originalDisplayName
 }

--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -54,9 +54,9 @@ const BaseLiveBlogWrapper = ({ posts = [], articleUrl, showShareButtons, id, liv
 	)
 }
 
-// This enables the component to work with x-interaction
-registerComponent(BaseLiveBlogWrapper, 'BaseLiveBlogWrapper')
-
 const LiveBlogWrapper = withLiveBlogWrapperActions(BaseLiveBlogWrapper)
+
+// This enables the component to work with x-interaction hydration
+registerComponent(LiveBlogWrapper, 'LiveBlogWrapper')
 
 export { LiveBlogWrapper, listenToLiveBlogEvents }


### PR DESCRIPTION
if the original component is registered, when we try to hydrate it it'll render the markup but it doesn't have the actions. previously, if the wrapper component was registered, the serialiser would complain because it's trying to get the name of the component from the original component, which doesn't know it.

i'm not set up to test live blogs locally, so @GlynnPhillips i'd really appreciate if you could kick the tyres :)