### PR TITLE
Add outline-offset to ensure that contrast is sufficient

### DIFF
--- a/components/x-privacy-manager/src/components/radio-btn.scss
+++ b/components/x-privacy-manager/src/components/radio-btn.scss
@@ -42,11 +42,12 @@ $transitionDuration: 0.1s;
 		background-color: oColorsByName('teal');
 		color: oColorsByName('white');
 	}
-	
+
 	// Since <input> itself is hidden, apply a familiar focus style to the visible <label>
 	// As adjacent siblings we can reflect the <input>'s focus state here
 	.input:focus + & {
-		outline: 2px solid oColorsByName('teal-100');
+		outline: 2px solid oColorsByName('teal-40');
+		outline-offset: 3px;
 		background-color: oColorsByName('teal-40');
 	}
 
@@ -67,7 +68,7 @@ $transitionDuration: 0.1s;
 		font-size: 1.2rem;
 		font-weight: 600;
 	}
-	
+
 	& > span {
 		display: block;
 		margin-top: oSpacingByName(s1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "x-dash",
   "private": true,
+  "volta": {
+    "node": "12.22.7",
+    "npm": "7.24.2"
+  },
   "scripts": {
     "clean": "git clean -fxdi",
     "build": "athloi run build --concurrency 3",


### PR DESCRIPTION
## Issue
`next-control-centre` currently fails DAC requirements:
> When tab navigating the radio, button located on the manage cookies page, the focus outline provided failed against the adjacent radio button colour, making it difficult for keyboard users to see that the element has received focus.

## Fix
This PR adds an offset to the focus outline making it stand out against its surroundings

### Before
![5a75ea09-13f7-45f8-9129-3d91b988c0a3](https://user-images.githubusercontent.com/21795/139077298-24b197e9-1162-4471-ad94-55d6ec13526e.png)
### After
![Screenshot 2021-10-27 at 14 07 51](https://user-images.githubusercontent.com/21795/139077313-d9b64193-04d0-44b9-878d-541532c94faa.png)


