### PR TITLE
Update Babel config to allow components to build

### DIFF
--- a/components/x-privacy-manager/src/actions.js
+++ b/components/x-privacy-manager/src/actions.js
@@ -13,6 +13,8 @@ function onConsentChange(consent) {
  * @returns {({ isLoading, consent }: { isLoading: boolean, consent: boolean }) => Promise<{_response: _Response}>}
  */
 function sendConsent({ consentApiUrl, onConsentSavedCallbacks, consentSource, cookieDomain, fow }) {
+	let res
+
 	return async ({ isLoading, consent }) => {
 		if (isLoading) return
 
@@ -41,7 +43,7 @@ function sendConsent({ consentApiUrl, onConsentSavedCallbacks, consentSource, co
 		}
 
 		try {
-			const res = await fetch(consentApiUrl, {
+			res = await fetch(consentApiUrl, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'

--- a/package.json
+++ b/package.json
@@ -68,5 +68,6 @@
     "components/*",
     "packages/*",
     "tools/*"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/packages/x-babel-config/index.js
+++ b/packages/x-babel-config/index.js
@@ -1,4 +1,16 @@
-module.exports = ({ targets = [], modules = false } = {}) => ({
+/**
+ * @param {{ targets?: Record<string, unknown>, modules?: boolean }} params
+ * @returns {{
+ *   babelHelpers: "external"
+ *   targets: any;
+ *   plugins: [string, Record<string, unknown>][]
+ *   presets: [string, Record<string, unknown>][];
+ * }}
+ *
+ */
+module.exports = ({ targets = undefined, modules = false } = {}) => ({
+	babelHelpers: 'external',
+	targets,
 	plugins: [
 		// this plugin is not React specific! It includes a general JSX parser and helper 🙄
 		[
@@ -23,7 +35,6 @@ module.exports = ({ targets = [], modules = false } = {}) => ({
 		[
 			require.resolve('@babel/preset-env'),
 			{
-				targets,
 				modules,
 				exclude: ['transform-regenerator', 'transform-async-to-generator']
 			}

--- a/packages/x-babel-config/index.js
+++ b/packages/x-babel-config/index.js
@@ -1,7 +1,6 @@
 /**
- * @param {{ targets?: Record<string, unknown>, modules?: boolean }} params
+ * @param {{ targets?: Record<string, unknown>, modules?: string | false }} params
  * @returns {{
- *   babelHelpers: "external"
  *   targets: any;
  *   plugins: [string, Record<string, unknown>][]
  *   presets: [string, Record<string, unknown>][];
@@ -9,7 +8,6 @@
  *
  */
 module.exports = ({ targets = undefined, modules = false } = {}) => ({
-	babelHelpers: 'external',
 	targets,
 	plugins: [
 		// this plugin is not React specific! It includes a general JSX parser and helper 🙄

--- a/packages/x-babel-config/jest.js
+++ b/packages/x-babel-config/jest.js
@@ -2,7 +2,7 @@ const getBabelConfig = require('./')
 const babelJest = require('babel-jest')
 
 const base = getBabelConfig({
-	targets: [{ node: 'current' }],
+	targets: { node: 'current' },
 	modules: 'commonjs'
 })
 

--- a/packages/x-rollup/package.json
+++ b/packages/x-rollup/package.json
@@ -14,11 +14,11 @@
     "@babel/core": "^7.6.4",
     "@babel/plugin-external-helpers": "^7.2.0",
     "@financial-times/x-babel-config": "file:../x-babel-config",
+    "@rollup/plugin-babel": "5.3.0",
+    "@rollup/plugin-commonjs": "17.1.0",
     "chalk": "^2.4.2",
     "log-symbols": "^3.0.0",
-    "rollup": "^1.23.0",
-    "rollup-plugin-babel": "^4.3.2",
-    "rollup-plugin-commonjs": "^10.1.0",
+    "rollup": "2.39.1",
     "rollup-plugin-postcss": "^2.0.2"
   }
 }

--- a/packages/x-rollup/package.json
+++ b/packages/x-rollup/package.json
@@ -11,14 +11,15 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@babel/core": "^7.6.4",
-    "@babel/plugin-external-helpers": "^7.2.0",
+    "@babel/core": "7.13.1",
+    "@babel/plugin-external-helpers": "7.12.13",
     "@financial-times/x-babel-config": "file:../x-babel-config",
     "@rollup/plugin-babel": "5.3.0",
     "@rollup/plugin-commonjs": "17.1.0",
     "chalk": "^2.4.2",
     "log-symbols": "^3.0.0",
-    "rollup": "2.39.1",
-    "rollup-plugin-postcss": "^2.0.2"
+    "postcss": "8.2.6",
+    "rollup": "2.40.0",
+    "rollup-plugin-postcss": "4.0.0"
   }
 }

--- a/packages/x-rollup/src/babel-config.js
+++ b/packages/x-rollup/src/babel-config.js
@@ -10,6 +10,7 @@ module.exports = (...args) => {
 
 	// rollup-specific option not included in base config
 	base.include = '**/*.{js,jsx}'
+	base.babelHelpers = 'external'
 
 	return base
 }

--- a/packages/x-rollup/src/babel-config.js
+++ b/packages/x-rollup/src/babel-config.js
@@ -3,14 +3,14 @@ const baseBabelConfig = require('@financial-times/x-babel-config')
 module.exports = (...args) => {
 	const base = baseBabelConfig(...args)
 
+	// rollup-specific option not included in base config
+	base.include = '**/*.{js,jsx}'
+	base.babelHelpers = 'external'
+
 	base.plugins.push(
 		// Instruct Babel to not include any internal helper declarations in the output
 		require.resolve('@babel/plugin-external-helpers')
 	)
-
-	// rollup-specific option not included in base config
-	base.include = '**/*.{js,jsx}'
-	base.babelHelpers = 'external'
 
 	return base
 }

--- a/packages/x-rollup/src/rollup-config.js
+++ b/packages/x-rollup/src/rollup-config.js
@@ -8,15 +8,17 @@ module.exports = ({ input, pkg }) => {
 	// Don't bundle any dependencies
 	const external = Object.keys(pkg.dependencies)
 
-	const plugins = [
+	const pluginsPreBabel = [
 		// Convert CommonJS modules to ESM so they can be included in the bundle
-		commonjs({ extensions: ['.js', '.jsx'] })
+		// commonjs({ extensions: ['.js', '.jsx'] })
 	]
+
+	const pluginsPostBabel = [commonjs({ extensions: ['.js', '.jsx'] })]
 
 	// Add support for CSS modules (and any required transpilation)
 	if (pkg.style) {
 		const config = postcssConfig(pkg.style)
-		plugins.push(postcss(config))
+		pluginsPostBabel.push(postcss(config))
 	}
 
 	// Pairs of input and output options
@@ -26,12 +28,13 @@ module.exports = ({ input, pkg }) => {
 				input,
 				external,
 				plugins: [
+					...pluginsPreBabel,
 					babel(
 						babelConfig({
 							targets: { node: '12' }
 						})
 					),
-					...plugins
+					...pluginsPostBabel
 				]
 			},
 			{
@@ -44,12 +47,13 @@ module.exports = ({ input, pkg }) => {
 				input,
 				external,
 				plugins: [
+					...pluginsPreBabel,
 					babel(
 						babelConfig({
 							targets: { node: '12' }
 						})
 					),
-					...plugins
+					...pluginsPostBabel
 				]
 			},
 			{
@@ -62,12 +66,13 @@ module.exports = ({ input, pkg }) => {
 				input,
 				external,
 				plugins: [
+					...pluginsPreBabel,
 					babel(
 						babelConfig({
 							targets: { ie: '11' }
 						})
 					),
-					...plugins
+					...pluginsPostBabel
 				]
 			},
 			{

--- a/packages/x-rollup/src/rollup-config.js
+++ b/packages/x-rollup/src/rollup-config.js
@@ -1,6 +1,6 @@
-const babel = require('rollup-plugin-babel')
+const { babel } = require('@rollup/plugin-babel')
+const commonjs = require('@rollup/plugin-commonjs')
 const postcss = require('rollup-plugin-postcss')
-const commonjs = require('rollup-plugin-commonjs')
 const postcssConfig = require('./postcss-config')
 const babelConfig = require('./babel-config')
 
@@ -28,7 +28,7 @@ module.exports = ({ input, pkg }) => {
 				plugins: [
 					babel(
 						babelConfig({
-							targets: [{ node: 12 }]
+							targets: { node: '12' }
 						})
 					),
 					...plugins
@@ -46,7 +46,7 @@ module.exports = ({ input, pkg }) => {
 				plugins: [
 					babel(
 						babelConfig({
-							targets: [{ node: 12 }]
+							targets: { node: '12' }
 						})
 					),
 					...plugins
@@ -64,7 +64,7 @@ module.exports = ({ input, pkg }) => {
 				plugins: [
 					babel(
 						babelConfig({
-							targets: [{ browsers: ['ie 11'] }]
+							targets: { ie: '11' }
 						})
 					),
 					...plugins


### PR DESCRIPTION
## Issue:
On fresh installs of x-dash components fail to build 

## Steps to reproduce:
- Clone x-dash
- Run `make install`
- Result: in the post-install step the process exits with this message:
```sh
[12:23:48] ✖ [BABEL] <path-to-repo>/components/x-follow-button/src/FollowButton.jsx: @babel/helper-compilation-targets: '[object Object]' is not a valid browserslist query (While processing: "<path-to-repo>/packages/x-babel-config/node_modules/@babel/preset-env/lib/index.js")
```

## Investigation
- It seems this happening due to the way Babel now parses `targets` properties: switching from an arrray to an object format allows the components to compile

## Supplemental
This PR is intended more to share my findings than function as a proposal. As such there are a couple of small additional updates:
- The `targets` block is moved to the top level of the object exported from `packages/x-babel-config/index.js` per the recommendations in this blog post:
    https://babeljs.io/blog/2021/02/22/7.13.0#top-level-targets-option-12189httpsgithubcombabelbabelpull12189-rfchttpsgithubcombabelrfcspull2
- Rollup plugins have been switched to their new home under the `@rollup` namespace