### PR TITLE
feat: Add support for Preact.Fragment in x-engine

### DIFF
--- a/packages/x-engine/src/concerns/presets.js
+++ b/packages/x-engine/src/concerns/presets.js
@@ -11,6 +11,7 @@ module.exports = {
 		runtime: 'preact',
 		factory: 'h',
 		component: 'Component',
+		fragment: 'Fragment',
 		render: 'render'
 	},
 	hyperons: {


### PR DESCRIPTION
We currently support Fragments in react and hyperons, but not preact ([which did not support Fragments until the latest major version, 10.x](https://preactjs.com/guide/v10/whats-new/#fragments)).

This PR adds support via x-engine for `preact.Fragment`.

I'm unsure how this change should affect versioning. So would very much appreciate input on that.