### PR TITLE
ADSDEV-898 DAC change outline buttons contrast

### DIFF
--- a/components/x-privacy-manager/src/components/radio-btn.scss
+++ b/components/x-privacy-manager/src/components/radio-btn.scss
@@ -46,8 +46,7 @@ $transitionDuration: 0.1s;
 	// Since <input> itself is hidden, apply a familiar focus style to the visible <label>
 	// As adjacent siblings we can reflect the <input>'s focus state here
 	.input:focus + & {
-		outline: 2px solid #7aacfe;
-		outline: 5px auto -webkit-focus-ring-color;
+		outline: 2px solid oColorsByName('teal-100');
 		background-color: oColorsByName('teal-40');
 	}
 

--- a/components/x-privacy-manager/src/privacy-manager.scss
+++ b/components/x-privacy-manager/src/privacy-manager.scss
@@ -72,4 +72,8 @@
 	display: block;
 	margin: oSpacingByName(s8) auto 0;
 	padding: 0 oSpacingByName(m12);
+
+	&:focus-visible {
+		outline: 2px solid oColorsByName('teal-100');
+	}
 }


### PR DESCRIPTION
See tickets [ADSDEV-897][ADSDEV-897] and [ADSDEV-898][ADSDEV-898].

Fixes an accessibility issue where the focus outline provided failed against the adjacent radio button colour, making it difficult for keyboard users to see that the element has received focus.
The component has been updated to use the colour `teal-100` for the focus outline.
* this is the same outline colour used by default in `o-buttons`.
* it provides a good contrast (>3) compared to the background colour of the button.
 
[ADSDEV-897]: https://financialtimes.atlassian.net/browse/ADSDEV-897
[ADSDEV-898]: https://financialtimes.atlassian.net/browse/ADSDEV-898