### PR TITLE
Fix gift article storybook to call activate action

### DIFF
--- a/components/x-gift-article/storybook/free-article.js
+++ b/components/x-gift-article/storybook/free-article.js
@@ -19,12 +19,10 @@ exports.fetchMock = (fetchMock) => {
 	fetchMock
 		.restore()
 		.get('/article/gift-credits', {
-			credits: {
-				allowance: 20,
-				consumedCredits: 5,
-				remainingCredits: 15,
-				renewalDate: '2018-08-01T00:00:00Z'
-			}
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
 		})
 		.get(`/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
 			shortenedUrl: 'https://shortened-non-gift-url'

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -20,7 +20,7 @@ export const WithGiftCredits = (args) => {
 			<Helmet>
 				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
 			</Helmet>
-			<GiftArticle {...args} />
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
 		</div>
 	)
 }
@@ -35,7 +35,7 @@ export const WithoutGiftCredits = (args) => {
 			<Helmet>
 				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
 			</Helmet>
-			<GiftArticle {...args} />
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
 		</div>
 	)
 }
@@ -67,7 +67,7 @@ export const FreeArticle = (args) => {
 			<Helmet>
 				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
 			</Helmet>
-			<GiftArticle {...args} />
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
 		</div>
 	)
 }
@@ -83,7 +83,7 @@ export const NativeShare = (args) => {
 			<Helmet>
 				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
 			</Helmet>
-			<GiftArticle {...args} />
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
 		</div>
 	)
 }
@@ -99,7 +99,7 @@ export const ErrorResponse = (args) => {
 			<Helmet>
 				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
 			</Helmet>
-			<GiftArticle {...args} />
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
 		</div>
 	)
 }

--- a/components/x-gift-article/storybook/native-share.js
+++ b/components/x-gift-article/storybook/native-share.js
@@ -23,12 +23,10 @@ exports.fetchMock = (fetchMock) => {
 	fetchMock
 		.restore()
 		.get('/article/gift-credits', {
-			credits: {
-				allowance: 20,
-				consumedCredits: 2,
-				remainingCredits: 18,
-				renewalDate: '2018-08-01T00:00:00Z'
-			}
+			allowance: 20,
+			consumedCredits: 2,
+			remainingCredits: 18,
+			renewalDate: '2018-08-01T00:00:00Z'
 		})
 		.get(`/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
 			shortenedUrl: 'https://shortened-gift-url'

--- a/components/x-gift-article/storybook/with-gift-credits.js
+++ b/components/x-gift-article/storybook/with-gift-credits.js
@@ -23,12 +23,10 @@ exports.fetchMock = (fetchMock) => {
 	fetchMock
 		.restore()
 		.get('/article/gift-credits', {
-			credits: {
-				allowance: 20,
-				consumedCredits: 5,
-				remainingCredits: 15,
-				renewalDate: '2018-08-01T00:00:00Z'
-			}
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
 		})
 		.get(`/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
 			shortenedUrl: 'https://shortened-gift-url'

--- a/components/x-gift-article/storybook/without-gift-credits.js
+++ b/components/x-gift-article/storybook/without-gift-credits.js
@@ -19,12 +19,10 @@ exports.fetchMock = (fetchMock) => {
 	fetchMock
 		.restore()
 		.get('/article/gift-credits', {
-			credits: {
-				allowance: 20,
-				consumedCredits: 20,
-				remainingCredits: 0,
-				renewalDate: '2018-08-01T00:00:00Z'
-			}
+			allowance: 20,
+			consumedCredits: 20,
+			remainingCredits: 0,
+			renewalDate: '2018-08-01T00:00:00Z'
 		})
 		.get(`/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
 			shortenedUrl: 'https://shortened-non-gift-url'


### PR DESCRIPTION
Fixes an issue where the gift articles stories in storybook weren't showing how many credits were left.

As per the gift article docs, the `activate` action needs to be called to run the API call (which is mocked by `node-fetch` in this case.) Not exactly sure where the best place to do this would be so I just put it inside its own `actionRef` callback. Maybe this makes sense as we aren't showing the `GiftArticle` component conditionally, instead showing it as soon as it's mounted.

For reference:

- [Description of `actionRef`](https://github.com/Financial-Times/x-dash/tree/09fd985bd97ce907cb297ad586ac9989cee9c296/components/x-gift-article#usage)
- [Description of the `ref` pattern it's based on](https://reactjs.org/docs/refs-and-the-dom.html)

Screenshot of 'With gift credits' story before and after:

**Before**
<img width="855" alt="Screenshot 2021-07-06 at 15 51 08" src="https://user-images.githubusercontent.com/7020796/124621199-fc454180-de71-11eb-9a67-f59d4b33bcf6.png">
**After**
<img width="855" alt="Story after fix" src="https://user-images.githubusercontent.com/7020796/124620914-c011e100-de71-11eb-84fb-3cf1599eecde.png">