### PR TITLE
CI-564: Remove overflow: auto from live blog post

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -3,7 +3,6 @@
 @import 'o-colors/main';
 
 .live-blog-post {
-	overflow: auto;
 	border-bottom: 1px solid oColorsMix(black, paper, 20);
 	margin-top: oSpacingByName('s8');
 	color: oColorsMix(black, paper, 90);


### PR DESCRIPTION
This was preventing us using `scroll-margin` to make the linking to the post via anchor better.

It was previously added to [allow for better calculations of the height of a post for scroll adjustments](https://github.com/Financial-Times/x-dash/commit/c90b2a459b5cc8a8a07a85faf1726ad358187444), but we no longer do this so we can remove it.