### PR TITLE
CON-1123 - fix invalid use of aria role on x-teaser

### DIFF
--- a/components/x-teaser/src/Title.jsx
+++ b/components/x-teaser/src/Title.jsx
@@ -28,9 +28,8 @@ export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators
 			{indicators && indicators.accessLevel === 'premium' ? (
 				<span>
 					{' '}
-					<span className={premiumClass} aria-label="Premium content">
-						Premium
-					</span>
+					<span className={premiumClass}>Premium</span>
+					<span className="o-normalise-visually-hidden">&nbsp;content</span>
 				</span>
 			) : null}
 		</div>


### PR DESCRIPTION
## Description

`aria-label` on a span element is not readable by screen readers. This PR adds a new hidden element to help screen readers to read the Premium label.

## Meta

- [Jira](https://financialtimes.atlassian.net/browse/CON-1123)
