### PR TITLE
fix invalid use of aria role on x-teaser

### DIFF
--- a/components/x-teaser/src/Title.jsx
+++ b/components/x-teaser/src/Title.jsx
@@ -28,9 +28,8 @@ export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators
 			{indicators && indicators.accessLevel === 'premium' ? (
 				<span>
 					{' '}
-					<span className={premiumClass} aria-label="Premium content">
-						Premium
-					</span>
+					<span className={premiumClass}>Premium</span>
+					<span className="o-normalise-visually-hidden">&nbsp;content</span>
 				</span>
 			) : null}
 		</div>


### PR DESCRIPTION
This is a clone of this [other PR](https://github.com/Financial-Times/x-dash/pull/610) to fix an accessibility issue on `x-teaser`.

The reason why it's duplicated is because the current homepage is using an old version of `x-teaser` (`v4.1.3`) and upgrade it to the latest (`v6.2.1`) requires an extra effort that might be useless since the homepage will be replace soon. See [Slack thread](https://financialtimes.slack.com/archives/C3TJ6KXEU/p1630922419003200).

To solve this we are creating a `v4` branch that will be used by `next-front-page`