### PR TITLE
Revert "AT-4761 Update x-teaser status spacing"

### DIFF
--- a/components/x-teaser/src/LiveBlogStatus.jsx
+++ b/components/x-teaser/src/LiveBlogStatus.jsx
@@ -15,6 +15,6 @@ const LiveBlogModifiers = {
 export default ({ status }) =>
 	status && status !== 'closed' ? (
 		<div className={`o-teaser__timestamp o-teaser__timestamp--${LiveBlogModifiers[status]}`}>
-			<span className="o-teaser__timestamp-prefix">{` ${LiveBlogLabels[status]} `}</span>
+			<span className="o-teaser__timestamp-prefix">{LiveBlogLabels[status]}</span>
 		</div>
 	) : null

--- a/components/x-teaser/src/RelativeTime.jsx
+++ b/components/x-teaser/src/RelativeTime.jsx
@@ -21,7 +21,7 @@ export default ({ publishedDate, firstPublishedDate, showAlways = false }) => {
 
 	return showAlways === true || isRecent(relativeDate) ? (
 		<div className={`o-teaser__timestamp o-teaser__timestamp--${status}`}>
-			{status ? <span className="o-teaser__timestamp-prefix">{` ${status} `} </span> : null}
+			{status ? <span className="o-teaser__timestamp-prefix">{`${status} `} </span> : null}
 			<time
 				className="o-teaser__timestamp-date o-date"
 				data-o-component="o-date"

--- a/components/x-teaser/storybook/index.jsx
+++ b/components/x-teaser/storybook/index.jsx
@@ -4,9 +4,9 @@ import BuildService from '../../../.storybook/build-service'
 
 const dependencies = {
 	'o-date': '^4.2.0',
-	'o-labels': '^5.2.0',
+	'o-labels': '^5.0.0',
 	'o-normalise': '^2.0.0',
-	'o-teaser': '^5.2.3',
+	'o-teaser': '^4.0.0',
 	'o-typography': '^6.0.0',
 	'o-video': '^6.0.0'
 }


### PR DESCRIPTION
Reverting this change temporarily while FT.com teams review the work needed to update their apps to latest x-teaser and relevant origami packages. Currently Article Page, MyFT Page, Stream Page and Front Page are major versions behind. 

We do not want this change to accidentally get released. 

See https://github.com/Financial-Times/x-dash/pull/606 for more context. 

The Apps team will block the AT-4761 while we wait for the green light from Content Discovery and Content Innovation. 

cc @umbobabo and @jkerr321 