### PR TITLE
Update x-live-blog-post byline documentation

### DIFF
--- a/components/x-live-blog-post/readme.md
+++ b/components/x-live-blog-post/readme.md
@@ -45,6 +45,7 @@ Feature             | Type   | Notes
 `postId`            | String | Deprecated - Unique id to reference the content
 `title`             | String | Title of the content
 `bodyHTML`          | String | Body of the content
+`byline`            | String | Byline for the post, sometimes used to render the author's name.
 `content`           | String | Deprecated - Body of the content
 `isBreakingNews`    | Bool   | When `true` displays "breaking news" tag
 `publishedDate`     | String | ISO timestamp of publish date


### PR DESCRIPTION
We added functionality to render a byline here:
https://github.com/Financial-Times/x-dash/commit/15eddd1741e87ba405acd9f73958a0eaa161c92a

This adds the documentation for that new property.