### PR TITLE
Update payload to ensure that FTConsent_GDPR is set

### DIFF
--- a/components/x-privacy-manager/src/__tests__/helpers.js
+++ b/components/x-privacy-manager/src/__tests__/helpers.js
@@ -2,6 +2,7 @@ export const CONSENT_PROXY_HOST = 'https://consent.ft.com'
 export const CONSENT_PROXY_ENDPOINT = 'https://consent.ft.com/__consent/consent-record/FTPINK/abcde'
 
 export const buildPayload = (consent) => ({
+	setConsentCookie: true,
 	consentSource: 'consuming-app',
 	data: {
 		behaviouralAds: {

--- a/components/x-privacy-manager/src/actions.js
+++ b/components/x-privacy-manager/src/actions.js
@@ -28,6 +28,7 @@ function sendConsent({ consentApiUrl, onConsentSavedCallbacks, consentSource, co
 		}
 
 		const payload = {
+			setConsentCookie: true,
 			formOfWordsId: fow.id,
 			consentSource,
 			data: {


### PR DESCRIPTION
This PR adds a `setConsentCookie` property to the payload to trigger the setting of the `FTConsent_GDPR` cookie in the response from the server