### PR TITLE
handle multiple customSlot components for x-teaser-timeline

### DIFF
--- a/components/x-teaser-timeline/__tests__/lib/transform.test.js
+++ b/components/x-teaser-timeline/__tests__/lib/transform.test.js
@@ -322,5 +322,32 @@ describe('buildModel', () => {
 				groupedItems[2]
 			])
 		})
+		test('returns correct model for multiple custom slots off end of all groups', () => {
+			const result = buildModel({
+				items,
+				timezoneOffset: 0,
+				localTodayDate: '2020-01-14',
+				customSlotContent: [{ foo: 1 }, { bar: 2 }],
+				customSlotPosition: [0, 10]
+			})
+			expect(result).toEqual([
+				{
+					...groupedItems[0],
+					items: [
+						{ foo: 1 },
+						groupedItems[0].items[0],
+						groupedItems[0].items[1],
+						groupedItems[0].items[2],
+						{ bar: 2 },
+						groupedItems[0].items[3]
+					]
+				},
+				groupedItems[1],
+				{
+					...groupedItems[2],
+					items: [...groupedItems[2].items, { bar: 2 }]
+				}
+			])
+		})
 	})
 })

--- a/components/x-teaser-timeline/__tests__/lib/transform.test.js
+++ b/components/x-teaser-timeline/__tests__/lib/transform.test.js
@@ -338,7 +338,6 @@ describe('buildModel', () => {
 						groupedItems[0].items[0],
 						groupedItems[0].items[1],
 						groupedItems[0].items[2],
-						{ bar: 2 },
 						groupedItems[0].items[3]
 					]
 				},

--- a/components/x-teaser-timeline/__tests__/lib/transform.test.js
+++ b/components/x-teaser-timeline/__tests__/lib/transform.test.js
@@ -322,6 +322,30 @@ describe('buildModel', () => {
 				groupedItems[2]
 			])
 		})
+		test('returns correct model for a non-zero custom slot', () => {
+			const result = buildModel({
+				items,
+				timezoneOffset: 0,
+				localTodayDate: '2020-01-14',
+				customSlotContent: [{ foo: 1 }, { bar: 2 }],
+				customSlotPosition: [2, 3]
+			})
+			expect(result).toEqual([
+				{
+					...groupedItems[0],
+					items: [
+						groupedItems[0].items[0],
+						groupedItems[0].items[1],
+						{ foo: 1 },
+						groupedItems[0].items[2],
+						{ bar: 2 },
+						groupedItems[0].items[3]
+					]
+				},
+				groupedItems[1],
+				groupedItems[2]
+			])
+		})
 		test('returns correct model for multiple custom slots off end of all groups', () => {
 			const result = buildModel({
 				items,

--- a/components/x-teaser-timeline/__tests__/lib/transform.test.js
+++ b/components/x-teaser-timeline/__tests__/lib/transform.test.js
@@ -298,5 +298,29 @@ describe('buildModel', () => {
 				groupedItems[2]
 			])
 		})
+		test('returns correct model for multiple custom slots', () => {
+			const result = buildModel({
+				items,
+				timezoneOffset: 0,
+				localTodayDate: '2020-01-14',
+				customSlotContent: [{ foo: 1 }, { bar: 2 }],
+				customSlotPosition: [0, 3]
+			})
+			expect(result).toEqual([
+				{
+					...groupedItems[0],
+					items: [
+						{ foo: 1 },
+						groupedItems[0].items[0],
+						groupedItems[0].items[1],
+						groupedItems[0].items[2],
+						{ bar: 2 },
+						groupedItems[0].items[3]
+					]
+				},
+				groupedItems[1],
+				groupedItems[2]
+			])
+		})
 	})
 })

--- a/components/x-teaser-timeline/readme.md
+++ b/components/x-teaser-timeline/readme.md
@@ -56,8 +56,8 @@ Feature              | Type            | Notes
 `localTodayDate`     | String          | (Defaults using runtime clock) ISO format YYYY-MM-DD representating today's date in the user's timezone.
 `latestItemsTime`    | String          | ISO time (HH:mm:ss). If provided, will be used in combination with `localTodayDate` to render today's items into separate "Latest" and "Earlier" groups.
 `showSaveButtons`    | Boolean         | (Default to true). Option to hide x-article-save-buttons if they are not needed. Those buttons will get their saved/unsaved state from a `saved` property of the content item.
-`customSlotContent`  | String          | Content to insert at `customSlotPosition`.
-`customSlotPosition` | Number          | (Default is 2). Where to insert `customSlotContent`. The custom content will be inserted after the item at this position number. If this position is greater than the number items to render, then it will be inserted last.
+`customSlotContent`  | String or Array | Content to insert at `customSlotPosition`.
+`customSlotPosition` | Number or Array | (Default is 2). Where to insert `customSlotContent`. The custom content will be inserted after the item at this position number. If this position is greater than the number items to render, then it will be inserted last.
 `csrfToken`          | String          | A CSRF token that will be used by the save buttons (if shown).
 `latestItemsAgeHours`| Number          | (Optional). If provided, used to calculate a cutoff time before which no article will count as "latest", regardless of the value of `latestItemsTime`. If omitted, articles before midnight this morning will not count as "latest".
 

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -166,18 +166,23 @@ export const buildModel = ({
 		latestItemsAgeHours
 	})
 	if (itemGroups.length > 0 && customSlotContent) {
-		customSlotContent = Array.isArray(customSlotContent) ? customSlotContent : [customSlotContent]
-		customSlotPosition = Array.isArray(customSlotPosition) ? customSlotPosition : [customSlotPosition]
+		const customSlotContentArray = Array.isArray(customSlotContent) ? customSlotContent : [customSlotContent]
+		const customSlotPositionArray = Array.isArray(customSlotPosition)
+			? customSlotPosition
+			: [customSlotPosition]
 
-		customSlotContent.forEach((item, index) => {
-			const insertPosition = Math.min(customSlotPosition[index], items.length)
+		for (const [index, slotContent] of customSlotContentArray.entries()) {
+			const insertPosition = Math.min(
+				customSlotPositionArray[index],
+				items.length + customSlotPositionArray.length - 1
+			)
 			const insert = getGroupAndIndex(itemGroups, insertPosition)
 			const copyOfItems = [...itemGroups[insert.group].items]
 
-			copyOfItems.splice(insert.index, 0, item)
+			copyOfItems.splice(insert.index, 0, slotContent)
 
 			itemGroups[insert.group].items = copyOfItems
-		})
+		}
 	}
 	return itemGroups
 }

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -167,13 +167,12 @@ export const buildModel = ({
 	})
 	if (itemGroups.length > 0 && customSlotContent) {
 		const customSlotContentArray = Array.isArray(customSlotContent) ? customSlotContent : [customSlotContent]
-		const customSlotPositionArray = Array.isArray(customSlotPosition) ? customSlotPosition : [customSlotPosition]
+		const customSlotPositionArray = Array.isArray(customSlotPosition)
+			? customSlotPosition
+			: [customSlotPosition]
 
 		for (const [index, slotContent] of customSlotContentArray.entries()) {
-			const insertPosition = Math.min(
-				customSlotPositionArray[index],
-				items.length + customSlotPositionArray.length - 1
-			)
+			const insertPosition = Math.min(customSlotPositionArray[index], items.length + index)
 			const insert = getGroupAndIndex(itemGroups, insertPosition)
 			const copyOfItems = [...itemGroups[insert.group].items]
 

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -165,15 +165,19 @@ export const buildModel = ({
 		latestItemsTime,
 		latestItemsAgeHours
 	})
-
 	if (itemGroups.length > 0 && customSlotContent) {
-		const insertPosition = Math.min(customSlotPosition, items.length)
-		const insert = getGroupAndIndex(itemGroups, insertPosition)
-		const copyOfItems = [...itemGroups[insert.group].items]
+		customSlotContent = Array.isArray(customSlotContent) ? customSlotContent : [customSlotContent]
+		customSlotPosition = Array.isArray(customSlotPosition) ? customSlotPosition : [customSlotPosition]
 
-		copyOfItems.splice(insert.index, 0, customSlotContent)
+		customSlotContent.forEach((item, index) => {
+			const insertPosition = Math.min(customSlotPosition[index], items.length)
+			const insert = getGroupAndIndex(itemGroups, insertPosition)
+			const copyOfItems = [...itemGroups[insert.group].items]
 
-		itemGroups[insert.group].items = copyOfItems
+			copyOfItems.splice(insert.index, 0, item)
+
+			itemGroups[insert.group].items = copyOfItems
+		})
 	}
 	return itemGroups
 }

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -162,8 +162,8 @@ const interleaveAllSlotsWithCustomSlots = (
 
 		copyOfItems.splice(insert.index, 0, slotContent)
 		itemGroups[insert.group].items = copyOfItems
-		return itemGroups
 	}
+	return itemGroups
 }
 
 export const buildModel = ({

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -167,9 +167,7 @@ export const buildModel = ({
 	})
 	if (itemGroups.length > 0 && customSlotContent) {
 		const customSlotContentArray = Array.isArray(customSlotContent) ? customSlotContent : [customSlotContent]
-		const customSlotPositionArray = Array.isArray(customSlotPosition)
-			? customSlotPosition
-			: [customSlotPosition]
+		const customSlotPositionArray = Array.isArray(customSlotPosition) ? customSlotPosition : [customSlotPosition]
 
 		for (const [index, slotContent] of customSlotContentArray.entries()) {
 			const insertPosition = Math.min(

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -149,6 +149,23 @@ const getGroupAndIndex = (groups, position) => {
 	}
 }
 
+const interleaveAllSlotsWithCustomSlots = (
+	customSlotContentArray,
+	customSlotPositionArray,
+	itemGroups,
+	items
+) => {
+	for (const [index, slotContent] of customSlotContentArray.entries()) {
+		const insertPosition = Math.min(customSlotPositionArray[index], items.length + index)
+		const insert = getGroupAndIndex(itemGroups, insertPosition)
+		const copyOfItems = [...itemGroups[insert.group].items]
+
+		copyOfItems.splice(insert.index, 0, slotContent)
+		itemGroups[insert.group].items = copyOfItems
+		return itemGroups
+	}
+}
+
 export const buildModel = ({
 	items,
 	customSlotContent,
@@ -158,28 +175,26 @@ export const buildModel = ({
 	latestItemsTime,
 	latestItemsAgeHours
 }) => {
-	const itemGroups = getItemGroups({
+	let itemGroups = getItemGroups({
 		items,
 		timezoneOffset,
 		localTodayDate,
 		latestItemsTime,
 		latestItemsAgeHours
 	})
+
 	if (itemGroups.length > 0 && customSlotContent) {
 		const customSlotContentArray = Array.isArray(customSlotContent) ? customSlotContent : [customSlotContent]
 		const customSlotPositionArray = Array.isArray(customSlotPosition)
 			? customSlotPosition
 			: [customSlotPosition]
 
-		for (const [index, slotContent] of customSlotContentArray.entries()) {
-			const insertPosition = Math.min(customSlotPositionArray[index], items.length + index)
-			const insert = getGroupAndIndex(itemGroups, insertPosition)
-			const copyOfItems = [...itemGroups[insert.group].items]
-
-			copyOfItems.splice(insert.index, 0, slotContent)
-
-			itemGroups[insert.group].items = copyOfItems
-		}
+		itemGroups = interleaveAllSlotsWithCustomSlots(
+			customSlotContentArray,
+			customSlotPositionArray,
+			itemGroups,
+			items
+		)
 	}
 	return itemGroups
 }


### PR DESCRIPTION
This update is a minor patch to enable multiple customSlots to be added to the `x-teaser-timeline` component.

Ideally I'd liked to have make this a new import, but I didn't want to make the change a breaking one. `x-teaser-timeline` can still accept the old style of customSlot (a String and a Number), but now also allows for multiple components.