### PR TITLE
NOPS-722 Fix blue headshots

### DIFF
--- a/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/components/x-teaser/__tests__/__snapshots__/snapshots.test.js.snap
@@ -216,7 +216,7 @@ exports[`x-teaser / snapshots renders a Hero teaser with opinion data 1`] = `
       aria-hidden="true"
       className="o-teaser__headshot"
       height={75}
-      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?0=t&1=i&2=n&3=t&4=%3D&5=0&6=5&7=4&8=5&9=9&10=3&11=%2C&12=d&13=6&14=d&15=5&16=d&17=3&source=next&fit=scale-down&dpr=2&width=75"
+      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?source=next&fit=scale-down&dpr=2&tint=054593%2Cd6d5d3&width=75"
       width={75}
     />
   </div>
@@ -733,7 +733,7 @@ exports[`x-teaser / snapshots renders a HeroNarrow teaser with opinion data 1`] 
       aria-hidden="true"
       className="o-teaser__headshot"
       height={75}
-      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?0=t&1=i&2=n&3=t&4=%3D&5=0&6=5&7=4&8=5&9=9&10=3&11=%2C&12=d&13=6&14=d&15=5&16=d&17=3&source=next&fit=scale-down&dpr=2&width=75"
+      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?source=next&fit=scale-down&dpr=2&tint=054593%2Cd6d5d3&width=75"
       width={75}
     />
   </div>
@@ -1212,7 +1212,7 @@ exports[`x-teaser / snapshots renders a HeroOverlay teaser with opinion data 1`]
       aria-hidden="true"
       className="o-teaser__headshot"
       height={75}
-      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?0=t&1=i&2=n&3=t&4=%3D&5=0&6=5&7=4&8=5&9=9&10=3&11=%2C&12=d&13=6&14=d&15=5&16=d&17=3&source=next&fit=scale-down&dpr=2&width=75"
+      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?source=next&fit=scale-down&dpr=2&tint=054593%2Cd6d5d3&width=75"
       width={75}
     />
   </div>
@@ -1681,7 +1681,7 @@ exports[`x-teaser / snapshots renders a HeroVideo teaser with opinion data 1`] =
       aria-hidden="true"
       className="o-teaser__headshot"
       height={75}
-      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?0=t&1=i&2=n&3=t&4=%3D&5=0&6=5&7=4&8=5&9=9&10=3&11=%2C&12=d&13=6&14=d&15=5&16=d&17=3&source=next&fit=scale-down&dpr=2&width=75"
+      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?source=next&fit=scale-down&dpr=2&tint=054593%2Cd6d5d3&width=75"
       width={75}
     />
   </div>
@@ -2204,7 +2204,7 @@ exports[`x-teaser / snapshots renders a Large teaser with opinion data 1`] = `
       aria-hidden="true"
       className="o-teaser__headshot"
       height={75}
-      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?0=t&1=i&2=n&3=t&4=%3D&5=0&6=5&7=4&8=5&9=9&10=3&11=%2C&12=d&13=6&14=d&15=5&16=d&17=3&source=next&fit=scale-down&dpr=2&width=75"
+      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?source=next&fit=scale-down&dpr=2&tint=054593%2Cd6d5d3&width=75"
       width={75}
     />
   </div>
@@ -2733,7 +2733,7 @@ exports[`x-teaser / snapshots renders a Small teaser with opinion data 1`] = `
       aria-hidden="true"
       className="o-teaser__headshot"
       height={75}
-      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?0=t&1=i&2=n&3=t&4=%3D&5=0&6=5&7=4&8=5&9=9&10=3&11=%2C&12=d&13=6&14=d&15=5&16=d&17=3&source=next&fit=scale-down&dpr=2&width=75"
+      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?source=next&fit=scale-down&dpr=2&tint=054593%2Cd6d5d3&width=75"
       width={75}
     />
   </div>
@@ -3200,7 +3200,7 @@ exports[`x-teaser / snapshots renders a SmallHeavy teaser with opinion data 1`] 
       aria-hidden="true"
       className="o-teaser__headshot"
       height={75}
-      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?0=t&1=i&2=n&3=t&4=%3D&5=0&6=5&7=4&8=5&9=9&10=3&11=%2C&12=d&13=6&14=d&15=5&16=d&17=3&source=next&fit=scale-down&dpr=2&width=75"
+      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?source=next&fit=scale-down&dpr=2&tint=054593%2Cd6d5d3&width=75"
       width={75}
     />
   </div>
@@ -3777,7 +3777,7 @@ exports[`x-teaser / snapshots renders a TopStory teaser with opinion data 1`] = 
       aria-hidden="true"
       className="o-teaser__headshot"
       height={75}
-      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?0=t&1=i&2=n&3=t&4=%3D&5=0&6=5&7=4&8=5&9=9&10=3&11=%2C&12=d&13=6&14=d&15=5&16=d&17=3&source=next&fit=scale-down&dpr=2&width=75"
+      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?source=next&fit=scale-down&dpr=2&tint=054593%2Cd6d5d3&width=75"
       width={75}
     />
   </div>
@@ -4341,7 +4341,7 @@ exports[`x-teaser / snapshots renders a TopStoryLandscape teaser with opinion da
       aria-hidden="true"
       className="o-teaser__headshot"
       height={75}
-      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?0=t&1=i&2=n&3=t&4=%3D&5=0&6=5&7=4&8=5&9=9&10=3&11=%2C&12=d&13=6&14=d&15=5&16=d&17=3&source=next&fit=scale-down&dpr=2&width=75"
+      src="https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1%3Agideon-rachman?source=next&fit=scale-down&dpr=2&tint=054593%2Cd6d5d3&width=75"
       width={75}
     />
   </div>

--- a/components/x-teaser/src/Headshot.jsx
+++ b/components/x-teaser/src/Headshot.jsx
@@ -6,7 +6,7 @@ import imageService from './concerns/image-service'
 const DEFAULT_TINT = '054593,d6d5d3'
 
 export default ({ headshot, headshotTint }) => {
-	const options = `tint=${headshotTint || DEFAULT_TINT}`
+	const options = { tint: `${headshotTint || DEFAULT_TINT}` }
 
 	return headshot ? (
 		<img


### PR DESCRIPTION
Currently on site headshots on the front page are not tinted blue, which they should be:
![image](https://user-images.githubusercontent.com/17846996/111600844-b2a0f000-87c9-11eb-94bb-79ed587af14a.png)

This fixes them so the tint is correctly applied:
![image](https://user-images.githubusercontent.com/17846996/111601647-7b7f0e80-87ca-11eb-8265-f3a5c73d43ba.png)

### The fix:
The headshot file creates an options variable **string** containing the tint values which is later passed into an `imageService` function used to construct the URL to the Origami image service:
```js
const options = `tint=${headshotTint || DEFAULT_TINT}`
...
src={imageService(headshot, ImageSizes.Headshot, options)}
```

[The `imageService` function](https://github.com/Financial-Times/x-dash/blob/main/components/x-teaser/src/concerns/image-service.js) expects an **object** (which is spread into a base object to create the URL) and so incorrectly handles the incoming string and produces a garbage query param on the constructed URL:

```js
imageSrc.search = new URLSearchParams({ ...OPTIONS, ...options })
```

So the fix is to update the value passed to the `imageService` function to be an object.

URL before fix (see tint param): 
![image](https://user-images.githubusercontent.com/17846996/111615512-bd16b600-87d8-11eb-9905-e3131c66b69e.png)

URL after fix: 
![image](https://user-images.githubusercontent.com/17846996/111615553-c99b0e80-87d8-11eb-87cc-c03c34021b48.png)

----
### How did this even work in the first place?!
Background to be discussed later with Kara:

- This bug was introduced in this PR: https://github.com/Financial-Times/next-front-page/commit/53dc5bd4bd2798c3558cc91a1de1aecf4a7c6b66 which bumped `x-teaser` in the front page from `1.6.4` to `3.3.0` on 22nd Jan
- In `v1.6.4` the code for the `imageService` function is set up to receive and process an `options` argument of type `string`, which makes sense on the surface:- somewhere between `v1.6.4` and `v3.3.0` that code was refactored to expect an object but updating the options type in the `headshot` function which calls `imageService` was forgotten:
```
 const BASE_URL = 'https://www.ft.com/__origami/service/image/v2/images/raw';
const OPTIONS = ['source=next', 'fit=scale-down', 'dpr=2'];

export default function imageService(url, width, options) {
	const encoded = encodeURIComponent(url);
	const href = `${BASE_URL}/${encoded}?${OPTIONS.join('&')}&width=${width}`;
	return options ? href + '&' + options : href;
}
```
- When `v3.3.0` was applied to the front-page this oversight manifested itself in not-blue headshots, and this PR is the fix for it

HOWEVER THIS IS NOT THE CASE!
- The code which refactored the `imageService` function to expect an object was actually written, released, and then _reverted_ on Dec 6th **2019** - https://github.com/Financial-Times/x-dash/pull/425 and the [commit history for the file](https://github.com/Financial-Times/x-dash/commits/main/components/x-teaser/src/Headshot.jsx) shows there have been no other changes since then bar one linting update:
![image](https://user-images.githubusercontent.com/17846996/111689490-017b7380-8824-11eb-9fea-00d00648698a.png)

- SO the object-expecting version of the `imageService` function should have been removed from the codebase entirely in 2019, and yet it was somehow re-applied at some point between `v1.6.4` and `v3.3.0` and yet there's no record of it in GitHub. Howwww?!!!

