### PR TITLE
Hide back-to-top on first Live Blog Post

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -32,16 +32,10 @@ const LiveBlogPost = (props) => {
 				return ref.includes('#') ? ref : `#${ref}`
 			}
 			BackToTopComponent = (
-				/**
-				 * (Ref: LBPC101) The class name `live-blog-post-controls__back-to-top-link` has been added to help consumers
-				 * of this component select and override css behaviours if it is required. Due to modularization.
-				 * the generated classnames will be differen on different releases so this addition provides a steady
-				 * selector for overrides
-				 */
 				<a
 					href={processTopRef(backToTop)}
 					aria-labelledby="Back to top"
-					className={`live-blog-post-controls__back-to-top-link ${styles['live-blog-post-controls__back-to-top-link']}`}
+					className={styles['live-blog-post-controls__back-to-top-link']}
 				>
 					Back to top
 				</a>
@@ -50,13 +44,10 @@ const LiveBlogPost = (props) => {
 
 		if (typeof backToTop === 'function') {
 			BackToTopComponent = (
-				/**
-				 * (Ref: LBPC101) Override class name `live-blog-post-controls__back-to-top-button`
-				 */
 				<button
 					onClick={backToTop}
 					aria-labelledby="Back to top"
-					className={`live-blog-post-controls__back-to-top-button ${styles['live-blog-post-controls__back-to-top-button']}`}
+					className={styles['live-blog-post-controls__back-to-top-button']}
 				>
 					Back to top
 				</button>
@@ -65,9 +56,6 @@ const LiveBlogPost = (props) => {
 	}
 
 	return (
-		/**
-		 * (Ref: LBPC101) Override class name `live-blog-post`
-		 */
 		<article
 			className={`live-blog-post ${styles['live-blog-post']}`}
 			data-trackable="live-post"

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -35,7 +35,7 @@ const LiveBlogPost = (props) => {
 				<a
 					href={processTopRef(backToTop)}
 					aria-labelledby="Back to top"
-					className={styles['live-blog-post-controls__back-to-top-link']}
+					className={`live-blog-post-controls__back-to-top-link ${styles['live-blog-post-controls__back-to-top-link']}`}
 				>
 					Back to top
 				</a>
@@ -47,7 +47,7 @@ const LiveBlogPost = (props) => {
 				<button
 					onClick={backToTop}
 					aria-labelledby="Back to top"
-					className={styles['live-blog-post-controls__back-to-top-button']}
+					className={`live-blog-post-controls__back-to-top-button ${styles['live-blog-post-controls__back-to-top-button']}`}
 				>
 					Back to top
 				</button>

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -32,6 +32,12 @@ const LiveBlogPost = (props) => {
 				return ref.includes('#') ? ref : `#${ref}`
 			}
 			BackToTopComponent = (
+				/**
+				 * (Ref: LBPC101) The class name `live-blog-post-controls__back-to-top-link` has been added to help consumers
+				 * of this component select and override css behaviours if it is required. Due to modularization.
+				 * the generated classnames will be differen on different releases so this addition provides a steady
+				 * selector for overrides
+				 */
 				<a
 					href={processTopRef(backToTop)}
 					aria-labelledby="Back to top"
@@ -44,6 +50,9 @@ const LiveBlogPost = (props) => {
 
 		if (typeof backToTop === 'function') {
 			BackToTopComponent = (
+				/**
+				 * (Ref: LBPC101) Override class name `live-blog-post-controls__back-to-top-button`
+				 */
 				<button
 					onClick={backToTop}
 					aria-labelledby="Back to top"
@@ -56,6 +65,9 @@ const LiveBlogPost = (props) => {
 	}
 
 	return (
+		/**
+		 * (Ref: LBPC101) Override class name `live-blog-post`
+		 */
 		<article
 			className={`live-blog-post ${styles['live-blog-post']}`}
 			data-trackable="live-post"

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import { h } from '@financial-times/x-engine'
+import { h, Fragment } from '@financial-times/x-engine'
 import ShareButtons from './ShareButtons'
 import Timestamp from './Timestamp'
 import styles from './LiveBlogPost.scss'
@@ -74,7 +74,7 @@ const LiveBlogPost = (props) => {
 			/>
 			<div className={styles['live-blog-post__controls']}>
 				{showShareButtons && <ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
-				{Boolean(BackToTopComponent) && <>{BackToTopComponent}</>}
+				{Boolean(BackToTopComponent) && <Fragment>{BackToTopComponent}</Fragment>}
 			</div>
 
 			{ad}

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -95,3 +95,8 @@
 .live-blog-post__controls .live-blog-post-controls__back-to-top-button:hover {
 	cursor: pointer;
 }
+
+.live-blog-post:first-child .live-blog-post-controls__back-to-top-link, 
+.live-blog-post:first-child .live-blog-post-controls__back-to-top-button {
+	display: none;
+}

--- a/components/x-live-blog-post/storybook/index.jsx
+++ b/components/x-live-blog-post/storybook/index.jsx
@@ -18,6 +18,7 @@ export const ContentBody = (args) => {
 		<div className="story-container">
 			{dependencies && <BuildService dependencies={dependencies} />}
 			<LiveBlogPost {...args} />
+			<LiveBlogPost {...args} />
 		</div>
 	)
 }
@@ -42,6 +43,7 @@ export const ContentBodyWithBackToTopButton = (args) => {
 	return (
 		<div className="story-container">
 			{dependencies && <BuildService dependencies={dependencies} />}
+			<LiveBlogPost {...args} />
 			<LiveBlogPost {...args} />
 		</div>
 	)


### PR DESCRIPTION

This is a follow-up PR from https://github.com/Financial-Times/x-dash/pull/621. The back to top button/link is not required on the first post. The initial plan was to let the consumers create overrides in their `css` to achieve this. Because the style names are changed on `build` (CSS modularisation), it becomes harder for the consumer of this component to override the styles as every new version released comes with a new class name.

This PR adds the styling direct to the component and also updates the storybook to reflect this. This CSS class names are also added directly to the styles without any modularisation so consumers can directly select these elements and modify them.