### PR TITLE
Minimal fix: refactor targets properties alone

### DIFF
--- a/components/x-privacy-manager/src/actions.js
+++ b/components/x-privacy-manager/src/actions.js
@@ -13,6 +13,8 @@ function onConsentChange(consent) {
  * @returns {({ isLoading, consent }: { isLoading: boolean, consent: boolean }) => Promise<{_response: _Response}>}
  */
 function sendConsent({ consentApiUrl, onConsentSavedCallbacks, consentSource, cookieDomain, fow }) {
+	let res
+
 	return async ({ isLoading, consent }) => {
 		if (isLoading) return
 
@@ -41,7 +43,7 @@ function sendConsent({ consentApiUrl, onConsentSavedCallbacks, consentSource, co
 		}
 
 		try {
-			const res = await fetch(consentApiUrl, {
+			res = await fetch(consentApiUrl, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'

--- a/packages/x-babel-config/jest.js
+++ b/packages/x-babel-config/jest.js
@@ -2,7 +2,7 @@ const getBabelConfig = require('./')
 const babelJest = require('babel-jest')
 
 const base = getBabelConfig({
-	targets: [{ node: 'current' }],
+	targets: { node: 'current' },
 	modules: 'commonjs'
 })
 

--- a/packages/x-rollup/src/rollup-config.js
+++ b/packages/x-rollup/src/rollup-config.js
@@ -28,7 +28,7 @@ module.exports = ({ input, pkg }) => {
 				plugins: [
 					babel(
 						babelConfig({
-							targets: { node: 12 }
+							targets: { node: '12' }
 						})
 					),
 					...plugins
@@ -46,7 +46,7 @@ module.exports = ({ input, pkg }) => {
 				plugins: [
 					babel(
 						babelConfig({
-							targets: { node: 12 }
+							targets: { node: '12' }
 						})
 					),
 					...plugins

--- a/packages/x-rollup/src/rollup-config.js
+++ b/packages/x-rollup/src/rollup-config.js
@@ -28,7 +28,7 @@ module.exports = ({ input, pkg }) => {
 				plugins: [
 					babel(
 						babelConfig({
-							targets: [{ node: 12 }]
+							targets: { node: 12 }
 						})
 					),
 					...plugins
@@ -46,7 +46,7 @@ module.exports = ({ input, pkg }) => {
 				plugins: [
 					babel(
 						babelConfig({
-							targets: [{ node: 12 }]
+							targets: { node: 12 }
 						})
 					),
 					...plugins
@@ -64,7 +64,7 @@ module.exports = ({ input, pkg }) => {
 				plugins: [
 					babel(
 						babelConfig({
-							targets: [{ browsers: ['ie 11'] }]
+							targets: { ie: '11' }
 						})
 					),
 					...plugins


### PR DESCRIPTION
### Context
Last week I found that a clean install of x-dash was failing to compile any of the components: running `make build` would error with the following message:

```
✖ [BABEL] <path-to-repo>/components/x-teaser/src/Teaser.jsx: @babel/helper-compilation-targets: '[object Object]' is not a valid browserslist query (While processing: "<path-to-repo>/packages/x-babel-config/node_modules/@babel/preset-env/lib/index.js")
```

Today @nickcolley reported having the same issue, so this PR is submitted as the quickest way to get compiling.

### PS
I investigated making a fuller update to the rollup dependencies (since the current versions have moved under the @rollup namespace) but had issues with emitting the `babelHelpers` in a form that consuming apps (such as `next-control-centre`) could pick up