### PR TITLE
Send setConsentCookie only when legislationId is 'gdpr'

### DIFF
--- a/components/x-privacy-manager/jsconfig.json
+++ b/components/x-privacy-manager/jsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "outDir": "dist/types",
-    "allowJs": true,
     "target": "es2015",
     "module": "commonjs",
     "strict": true,

--- a/components/x-privacy-manager/src/__tests__/helpers.js
+++ b/components/x-privacy-manager/src/__tests__/helpers.js
@@ -1,39 +1,58 @@
+const React = require('react')
+
+// eslint-disable-next-line no-unused-vars
+const { h } = require('@financial-times/x-engine')
+const { mount } = require('@financial-times/x-test-utils/enzyme')
+
+import { PrivacyManager } from '../privacy-manager'
+
 export const CONSENT_PROXY_HOST = 'https://consent.ft.com'
 export const CONSENT_PROXY_ENDPOINT = 'https://consent.ft.com/__consent/consent-record/FTPINK/abcde'
 
-export const buildPayload = (consent) => ({
-	setConsentCookie: true,
-	consentSource: 'consuming-app',
-	data: {
-		behaviouralAds: {
-			onsite: {
-				fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
-				lbi: true,
-				source: 'consuming-app',
-				status: consent
+/**
+ *
+ * @param {{
+ *   setConsentCookie: boolean,
+ *   consent: boolean
+ * }}
+ * @returns
+ */
+export const buildPayload = ({ setConsentCookie, consent }) => {
+	return {
+		setConsentCookie,
+		consentSource: 'consuming-app',
+		data: {
+			behaviouralAds: {
+				onsite: {
+					fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
+					lbi: true,
+					source: 'consuming-app',
+					status: consent
+				}
+			},
+			demographicAds: {
+				onsite: {
+					fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
+					lbi: true,
+					source: 'consuming-app',
+					status: consent
+				}
+			},
+			programmaticAds: {
+				onsite: {
+					fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
+					lbi: true,
+					source: 'consuming-app',
+					status: consent
+				}
 			}
 		},
-		demographicAds: {
-			onsite: {
-				fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
-				lbi: true,
-				source: 'consuming-app',
-				status: consent
-			}
-		},
-		programmaticAds: {
-			onsite: {
-				fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
-				lbi: true,
-				source: 'consuming-app',
-				status: consent
-			}
-		}
-	},
-	cookieDomain: '.ft.com',
-	formOfWordsId: 'privacyCCPA'
-})
+		cookieDomain: '.ft.com',
+		formOfWordsId: 'privacyCCPA'
+	}
+}
 
+/** @type {XPrivacyManager.BasePrivacyManagerProps} */
 export const defaultProps = {
 	userId: 'abcde',
 	legislationId: 'ccpa',
@@ -48,5 +67,36 @@ export const defaultProps = {
 	actions: {
 		onConsentChange: jest.fn(() => {}),
 		sendConsent: jest.fn().mockReturnValue({ _response: { ok: undefined } })
+	},
+	onConsentSavedCallbacks: [jest.fn(), jest.fn()]
+}
+
+/**
+ * Configure an instance of PrivacyManager and set up
+ * - Handlers for submit events
+ * - Post-submission callbacks
+ *
+ * @param {Partial<XPrivacyManager.BasePrivacyManagerProps>} propOverrides
+ *
+ * @returns {{
+ *   subject: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
+ *   callbacks: XPrivacyManager.OnSaveCallback[] | jest.Mock<any, any>[];
+ *   submitConsent(value: boolean): Promise<void>;
+ * }}
+ */
+export function setupPrivacyManager(propOverrides = {}) {
+	const props = Object.assign({}, defaultProps, propOverrides)
+	const subject = mount(<PrivacyManager {...props} />)
+
+	return {
+		subject,
+		callbacks: props.onConsentSavedCallbacks,
+		async submitConsent(value) {
+			await subject.find(`input[value="${value}"]`).first().prop('onChange')(undefined)
+			await subject.find('form').first().prop('onSubmit')(undefined)
+
+			// Reconcile snapshot with state
+			subject.update()
+		}
 	}
 }

--- a/components/x-privacy-manager/src/__tests__/messaging.test.jsx
+++ b/components/x-privacy-manager/src/__tests__/messaging.test.jsx
@@ -1,21 +1,21 @@
-const { h } = require('@financial-times/x-engine');
-const { mount } = require('@financial-times/x-test-utils/enzyme');
+const { h } = require('@financial-times/x-engine')
+const { mount } = require('@financial-times/x-test-utils/enzyme')
 
-import { defaultProps } from './helpers';
+import { defaultProps } from './helpers'
 
-import { BasePrivacyManager } from '../privacy-manager';
+import { BasePrivacyManager } from '../privacy-manager'
 
 function findMessageComponent(props) {
-	const subject = mount(<BasePrivacyManager {...props} />);
-	const messages = subject.find('[data-o-component="o-message"]');
-	const message = messages.first();
-	const link = message.find('[data-component="referrer-link"]');
+	const subject = mount(<BasePrivacyManager {...props} />)
+	const messages = subject.find('[data-o-component="o-message"]')
+	const message = messages.first()
+	const link = message.find('[data-component="referrer-link"]')
 
 	return {
 		messages,
 		message,
-		link,
-	};
+		link
+	}
 }
 
 describe('x-privacy-manager', () => {
@@ -25,50 +25,50 @@ describe('x-privacy-manager', () => {
 			consent: true,
 			legislation: ['ccpa'],
 			isLoading: false,
-			_response: undefined,
-		};
+			_response: undefined
+		}
 
 		it('None by default', () => {
-			const { messages } = findMessageComponent(messageProps);
-			expect(messages).toHaveLength(0);
-		});
+			const { messages } = findMessageComponent(messageProps)
+			expect(messages).toHaveLength(0)
+		})
 
 		it('While loading', () => {
-			const { messages, message } = findMessageComponent({ ...messageProps, isLoading: true });
-			expect(messages).toHaveLength(1);
-			expect(message).toHaveClassName('o-message--neutral');
-		});
+			const { messages, message } = findMessageComponent({ ...messageProps, isLoading: true })
+			expect(messages).toHaveLength(1)
+			expect(message).toHaveClassName('o-message--neutral')
+		})
 
 		it('On receiving a response with a status of 200', () => {
-			const _response = { ok: true, status: 200 };
-			const { messages, message, link } = findMessageComponent({ ...messageProps, _response });
+			const _response = { ok: true, status: 200 }
+			const { messages, message, link } = findMessageComponent({ ...messageProps, _response })
 
-			expect(messages).toHaveLength(1);
-			expect(message).toHaveClassName('o-message--success');
-			expect(link).toHaveProp('href', 'https://www.ft.com/');
-		});
+			expect(messages).toHaveLength(1)
+			expect(message).toHaveClassName('o-message--success')
+			expect(link).toHaveProp('href', 'https://www.ft.com/')
+		})
 
 		it('On receiving a response with a non-200 status', () => {
-			const _response = { ok: false, status: 400 };
-			const { messages, message, link } = findMessageComponent({ ...messageProps, _response });
+			const _response = { ok: false, status: 400 }
+			const { messages, message, link } = findMessageComponent({ ...messageProps, _response })
 
-			expect(messages).toHaveLength(1);
-			expect(message).toHaveClassName('o-message--error');
-			expect(link).toHaveProp('href', 'https://www.ft.com/');
-		});
+			expect(messages).toHaveLength(1)
+			expect(message).toHaveClassName('o-message--error')
+			expect(link).toHaveProp('href', 'https://www.ft.com/')
+		})
 
 		it('On receiving any response with referrer undefined', () => {
-			const _response = { ok: false, status: 400 };
-			const referrer = undefined;
+			const _response = { ok: false, status: 400 }
+			const referrer = undefined
 			const { messages, message, link } = findMessageComponent({
 				...messageProps,
 				referrer,
-				_response,
-			});
+				_response
+			})
 
-			expect(messages).toHaveLength(1);
-			expect(message).toHaveClassName('o-message--error');
-			expect(link).toHaveLength(0);
-		});
-	});
-});
+			expect(messages).toHaveLength(1)
+			expect(message).toHaveClassName('o-message--error')
+			expect(link).toHaveLength(0)
+		})
+	})
+})

--- a/components/x-privacy-manager/src/actions.js
+++ b/components/x-privacy-manager/src/actions.js
@@ -9,10 +9,17 @@ function onConsentChange(consent) {
  * - consentSource: (e.g. 'next-control-centre')
  * - cookieDomain: (e.g. '.thebanker.com')
  *
- * @param {import("../types").SendConsentProps} args
+ * @param {XPrivacyManager.SendConsentProps} args
  * @returns {({ isLoading, consent }: { isLoading: boolean, consent: boolean }) => Promise<{_response: _Response}>}
  */
-function sendConsent({ consentApiUrl, onConsentSavedCallbacks, consentSource, cookieDomain, fow }) {
+function sendConsent({
+	setConsentCookie,
+	consentApiUrl,
+	onConsentSavedCallbacks,
+	consentSource,
+	cookieDomain,
+	fow
+}) {
 	let res
 
 	return async ({ isLoading, consent }) => {
@@ -28,7 +35,7 @@ function sendConsent({ consentApiUrl, onConsentSavedCallbacks, consentSource, co
 		}
 
 		const payload = {
-			setConsentCookie: true,
+			setConsentCookie,
 			formOfWordsId: fow.id,
 			consentSource,
 			data: {

--- a/components/x-privacy-manager/src/components/form.jsx
+++ b/components/x-privacy-manager/src/components/form.jsx
@@ -2,10 +2,10 @@ import { h } from '@financial-times/x-engine'
 import s from '../privacy-manager.scss'
 
 /**
- * @param {import('../../typings/x-privacy-manager').FormProps} args
+ * @param {XPrivacyManager.FormProps} args
  */
 export const Form = ({ consent, consentApiUrl, sendConsent, trackingKeys, buttonText, children }) => {
-	/** @type {import('../../typings/x-privacy-manager').TrackingKey} */
+	/** @type {XPrivacyManager.TrackingKey} */
 	const consentAction = consent ? 'consent-allow' : 'consent-block'
 	const btnTrackingId = trackingKeys[consentAction]
 	const isDisabled = typeof consent === 'undefined'

--- a/components/x-privacy-manager/src/components/messages.jsx
+++ b/components/x-privacy-manager/src/components/messages.jsx
@@ -82,7 +82,7 @@ export function LoadingMessage() {
 
 /**
  * @param {boolean} isLoading
- * @param {import('../../typings/x-privacy-manager')._Response} response
+ * @param {XPrivacyManager._Response} response
  * @param {string} referrer
  */
 export function renderMessage(isLoading, response, referrer) {

--- a/components/x-privacy-manager/src/components/radio-btn.jsx
+++ b/components/x-privacy-manager/src/components/radio-btn.jsx
@@ -7,7 +7,7 @@ import s from './radio-btn.scss'
  *   name: string,
  *   type: "allow" | "block",
  *   checked: boolean,
- *   trackingKeys: import('../../typings/x-privacy-manager').TrackingKeys,
+ *   trackingKeys: XPrivacyManager.TrackingKeys,
  *   onChange: (value: boolean) => void,
  * }} args
  *

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -14,7 +14,7 @@ const defaultButtonText = {
 }
 
 /**
- * @param {import('../typings/x-privacy-manager').BasePrivacyManagerProps} Props
+ * @param {XPrivacyManager.BasePrivacyManagerProps} Props
  */
 export function BasePrivacyManager({
 	userId,
@@ -59,7 +59,7 @@ export function BasePrivacyManager({
 		onChange: onConsentChange
 	})
 
-	/** @type {import('../typings/x-privacy-manager').FormProps} */
+	/** @type {XPrivacyManager.FormProps} */
 	const formProps = {
 		consent,
 		consentApiUrl,
@@ -67,6 +67,7 @@ export function BasePrivacyManager({
 		buttonText,
 		sendConsent: () => {
 			return sendConsent({
+				setConsentCookie: legislationId === 'gdpr',
 				consentApiUrl,
 				onConsentSavedCallbacks,
 				consentSource,

--- a/components/x-privacy-manager/src/utils.js
+++ b/components/x-privacy-manager/src/utils.js
@@ -1,4 +1,4 @@
-/** @type {import("../types").TrackingKey[]} */
+/** @type {XPrivacyManager.TrackingKey[]} */
 const trackingKeys = [
 	'advertising-toggle-block',
 	'advertising-toggle-allow',
@@ -12,7 +12,7 @@ const trackingKeys = [
  *
  * @param {string} legislationId
  *
- * @returns {import("@financial-times/x-privacy-manager").TrackingKeys}
+ * @returns {XPrivacyManager.TrackingKeys}
  */
 export function getTrackingKeys(legislationId) {
 	/** @type Record<TrackingKey, string> */
@@ -32,7 +32,7 @@ export function getTrackingKeys(legislationId) {
  *   cookieDomain?: string;
  * }} param
  *
- * @returns {import("@financial-times/x-privacy-manager").ConsentProxyEndpoint}
+ * @returns {XPrivacyManager.ConsentProxyEndpoint}
  */
 export function getConsentProxyEndpoints({
 	userId,

--- a/components/x-privacy-manager/storybook/stories/consent-accepted.js
+++ b/components/x-privacy-manager/storybook/stories/consent-accepted.js
@@ -2,7 +2,7 @@ import { StoryContainer } from '../story-container'
 import { defaultArgs, defaultArgTypes, getFetchMock } from '../data'
 
 /**
- * @param {import('../../typings/x-privacy-manager').PrivacyManagerProps} args
+ * @param {XPrivacyManager.PrivacyManagerProps} args
  */
 export const ConsentAccepted = (args) => {
 	getFetchMock(200)

--- a/components/x-privacy-manager/storybook/stories/consent-indeterminate.js
+++ b/components/x-privacy-manager/storybook/stories/consent-indeterminate.js
@@ -2,7 +2,7 @@ import { StoryContainer } from '../story-container'
 import { defaultArgs, defaultArgTypes, getFetchMock } from '../data'
 
 /**
- * @param {import('../../typings/x-privacy-manager').PrivacyManagerProps} args
+ * @param {XPrivacyManager.PrivacyManagerProps} args
  */
 export const ConsentIndeterminate = (args) => {
 	getFetchMock(200)

--- a/components/x-privacy-manager/storybook/stories/save-failed.js
+++ b/components/x-privacy-manager/storybook/stories/save-failed.js
@@ -2,7 +2,7 @@ import { StoryContainer } from '../story-container'
 import { defaultArgs, defaultArgTypes, getFetchMock } from '../data'
 
 /**
- * @param {import('../../typings/x-privacy-manager').PrivacyManagerProps} args
+ * @param {XPrivacyManager.PrivacyManagerProps} args
  */
 export const SaveFailed = (args) => {
 	getFetchMock(500)

--- a/components/x-privacy-manager/typings/x-privacy-manager.d.ts
+++ b/components/x-privacy-manager/typings/x-privacy-manager.d.ts
@@ -29,9 +29,10 @@ interface ConsentPayload {
   data: ConsentData
 }
 
-type OnSaveCallback = (err: null | Error, data: { consent: boolean; payload: ConsentPayload }) => void
+export type OnSaveCallback = (err: null | Error, data: { consent: boolean; payload: ConsentPayload }) => void
 
 export interface SendConsentProps {
+  setConsentCookie: boolean
   consentApiUrl: string
   onConsentSavedCallbacks: OnSaveCallback[]
   consentSource: string
@@ -96,3 +97,5 @@ export interface FormProps {
 }
 
 export { PrivacyManager } from '../src/privacy-manager'
+
+export as namespace XPrivacyManager


### PR DESCRIPTION
It has transpired that the Privacy Manager component should send the `setConsentCookie` flag based on  legislation: CCPA users opting in/out of the sale of their data should not have `FTConsent_GDPR` set to true because they should still be shown the cookie banner.

This PR [encapsulates that requirement](https://github.com/Financial-Times/x-dash/pull/596/files#diff-5c14b4096cd7b936e70498295744fa9fa2a6d91df6a92a676892bd6fefd26614R70) so that consuming apps do not need to make any changes

Additionally 
- Tests have been refactored to simplify the mounting a configured instance of the component
- Type definitions have been updated to make reference easier under an `XPrivacyManager` namespace