### PR TITLE
added back to top link to liveBlogPost

### DIFF
--- a/components/x-live-blog-post/readme.md
+++ b/components/x-live-blog-post/readme.md
@@ -52,5 +52,5 @@ Feature             | Type   | Notes
 `publishedTimestamp`| String | Deprecated - ISO timestamp of publish date
 `articleUrl`        | String | Url of the main article that includes this post
 `showShareButtons`  | Bool   | default: `false` - Shows social media share buttons when `true`
-`backToTop`  		| Function | String   | Shows the back to top link at the bottom of posts and manages navigating to `selected top` with a javascript function or a hashed link. Only pass in. Please call event.preventDefault() at the top level if this prop is a function. If prop is a string, add the string as the `id` to the element that represents the top.
+`backToTop`  		| Function | String   | Shows the back to top link at the bottom of posts and manages navigating to `selected top` with a javascript function or a hashed href. Please call event.preventDefault() at the top level if this prop is a function. If prop is a string, add the string as the `id` to the element that represents the top.
 

--- a/components/x-live-blog-post/readme.md
+++ b/components/x-live-blog-post/readme.md
@@ -52,3 +52,6 @@ Feature             | Type   | Notes
 `publishedTimestamp`| String | Deprecated - ISO timestamp of publish date
 `articleUrl`        | String | Url of the main article that includes this post
 `showShareButtons`  | Bool   | default: `false` - Shows social media share buttons when `true`
+`topRef`  			| String   | Shows the back to top link at the bottom of posts and navigates to the hashed section of the page. No defaults, example `#top`
+`backToTop`  		| Function   | Shows the back to top link at the bottom of posts and manages navigating to `selected top` with a javascript function. No defaults. Only pass in `topRef` or `backToTop` props to the component. Please call event.preventDefault() at the top level of this function.
+

--- a/components/x-live-blog-post/readme.md
+++ b/components/x-live-blog-post/readme.md
@@ -52,6 +52,5 @@ Feature             | Type   | Notes
 `publishedTimestamp`| String | Deprecated - ISO timestamp of publish date
 `articleUrl`        | String | Url of the main article that includes this post
 `showShareButtons`  | Bool   | default: `false` - Shows social media share buttons when `true`
-`backToTopRef`  			| String   | Shows the back to top link at the bottom of posts and navigates to the hashed section of the page. No defaults, example `#top`
-`backToTopFunction`  		| Function   | Shows the back to top link at the bottom of posts and manages navigating to `selected top` with a javascript function. No defaults. Only pass in `backToTopRef` or `backToTopFunction` props to the component. Please call event.preventDefault() at the top level of this function.
+`backToTop`  		| Function | String   | Shows the back to top link at the bottom of posts and manages navigating to `selected top` with a javascript function or a hashed link. Only pass in. Please call event.preventDefault() at the top level if this prop is a function. If prop is a string, add the string as the `id` to the element that represents the top.
 

--- a/components/x-live-blog-post/readme.md
+++ b/components/x-live-blog-post/readme.md
@@ -52,6 +52,6 @@ Feature             | Type   | Notes
 `publishedTimestamp`| String | Deprecated - ISO timestamp of publish date
 `articleUrl`        | String | Url of the main article that includes this post
 `showShareButtons`  | Bool   | default: `false` - Shows social media share buttons when `true`
-`topRef`  			| String   | Shows the back to top link at the bottom of posts and navigates to the hashed section of the page. No defaults, example `#top`
-`backToTop`  		| Function   | Shows the back to top link at the bottom of posts and manages navigating to `selected top` with a javascript function. No defaults. Only pass in `topRef` or `backToTop` props to the component. Please call event.preventDefault() at the top level of this function.
+`backToTopRef`  			| String   | Shows the back to top link at the bottom of posts and navigates to the hashed section of the page. No defaults, example `#top`
+`backToTopFunction`  		| Function   | Shows the back to top link at the bottom of posts and manages navigating to `selected top` with a javascript function. No defaults. Only pass in `backToTopRef` or `backToTopFunction` props to the component. Please call event.preventDefault() at the top level of this function.
 

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -27,17 +27,17 @@ const LiveBlogPost = (props) => {
 
 	let backToTopProps = {}
 
-	if (backToTop) {
-		backToTopProps = {
-			...backToTopProps,
-			onClick: backToTop
-		}
-	}
-
 	if (topRef) {
 		backToTopProps = {
 			...backToTopProps,
 			href: topRef
+		}
+	}
+
+	if (backToTop) {
+		backToTopProps = {
+			...backToTopProps,
+			onClick: backToTop
 		}
 	}
 

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -24,18 +24,34 @@ const LiveBlogPost = (props) => {
 
 	const showBreakingNewsLabel = standout.breakingNews || isBreakingNews
 
-	let backToTopProps = {}
+	let BackToTopComponent
 
 	if (backToTop) {
 		if (typeof backToTop === 'string') {
 			const processTopRef = (ref) => {
 				return ref.includes('#') ? ref : `#${ref}`
 			}
-			backToTopProps.href = processTopRef(backToTop)
+			BackToTopComponent = (
+				<a
+					href={processTopRef(backToTop)}
+					aria-labelledby="Back to top"
+					className={styles['live-blog-post-controls__back-to-top-link']}
+				>
+					Back to top
+				</a>
+			)
 		}
 
 		if (typeof backToTop === 'function') {
-			backToTopProps.onClick = backToTop
+			BackToTopComponent = (
+				<button
+					onClick={backToTop}
+					aria-labelledby="Back to top"
+					className={styles['live-blog-post-controls__back-to-top-button']}
+				>
+					Back to top
+				</button>
+			)
 		}
 	}
 
@@ -58,16 +74,7 @@ const LiveBlogPost = (props) => {
 			/>
 			<div className={styles['live-blog-post__controls']}>
 				{showShareButtons && <ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
-				{Boolean(backToTop) && (
-					// eslint-disable-next-line jsx-a11y/click-events-have-key-events
-					<a
-						{...backToTopProps}
-						aria-labelledby="Back to top"
-						className={styles['live-blog-post-controls__back-to-top']}
-					>
-						Back to top
-					</a>
-				)}
+				{Boolean(BackToTopComponent) && <>{BackToTopComponent}</>}
 			</div>
 
 			{ad}

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -64,10 +64,9 @@ const LiveBlogPost = (props) => {
 					// eslint-disable-next-line jsx-a11y/click-events-have-key-events
 					<a
 						{...backToTopProps}
-						aria-labelledby="Back to top link"
+						aria-labelledby="Back to top"
 						{...backToTopProps}
 						className={styles['back-to-top']}
-						onClick={backToTop}
 					>
 						Back to top
 					</a>

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -68,7 +68,6 @@ const LiveBlogPost = (props) => {
 					<a
 						{...backToTopProps}
 						aria-labelledby="Back to top"
-						{...backToTopProps}
 						className={styles['live-blog-post-controls__back-to-top']}
 					>
 						Back to top

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -19,28 +19,23 @@ const LiveBlogPost = (props) => {
 		showShareButtons = false,
 		byline,
 		ad,
-		backToTopFunction,
-		backToTopRef
+		backToTop
 	} = props
 
 	const showBreakingNewsLabel = standout.breakingNews || isBreakingNews
 
 	let backToTopProps = {}
 
-	if (backToTopRef) {
-		const processTopRef = (ref) => {
-			return typeof ref === 'string' && ref.includes('#') ? ref : `#${ref}`
+	if (backToTop) {
+		if (typeof backToTop === 'string') {
+			const processTopRef = (ref) => {
+				return ref.includes('#') ? ref : `#${ref}`
+			}
+			backToTopProps.href = processTopRef(backToTop)
 		}
-		backToTopProps = {
-			...backToTopProps,
-			href: processTopRef(backToTopRef)
-		}
-	}
 
-	if (backToTopFunction) {
-		backToTopProps = {
-			...backToTopProps,
-			onClick: backToTopFunction
+		if (typeof backToTop === 'function') {
+			backToTopProps.onClick = backToTop
 		}
 	}
 
@@ -63,7 +58,7 @@ const LiveBlogPost = (props) => {
 			/>
 			<div className={styles['live-blog-post__controls']}>
 				{showShareButtons && <ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
-				{(Boolean(backToTopFunction) || Boolean(backToTopRef)) && (
+				{Boolean(backToTop) && (
 					// eslint-disable-next-line jsx-a11y/click-events-have-key-events
 					<a
 						{...backToTopProps}

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -19,25 +19,28 @@ const LiveBlogPost = (props) => {
 		showShareButtons = false,
 		byline,
 		ad,
-		backToTop,
-		topRef
+		backToTopFunction,
+		backToTopRef
 	} = props
 
 	const showBreakingNewsLabel = standout.breakingNews || isBreakingNews
 
 	let backToTopProps = {}
 
-	if (topRef) {
+	if (backToTopRef) {
+		const processTopRef = (ref) => {
+			return typeof ref === 'string' && ref.includes('#') ? ref : `#${ref}`
+		}
 		backToTopProps = {
 			...backToTopProps,
-			href: topRef
+			href: processTopRef(backToTopRef)
 		}
 	}
 
-	if (backToTop) {
+	if (backToTopFunction) {
 		backToTopProps = {
 			...backToTopProps,
-			onClick: backToTop
+			onClick: backToTopFunction
 		}
 	}
 
@@ -60,7 +63,7 @@ const LiveBlogPost = (props) => {
 			/>
 			<div className={styles['live-blog-post__controls']}>
 				{showShareButtons && <ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
-				{(Boolean(backToTop) || Boolean(topRef)) && (
+				{(Boolean(backToTopFunction) || Boolean(backToTopRef)) && (
 					// eslint-disable-next-line jsx-a11y/click-events-have-key-events
 					<a
 						{...backToTopProps}

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -58,7 +58,7 @@ const LiveBlogPost = (props) => {
 				className={`${styles['live-blog-post__body']} n-content-body article--body`}
 				dangerouslySetInnerHTML={{ __html: bodyHTML || content }}
 			/>
-			<div className={styles['live-blog-post__bottom-controls']}>
+			<div className={styles['live-blog-post__controls']}>
 				{showShareButtons && <ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
 				{(Boolean(backToTop) || Boolean(topRef)) && (
 					// eslint-disable-next-line jsx-a11y/click-events-have-key-events
@@ -66,7 +66,7 @@ const LiveBlogPost = (props) => {
 						{...backToTopProps}
 						aria-labelledby="Back to top"
 						{...backToTopProps}
-						className={styles['back-to-top']}
+						className={styles['live-blog-post-controls__back-to-top']}
 					>
 						Back to top
 					</a>

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import { h } from '@financial-times/x-engine'
+import { h, Fragment } from '@financial-times/x-engine'
 import ShareButtons from './ShareButtons'
 import Timestamp from './Timestamp'
 import styles from './LiveBlogPost.scss'
@@ -74,7 +74,7 @@ const LiveBlogPost = (props) => {
 			/>
 			<div className={styles['live-blog-post__controls']}>
 				{showShareButtons && <ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
-				{Boolean(BackToTopComponent) && <>{BackToTopComponent}</>}
+				{Boolean(BackToTopComponent) && <Fragment>{BackToTopComponent}</Fragment>}
 			</div>
 
 			{ad}

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import { h } from '@financial-times/x-engine'
 import ShareButtons from './ShareButtons'
 import Timestamp from './Timestamp'
@@ -17,10 +18,28 @@ const LiveBlogPost = (props) => {
 		articleUrl,
 		showShareButtons = false,
 		byline,
-		ad
+		ad,
+		backToTop,
+		topRef
 	} = props
 
 	const showBreakingNewsLabel = standout.breakingNews || isBreakingNews
+
+	let backToTopProps = {}
+
+	if (backToTop) {
+		backToTopProps = {
+			...backToTopProps,
+			onClick: backToTop
+		}
+	}
+
+	if (topRef) {
+		backToTopProps = {
+			...backToTopProps,
+			href: topRef
+		}
+	}
 
 	return (
 		<article
@@ -39,7 +58,22 @@ const LiveBlogPost = (props) => {
 				className={`${styles['live-blog-post__body']} n-content-body article--body`}
 				dangerouslySetInnerHTML={{ __html: bodyHTML || content }}
 			/>
-			{showShareButtons && <ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
+			<div className={styles['live-blog-post__bottom-controls']}>
+				{showShareButtons && <ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
+				{(Boolean(backToTop) || Boolean(topRef)) && (
+					// eslint-disable-next-line jsx-a11y/click-events-have-key-events
+					<a
+						{...backToTopProps}
+						aria-labelledby="Back to top link"
+						{...backToTopProps}
+						className={styles['back-to-top']}
+						onClick={backToTop}
+					>
+						Back to top
+					</a>
+				)}
+			</div>
+
 			{ad}
 		</article>
 	)

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -54,10 +54,6 @@
 	padding-top: oSpacingByName('s1');
 }
 
-.live-blog-post__share-buttons {
-	margin-top: oSpacingByName('s6');
-}
-
 .live-blog-post__breaking-news {
 	@include oTypographySans($scale: -2);
 	color: oColorsByName('crimson');
@@ -73,4 +69,23 @@
 	margin-right: oSpacingByName('s1');
 	border-radius: 50%;
 	background-color: oColorsByName('crimson');
+}
+
+.live-blog-post__bottom-controls {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	margin-top: oSpacingByName('s6');
+}
+
+.live-blog-post__bottom-controls .back-to-top {
+	@include oTypographySans($scale: 1);
+	color: oColorsByName('teal');
+	text-decoration: underline;
+	margin-left: auto;
+}
+
+.live-blog-post__bottom-controls .back-to-top:hover {
+	cursor: pointer;
 }

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -79,13 +79,19 @@
 	margin-top: oSpacingByName('s6');
 }
 
-.live-blog-post__controls .live-blog-post-controls__back-to-top {
+.live-blog-post__controls .live-blog-post-controls__back-to-top-link,
+.live-blog-post__controls .live-blog-post-controls__back-to-top-button  {
 	@include oTypographySans($scale: 1);
 	color: oColorsByName('teal');
 	text-decoration: underline;
 	margin-left: auto;
 }
 
-.live-blog-post__controls .live-blog-post-controls__back-to-top:hover {
+.live-blog-post__controls .live-blog-post-controls__back-to-top-button {
+	background: unset;
+	border: unset;
+}
+
+.live-blog-post__controls .live-blog-post-controls__back-to-top-button:hover {
 	cursor: pointer;
 }

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -86,6 +86,6 @@
 	margin-left: auto;
 }
 
-.live-blog-post__bottom-controls .live-blog-post-controls__back-to-top:hover {
+.live-blog-post__controls .live-blog-post-controls__back-to-top:hover {
 	cursor: pointer;
 }

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -71,7 +71,7 @@
 	background-color: oColorsByName('crimson');
 }
 
-.live-blog-post__bottom-controls {
+.live-blog-post__controls {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -79,13 +79,13 @@
 	margin-top: oSpacingByName('s6');
 }
 
-.live-blog-post__bottom-controls .back-to-top {
+.live-blog-post__controls .live-blog-post-controls__back-to-top {
 	@include oTypographySans($scale: 1);
 	color: oColorsByName('teal');
 	text-decoration: underline;
 	margin-left: auto;
 }
 
-.live-blog-post__bottom-controls .back-to-top:hover {
+.live-blog-post__bottom-controls .live-blog-post-controls__back-to-top:hover {
 	cursor: pointer;
 }

--- a/components/x-live-blog-post/src/ShareButtons.jsx
+++ b/components/x-live-blog-post/src/ShareButtons.jsx
@@ -1,5 +1,4 @@
 import { h } from '@financial-times/x-engine'
-import styles from './LiveBlogPost.scss'
 
 export default ({ postId, articleUrl, title }) => {
 	const shareUrl = articleUrl ? new URL(articleUrl) : null
@@ -18,18 +17,20 @@ export default ({ postId, articleUrl, title }) => {
 	)}&title=${encodeURIComponent(title)}&source=Financial+Times`
 
 	return (
-		<div className={styles['live-blog-post__share-buttons']}>
+		<div>
 			<div
 				data-o-component="o-share"
 				data-o-share-location={`live-blog-post-${postId}`}
-				className="o-share o-share--small">
+				className="o-share o-share--small"
+			>
 				<ul data-toolbar="share">
 					<li className="o-share__action" data-share="twitter">
 						<a
 							className="o-share__icon o-share__icon--twitter"
 							rel="noopener"
 							href={twitterUrl}
-							data-trackable="twitter">
+							data-trackable="twitter"
+						>
 							<span className="o-share__text" aria-label={`Share ${title} on Twitter`}>
 								Share on Twitter (opens new window)
 							</span>
@@ -40,7 +41,8 @@ export default ({ postId, articleUrl, title }) => {
 							className="o-share__icon o-share__icon--facebook"
 							rel="noopener"
 							href={facebookUrl}
-							data-trackable="facebook">
+							data-trackable="facebook"
+						>
 							<span className="o-share__text" aria-label={`Share ${title} on Facebook`}>
 								Share on Facebook (opens new window)
 							</span>
@@ -51,7 +53,8 @@ export default ({ postId, articleUrl, title }) => {
 							className="o-share__icon o-share__icon--linkedin"
 							rel="noopener"
 							href={linkedInUrl}
-							data-trackable="linkedin">
+							data-trackable="linkedin"
+						>
 							<span className="o-share__text" aria-label={`Share ${title} on LinkedIn`}>
 								Share on LinkedIn (opens new window)
 							</span>

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -56,8 +56,8 @@ const backToTopPostSpark = {
 	isBreakingNews: false,
 	articleUrl: 'Https://www.ft.com',
 	showShareButtons: true,
-	backToTop: () => {},
-	topRef: '#top'
+	backToTopFunction: () => {},
+	backToTopRef: '#top'
 }
 
 describe('x-live-blog-post', () => {

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -47,6 +47,19 @@ const regularPostSpark = {
 	showShareButtons: true
 }
 
+const backToTopPostSpark = {
+	id: '12345',
+	title: 'Test title',
+	byline: 'Test author',
+	bodyHTML: '<p><i>Test body</i></p>',
+	publishedDate: new Date().toISOString(),
+	isBreakingNews: false,
+	articleUrl: 'Https://www.ft.com',
+	showShareButtons: true,
+	backToTop: () => {},
+	topRef: '#top'
+}
+
 describe('x-live-blog-post', () => {
 	describe('Spark cms', () => {
 		describe('title property exists', () => {
@@ -106,6 +119,15 @@ describe('x-live-blog-post', () => {
 			const liveBlogPost = mount(<LiveBlogPost {...regularPostSpark} />)
 
 			expect(liveBlogPost.html()).toContain('<p><i>Test body</i></p>')
+		})
+
+		describe('Back to top post', () => {
+			it('renders back to top link', () => {
+				const liveBlogPost = mount(<LiveBlogPost {...backToTopPostSpark} />)
+
+				expect(liveBlogPost.html()).toContain('Back to top')
+				expect(liveBlogPost.html()).toContain('</a>')
+			})
 		})
 	})
 

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -56,8 +56,7 @@ const backToTopPostSpark = {
 	isBreakingNews: false,
 	articleUrl: 'Https://www.ft.com',
 	showShareButtons: true,
-	backToTopFunction: () => {},
-	backToTopRef: '#top'
+	backToTop: () => {}
 }
 
 describe('x-live-blog-post', () => {

--- a/components/x-live-blog-post/storybook/index.jsx
+++ b/components/x-live-blog-post/storybook/index.jsx
@@ -35,5 +35,30 @@ ContentBody.args = {
 	publishedDate: '2020-05-13T18:52:28.000Z',
 	articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
 	showShareButtons: true,
-	backToTopFunction: () => {}
+	backToTop: () => {}
+}
+
+export const ContentBodyWithBackToTopString = (args) => {
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<LiveBlogPost {...args} />
+		</div>
+	)
+}
+
+ContentBodyWithBackToTopString.args = {
+	title: 'Turkey’s virus deaths may be 25% higher than official figure',
+	byline: 'George Russell',
+	isBreakingNews: false,
+	standout: {
+		breakingNews: false
+	},
+	bodyHTML:
+		'<p>Turkey&#x2019;s death toll from coronavirus could be as much as 25 per cent higher than the government&#x2019;s official tally, adding the country of 83m people to the raft of nations that have struggled to accurately capture the impact of the pandemic.</p>\n<p>Ankara has previously rejected suggestions that municipal data from Istanbul, the epicentre of the country&#x2019;s Covid-19 outbreak, showed that there were more deaths from the disease than reported.</p>\n<p>But an analysis of individual death records by the Financial Times raises questions about the Turkish government&#x2019;s explanation for a spike in all-cause mortality in the city of almost 16m people.</p>\n<p><a href="https://www.ft.com/content/80bb222c-b6eb-40ea-8014-563cbe9e0117" target="_blank">Read the article here</a></p>\n<p><img class="picture" src="http://blogs.ft.com/the-world/files/2020/05/istanbul_excess_morts_l.jpg"></p>',
+	id: '12345',
+	publishedDate: '2020-05-13T18:52:28.000Z',
+	articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
+	showShareButtons: true,
+	backToTop: '#Top'
 }

--- a/components/x-live-blog-post/storybook/index.jsx
+++ b/components/x-live-blog-post/storybook/index.jsx
@@ -34,5 +34,6 @@ ContentBody.args = {
 	id: '12345',
 	publishedDate: '2020-05-13T18:52:28.000Z',
 	articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
-	showShareButtons: true
+	showShareButtons: true,
+	backToTop: () => {}
 }

--- a/components/x-live-blog-post/storybook/index.jsx
+++ b/components/x-live-blog-post/storybook/index.jsx
@@ -35,10 +35,10 @@ ContentBody.args = {
 	publishedDate: '2020-05-13T18:52:28.000Z',
 	articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
 	showShareButtons: true,
-	backToTop: () => {}
+	backToTop: '#Top'
 }
 
-export const ContentBodyWithBackToTopString = (args) => {
+export const ContentBodyWithBackToTopButton = (args) => {
 	return (
 		<div className="story-container">
 			{dependencies && <BuildService dependencies={dependencies} />}
@@ -47,7 +47,7 @@ export const ContentBodyWithBackToTopString = (args) => {
 	)
 }
 
-ContentBodyWithBackToTopString.args = {
+ContentBodyWithBackToTopButton.args = {
 	title: 'Turkey’s virus deaths may be 25% higher than official figure',
 	byline: 'George Russell',
 	isBreakingNews: false,
@@ -60,5 +60,5 @@ ContentBodyWithBackToTopString.args = {
 	publishedDate: '2020-05-13T18:52:28.000Z',
 	articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
 	showShareButtons: true,
-	backToTop: '#Top'
+	backToTop: () => {}
 }

--- a/components/x-live-blog-post/storybook/index.jsx
+++ b/components/x-live-blog-post/storybook/index.jsx
@@ -35,5 +35,5 @@ ContentBody.args = {
 	publishedDate: '2020-05-13T18:52:28.000Z',
 	articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
 	showShareButtons: true,
-	backToTop: () => {}
+	backToTopFunction: () => {}
 }


### PR DESCRIPTION
## Back to top link on x-live-blog-post component

This PR adds a `back to top` link to the bottom of `x-live-blog-post` component. It is a minor feature and with it, a new props have been added to the component. `backToTop`  which can be a function or a string. The aim is to have either `type` passed to achieve same result. The function `type` was added for more fine-grained control of the scrolling with javascript if the consuming component desires that. Pass a string `top` or `#top` to allow the browser handle the scrolling back to top. A string also requires the an element in the `DOM` to have same value as the id attribute.

