### PR TITLE
AT-4761 Update x-teaser status spacing

### DIFF
--- a/components/x-teaser/src/LiveBlogStatus.jsx
+++ b/components/x-teaser/src/LiveBlogStatus.jsx
@@ -15,6 +15,6 @@ const LiveBlogModifiers = {
 export default ({ status }) =>
 	status && status !== 'closed' ? (
 		<div className={`o-teaser__timestamp o-teaser__timestamp--${LiveBlogModifiers[status]}`}>
-			<span className="o-teaser__timestamp-prefix">{LiveBlogLabels[status]}</span>
+			<span className="o-teaser__timestamp-prefix">{` ${LiveBlogLabels[status]} `}</span>
 		</div>
 	) : null

--- a/components/x-teaser/src/RelativeTime.jsx
+++ b/components/x-teaser/src/RelativeTime.jsx
@@ -21,7 +21,7 @@ export default ({ publishedDate, firstPublishedDate, showAlways = false }) => {
 
 	return showAlways === true || isRecent(relativeDate) ? (
 		<div className={`o-teaser__timestamp o-teaser__timestamp--${status}`}>
-			{status ? <span className="o-teaser__timestamp-prefix">{`${status} `} </span> : null}
+			{status ? <span className="o-teaser__timestamp-prefix">{` ${status} `} </span> : null}
 			<time
 				className="o-teaser__timestamp-date o-date"
 				data-o-component="o-date"

--- a/components/x-teaser/storybook/index.jsx
+++ b/components/x-teaser/storybook/index.jsx
@@ -4,9 +4,9 @@ import BuildService from '../../../.storybook/build-service'
 
 const dependencies = {
 	'o-date': '^4.2.0',
-	'o-labels': '^5.0.0',
+	'o-labels': '^5.2.0',
 	'o-normalise': '^2.0.0',
-	'o-teaser': '^4.0.0',
+	'o-teaser': '^5.2.3',
 	'o-typography': '^6.0.0',
 	'o-video': '^6.0.0'
 }


### PR DESCRIPTION
### Add leading space to increase spacing in Teaser status

#### Context:
* Apps team UX noticed that the App is out of sync with FT.com and has less spacing between the Teaser status dot and the status text (FT.com currently has `5px`). 
* Investigation found that FT.com is using some older versions of `o-teaser` and `o-labels` - `next-front-page` uses `o-teaser "4.1.0-beta.1", "o-labels": "^5.0.0", "@financial-times/x-teaser": "^4.1.3"`, `ft-app` uses `o-teaser": "^5.2.2", o-labels": "^5.1.5", x-teaser": "5.2.0"`
* `o-labels` now (as of `v5.1.5`) only adds `margin-right: 2px` between these two elements. Change introduced [here](https://github.com/Financial-Times/o-labels/commit/cbdfb2a7d78427b691a439704613f3c2a6c34014#diff-369e718fbbdf6907bf9e45dfdf3234cce054c6e399981f0bca5cfa5a2926d1a8).
* Design spec for the status shows `4px` space between the elements:
<img src="https://user-images.githubusercontent.com/35195024/124148907-089f5800-da88-11eb-9ebe-edfbd1f007d4.png" width=160 />


#### Approach:
* Raised discussion with the Origami team to see if preference was to update `o-labels` to `margin-right: 4px` or update `x-teaser`. The Origami team were keen to leave `o-labels` as is (due to unknown number of consumers and wider impact). Full conversation here - https://financialtimes.slack.com/archives/C02FU5ARJ/p1624447956081800
* Adding a leading literal space creates the required visual. (`o-labels` demo also includes a leading space https://www.ft.com/__origami/service/build/v2/demos/o-labels@5.2.0/indicators?brand=master). 

#### Testing:
1. Updated the `x-teaser` storybook dependencies to use the newer `o-teaser` and `o-labels` as per this change of styles.
2. Tested locally in the FT App:
<img width="289" alt="Updated Status 'New' in FT App - July 2021" src="https://user-images.githubusercontent.com/35195024/124148176-510a4600-da87-11eb-9e45-26b43a828500.png">
<img width="289" alt="Live Blog Status in FT App - July 2021" src="https://user-images.githubusercontent.com/35195024/124148186-536ca000-da87-11eb-9033-7970e368527c.png">
<img width="288" alt="X-teaser Timeline Status in FT App - July 2021" src="https://user-images.githubusercontent.com/35195024/124148196-55cefa00-da87-11eb-98e1-e88c5c0f63ee.png">

3. Tested locally on FT.com front page (also had to update `o-teaser` and `o-labels` locally for for this test):
<img width="623" alt="Update Status on FT com Next Front Page - July 2021" src="https://user-images.githubusercontent.com/35195024/124148213-59628100-da87-11eb-8f49-1b555c27c4b8.png">

#### Proposed Next Steps:
- If approved, release changes as a "patch" change to `x-teaser`.
- I will contact the `next-front-page` maintainers to let them know about this change.
- Update `ft-app` to consume a new "patch" version of `x-teaser` containing this change. 

