### PR TITLE
outline-offset and background colour change for the form submit save button

### DIFF
--- a/components/x-privacy-manager/src/privacy-manager.scss
+++ b/components/x-privacy-manager/src/privacy-manager.scss
@@ -74,6 +74,8 @@
 	padding: 0 oSpacingByName(m12);
 
 	&:focus-visible {
-		outline: 2px solid oColorsByName('teal-100');
+		outline: 2px solid oColorsByName('teal-40');
+		outline-offset: 3px;
+		background-color: oColorsByName('teal-40');
 	}
 }


### PR DESCRIPTION
Ticket is [here](https://financialtimes.atlassian.net/jira/software/c/projects/ADSDEV/boards/803?modal=detail&selectedIssue=ADSDEV-898)

Following the example laid out by [this PR](https://github.com/Financial-Times/x-dash/pull/620) by @oliverturner 

We are using `teal-40` to make an offset around the button for when it is in focus. Originally I juggled with a few colours to see if I could find one that had a contrast ratio of 3:1 with both the `paper` and the `teal-40` colour, but there might just not be one.

This keeps the design consistent with Oliver's PR.

Changes are:
- button hover state changed to `teal-40`
- button outline matches hover state to be `teal-40`
- offset for outline of `3px` to make it more obvious

This should result in a contrast of 6.75:1 for the `teal-40` compared with the `paper` background.

Before
<img width="973" alt="Screenshot 2021-11-01 at 19 27 09" src="https://user-images.githubusercontent.com/12858421/139729497-70f35ceb-18f1-48e3-b1a5-a0ec0a443bad.png">

After
<img width="954" alt="Screenshot 2021-11-01 at 19 09 22" src="https://user-images.githubusercontent.com/12858421/139729455-37c8a5aa-e74f-4c20-98cc-dc2d7b3fb012.png">

