### PR TITLE
Apply focus outline depends on theme colour

### DIFF
--- a/components/x-follow-button/src/styles/mixins/lozenge/_themes.scss
+++ b/components/x-follow-button/src/styles/mixins/lozenge/_themes.scss
@@ -6,28 +6,32 @@ $myft-lozenge-themes: (
 		text: oColorsByName('white'),
 		highlight: oColorsByName('claret-50'),
 		pressed-highlight: rgba(oColorsByName('black'), 0.05),
-		disabled: rgba(oColorsByName('black'), 0.5)
+		disabled: rgba(oColorsByName('black'), 0.5),
+		focus-outline: oColorsByUsecase('focus', 'outline', $fallback: null)
 	),
 	inverse: (
 		background: oColorsByName('white'),
 		text: oColorsByName('claret'),
 		highlight: rgba(white, 0.8),
 		pressed-highlight: rgba(white, 0.2),
-		disabled: rgba(oColorsByName('white'), 0.5)
+		disabled: rgba(oColorsByName('white'), 0.5),
+		focus-outline: oColorsByName('white')
 	),
 	opinion: (
 		background: oColorsByName('oxford-40'),
 		text: oColorsByName('white'),
 		highlight: oColorsByName('oxford-30'),
 		pressed-highlight: rgba(oColorsByName('oxford-40'), 0.2),
-		disabled: rgba(oColorsByName('black'), 0.5)
+		disabled: rgba(oColorsByName('black'), 0.5),
+		focus-outline: oColorsByUsecase('focus', 'outline', $fallback: null)
 	),
 	monochrome: (
 		background: oColorsByName('white'),
 		text: oColorsByName('black'),
 		highlight: oColorsByName('white-80'),
 		pressed-highlight: rgba(oColorsByName('white'), 0.2),
-		disabled: rgba(oColorsByName('white'), 0.5)
+		disabled: rgba(oColorsByName('white'), 0.5),
+		focus-outline: oColorsByName('white')
 	)
 );
 

--- a/components/x-follow-button/src/styles/mixins/lozenge/main.scss
+++ b/components/x-follow-button/src/styles/mixins/lozenge/main.scss
@@ -1,6 +1,53 @@
 @import './themes';
 @import './toggle-icon';
 
+@mixin focusOutlineColor($focus-color) {
+	// Apply :focus styles as a fallback
+	// These styles will be applied to all browsers that don't use the polyfill, this includes browsers which support the feature natively.
+	:global(body:not(.js-focus-visible)) &,
+	:global(html:not(.js-focus-visible)) & {
+		// Standardise focus styles.
+		&:focus {
+			outline: 2px solid $focus-color;
+		}
+	}
+
+	// When the focus-visible polyfill is applied `.js-focus-visible` is added to the html dom node
+	// (the body node in v4 of the 3rd party polyfill)
+
+	// stylelint-disable-next-line selector-no-qualifying-type
+	:global(body.js-focus-visible) &, // stylelint-disable-next-line selector-no-qualifying-type
+	:global(html.js-focus-visible) & {
+		// Standardise focus styles.
+		// stylelint-disable-next-line selector-no-qualifying-type
+		&:global(.focus-visible) {
+			outline: 2px solid $focus-color;
+		}
+		// Disable browser default focus style.
+		// stylelint-disable-next-line selector-no-qualifying-type
+		&:focus:not(:global(.focus-visible)) {
+			outline: 0;
+		}
+	}
+
+	// These styles will be ignored by browsers which do not recognise the :focus-visible selector (as per the third bullet point in https://www.w3.org/TR/selectors-3/#Conformance)
+	// If a browser supports :focus-visible we unset the :focus styles that were applied above
+	// (within the html:not(.js-focus-visible) block).
+	&:focus-visible,
+	:global(body:not(.js-focus-visible)) &:focus,
+	:global(html:not(.js-focus-visible)) &:focus {
+		outline: unset;
+	}
+
+	// Styles given :focus-visible support. Extra selectors needed to match
+	// previous `:focus` selector specificity.
+	:global(body:not(.js-focus-visible)) &:focus-visible,
+	:global(html:not(.js-focus-visible)) &:focus-visible,
+	&:focus-visible {
+		outline: 2px solid $focus-color;
+	}
+}
+
 @mixin myftLozengeTheme($theme: standard, $with-toggle-icon: false) {
 	@if $with-toggle-icon != false {
 		@include myftToggleIcon($theme);
@@ -10,6 +57,8 @@
 		background-color: transparent;
 		border: 1px solid getThemeColor(background);
 		color: getThemeColor(background);
+
+		@include focusOutlineColor(getThemeColor(focus-outline))
 
 		&:hover,
 		&:focus {
@@ -57,8 +106,4 @@
 	text-overflow: ellipsis;
 	transition: border-color, background-color 0.5s ease;
 	white-space: nowrap;
-
-	&:focus {
-		outline: none;
-	}
 }


### PR DESCRIPTION
## Description

When background is dark colour (claret, oxford, teal...), there is not enough contrast between background and focus outline colour.

![image-20210715-121204](https://user-images.githubusercontent.com/21194161/129552165-388d053e-d166-48da-b438-c83467bd90ef.png)
Colour ratio:
Foreground: #807973
Background: #990F3D
The contrast ratio is: 2:1 (**It should be over 3:1**)

This issue was reported by DAC 2021 summer doc. ([Jira ticket](https://financialtimes.atlassian.net/browse/CON-1096))

To fix this issue, applying white outline instead of grey outline(which is provided by o-nomalise).
📝   I'm going to apply the same change to n-myft-ui follow button css as well ([the PR](https://github.com/Financial-Times/n-myft-ui/pull/446)).

## Screenshots

|theme|storybook screenshot|
|---|---|
| standard <br>(grey outline)| ![Screenshot 2021-08-16 at 11 23 42](https://user-images.githubusercontent.com/21194161/129553094-7823e352-05b9-444c-ad7d-31e316bd8e5e.png)|
|inverse <br>(white outline)|![Screenshot 2021-08-16 at 11 23 53](https://user-images.githubusercontent.com/21194161/129553102-6008e2c2-e66d-4f11-b621-36e09d329c41.png)|
|opinion <br>(grey outline)|![Screenshot 2021-08-16 at 11 24 01](https://user-images.githubusercontent.com/21194161/129553110-5df735ac-7acf-4e0d-b403-19c602076a1d.png)|
|monochrome <br>(grey outline)|![Screenshot 2021-08-16 at 11 24 10](https://user-images.githubusercontent.com/21194161/129553123-c9ad7138-995f-42a0-b1e0-5c2c6d2de259.png)|


