### PR TITLE
FTDCS-36 - Fix Sentry error

### DIFF
--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -135,11 +135,13 @@ const getItemGroups = ({
 const getGroupAndIndex = (groups, position) => {
 	if (position > 0) {
 		const group = groups.findIndex((g) => g.items.some((item) => item.articleIndex === position - 1))
-		const index = groups[group].items.findIndex((item) => item.articleIndex === position - 1)
+		if(groups[group]){
+			const index = groups[group].items.findIndex((item) => item.articleIndex === position - 1)
 
-		return {
-			group: group,
-			index: index + 1
+			return {
+				group: group,
+				index: index + 1
+			}
 		}
 	}
 


### PR DESCRIPTION
Sentry error [Cannot read property 'items' of undefined](https://sentry.io/organizations/financial-times/issues/2770847631)
itemGroups without group led to a TypeError:
Cannot read property 'items' of undefined
