### PR TITLE
Remove unused docs and sb build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "clean": "git clean -fxdi",
-    "build": "athloi run build --concurrency 3 && npm run build-storybook",
+    "build": "athloi run build --concurrency 3",
     "build-only": "athloi run build",
     "jest": "jest -c jest.config.js",
     "test": "npm run lint && npm run jest",
@@ -11,10 +11,7 @@
     "blueprint": "node private/scripts/blueprint.js",
     "start-storybook": "start-storybook -p ${STORYBOOK_PORT:-9001} -s .storybook/static -h local.ft.com",
     "start-storybook:ci": "start-storybook -p ${STORYBOOK_PORT:-9001} -s .storybook/static -h local.ft.com --ci --smoke-test",
-    "build-storybook": "build-storybook -o dist/storybook -s .storybook/static",
     "deploy-storybook:ci": "storybook-to-ghpages --ci --source-branch=main",
-    "start-docs": "(cd web && npm start)",
-    "build-docs": "(cd web && npm run build)",
     "heroku-postbuild": "make install && npm run build",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
   },


### PR DESCRIPTION
The 404 error on Storybook started showing up again after the main branch ran the `deploy` task on CircleCI. I have been able to fix it locally by removing the `build-storybook` command, my guess is that it could be because the `storybook-to-ghpages` also runs a command named `build-storybook`.

If it is not that it could be that I am running the `storybook-to-ghpages` command without the `--ci` option locally.

I also removed the unused scripts for the docs.