### PR TITLE
ACC-749 fix: removed a stray semicolon and wrapped the div inside a return

### DIFF
--- a/components/x-gift-article/src/Title.jsx
+++ b/components/x-gift-article/src/Title.jsx
@@ -26,8 +26,10 @@ export default ({
 			</div>
 		)
 	} else {
-		;<div className={titleClassNames} id="gift-article-title">
-			{title}
-		</div>
+		return (
+			<div className={titleClassNames} id="gift-article-title">
+				{title}
+			</div>
+		)
 	}
 }


### PR DESCRIPTION
Somehow the stray semicolon and the lack of `return` snuck past everyone and made for somewhat unpleasant gifting experience. It meant that the Title was not displayed at all. 

With other work taking priority the work on gifting AB test needs to be paused, but with this patch x-gift-article should work as it previously did whist retaining the prep work for the gifting AB