### PR TITLE
changed live-blog-post title tag to h2

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -31,7 +31,7 @@ const LiveBlogPost = (props) => {
 				<Timestamp publishedTimestamp={publishedDate || publishedTimestamp} />
 			</div>
 			{showBreakingNewsLabel && <div className={styles['live-blog-post__breaking-news']}>Breaking news</div>}
-			{title && <h1 className={styles['live-blog-post__title']}>{title}</h1>}
+			{title && <h2 className={styles['live-blog-post__title']}>{title}</h2>}
 			{byline && <p className={styles['live-blog-post__byline']}>{byline}</p>}
 			<div
 				className={`${styles['live-blog-post__body']} n-content-body article--body`}

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -54,7 +54,7 @@ describe('x-live-blog-post', () => {
 				const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />)
 
 				expect(liveBlogPost.html()).toContain('Test title')
-				expect(liveBlogPost.html()).toContain('</h1>')
+				expect(liveBlogPost.html()).toContain('</h2>')
 			})
 		})
 
@@ -68,7 +68,7 @@ describe('x-live-blog-post', () => {
 			it('skips rendering of the title', () => {
 				const liveBlogPost = mount(<LiveBlogPost {...postWithoutTitle} />)
 
-				expect(liveBlogPost.html()).not.toContain('</h1>')
+				expect(liveBlogPost.html()).not.toContain('</h2>')
 			})
 		})
 
@@ -115,7 +115,7 @@ describe('x-live-blog-post', () => {
 				const liveBlogPost = mount(<LiveBlogPost {...regularPostWordpress} />)
 
 				expect(liveBlogPost.html()).toContain('Test title')
-				expect(liveBlogPost.html()).toContain('</h1>')
+				expect(liveBlogPost.html()).toContain('</h2>')
 			})
 		})
 
@@ -129,7 +129,7 @@ describe('x-live-blog-post', () => {
 			it('skips rendering of the title', () => {
 				const liveBlogPost = mount(<LiveBlogPost {...postWithoutTitle} />)
 
-				expect(liveBlogPost.html()).not.toContain('</h1>')
+				expect(liveBlogPost.html()).not.toContain('</h2>')
 			})
 		})
 


### PR DESCRIPTION
This PR is a minor patch to the `LiveBlogPost.jsx` component. 

The current component uses `h1` for the title of each post. This doesn't work very well for subscribers who depend on accessibility tool.

We are changing the title of a post to heading level 2 `h2` so it doesn't cause any confusion with the main header of a live-blog package.