### PR TITLE
removed fragment from live-blog-post component

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -1,5 +1,4 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-import { h, Fragment } from '@financial-times/x-engine'
+import { h } from '@financial-times/x-engine'
 import ShareButtons from './ShareButtons'
 import Timestamp from './Timestamp'
 import styles from './LiveBlogPost.scss'
@@ -35,7 +34,7 @@ const LiveBlogPost = (props) => {
 				<a
 					href={processTopRef(backToTop)}
 					aria-labelledby="Back to top"
-					className={styles['live-blog-post-controls__back-to-top-link']}
+					className={styles['live-blog-post-controls__right__back-to-top-link']}
 				>
 					Back to top
 				</a>
@@ -47,7 +46,7 @@ const LiveBlogPost = (props) => {
 				<button
 					onClick={backToTop}
 					aria-labelledby="Back to top"
-					className={styles['live-blog-post-controls__back-to-top-button']}
+					className={styles['live-blog-post-controls__right__back-to-top-button']}
 				>
 					Back to top
 				</button>
@@ -74,7 +73,9 @@ const LiveBlogPost = (props) => {
 			/>
 			<div className={styles['live-blog-post__controls']}>
 				{showShareButtons && <ShareButtons postId={id || postId} articleUrl={articleUrl} title={title} />}
-				{Boolean(BackToTopComponent) && <Fragment>{BackToTopComponent}</Fragment>}
+				{Boolean(BackToTopComponent) && (
+					<div className={styles['live-blog-post__controls__right']}>{BackToTopComponent}</div>
+				)}
 			</div>
 
 			{ad}

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -79,24 +79,27 @@
 	margin-top: oSpacingByName('s6');
 }
 
-.live-blog-post__controls .live-blog-post-controls__back-to-top-link,
-.live-blog-post__controls .live-blog-post-controls__back-to-top-button  {
-	@include oTypographySans($scale: 1);
-	color: oColorsByName('teal');
-	text-decoration: underline;
+.live-blog-post__controls__right {
 	margin-left: auto;
 }
 
-.live-blog-post__controls .live-blog-post-controls__back-to-top-button {
+.live-blog-post__controls__right .live-blog-post-controls__right__back-to-top-link,
+.live-blog-post__controls__right .live-blog-post-controls__right__back-to-top-button  {
+	@include oTypographySans($scale: 1);
+	color: oColorsByName('teal');
+	text-decoration: underline;
+}
+
+.live-blog-post__controls__right .live-blog-post-controls__right__back-to-top-button {
 	background: unset;
 	border: unset;
 }
 
-.live-blog-post__controls .live-blog-post-controls__back-to-top-button:hover {
+.live-blog-post__controls__right .live-blog-post-controls__right__back-to-top-button:hover {
 	cursor: pointer;
 }
 
-.live-blog-post:first-child .live-blog-post-controls__back-to-top-link, 
-.live-blog-post:first-child .live-blog-post-controls__back-to-top-button {
+.live-blog-post:first-child .live-blog-post-controls__right__back-to-top-link, 
+.live-blog-post:first-child .live-blog-post-controls__right__back-to-top-button {
 	display: none;
 }


### PR DESCRIPTION
This PR contains a minor change to the structure of the `live-blog-post` component. 

The current component uses `Fragment` from `@financial-times/x-engine` package which doesn't render properly on `ft-app`. I've replaced the Fragment with a `div` and adjusted the styles accordingly.

This specific feature has had 3 releases which is specifically bad for our versions and I take the blame for this. 

I have also tested locally with the local package on both `ft-app` and `next-article` to ensure this issue doesn't show up on the published package.
