### PR TITLE
ENT-503 Add Enterprise Sharing to Gift Article

### DIFF
--- a/components/x-gift-article/bower.json
+++ b/components/x-gift-article/bower.json
@@ -7,6 +7,7 @@
     "o-buttons": "^6.0.0",
     "o-colors": "^5.0.0",
     "o-forms": "^8.0.0",
+    "o-icons": "^6.0.0",
     "o-labels": "5.0.0",
     "o-loading": "^4.0.0",
     "o-message": "^4.0.0",

--- a/components/x-gift-article/bower.json
+++ b/components/x-gift-article/bower.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "o-buttons": "^6.0.0",
+    "o-colors": "^5.0.0",
     "o-forms": "^8.0.0",
     "o-labels": "5.0.0",
     "o-loading": "^4.0.0",

--- a/components/x-gift-article/bower.json
+++ b/components/x-gift-article/bower.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "o-buttons": "^6.0.0",
     "o-forms": "^8.0.0",
+    "o-labels": "5.0.0",
     "o-loading": "^4.0.0",
     "o-message": "^4.0.0",
     "o-typography": "6.0.0",

--- a/components/x-gift-article/readme.md
+++ b/components/x-gift-article/readme.md
@@ -77,7 +77,7 @@ Property                  | Type    | Required | Note
 `nativeShare`             | Boolean | no       | This is a property for App to display Native Sharing.
 `apiProtocol`             | String  | no       | The protocol to use when making requests to the gift article and URL shortening services. Ignored if `apiDomain` is not set.
 `apiDomain`               | String  | no       | The domain to use when making requests to the gift article and URL shortening services.
-`enterpriseApiDomain`     | String  | no       | The domain to use when making requests to the enterprise sharing service.
+`enterpriseApiBaseUrl`    | String  | no       | The base URL to use when making requests to the enterprise sharing service.
 
 ###
 `isArticleSharingUxUpdates` boolean has been added as part of ACC-749 to enable AB testing of the impact of minor UX improvements to x-gift-article. Once AB testing is done, and decision to keep / remove has been made, the changes made in https://github.com/Financial-Times/x-dash/pull/579 need to be ditched or baked in as default. 

--- a/components/x-gift-article/readme.md
+++ b/components/x-gift-article/readme.md
@@ -77,6 +77,7 @@ Property                  | Type    | Required | Note
 `nativeShare`             | Boolean | no       | This is a property for App to display Native Sharing.
 `apiProtocol`             | String  | no       | The protocol to use when making requests to the gift article and URL shortening services. Ignored if `apiDomain` is not set.
 `apiDomain`               | String  | no       | The domain to use when making requests to the gift article and URL shortening services.
+`enterpriseApiDomain`     | String  | no       | The domain to use when making requests to the enterprise sharing service.
 
 ###
 `isArticleSharingUxUpdates` boolean has been added as part of ACC-749 to enable AB testing of the impact of minor UX improvements to x-gift-article. Once AB testing is done, and decision to keep / remove has been made, the changes made in https://github.com/Financial-Times/x-dash/pull/579 need to be ditched or baked in as default. 

--- a/components/x-gift-article/src/Buttons.jsx
+++ b/components/x-gift-article/src/Buttons.jsx
@@ -34,7 +34,13 @@ export default ({
 					<button
 						className={ButtonWithGapClassNames}
 						type="button"
-						onClick={shareType === ShareType.gift ? actions.copyGiftUrl : actions.copyNonGiftUrl}
+						onClick={
+							shareType === ShareType.gift
+								? actions.copyGiftUrl
+								: shareType === ShareType.enterprise
+								? actions.copyEnterpriseUrl
+								: actions.copyNonGiftUrl
+						}
 						aria-label="Copy the gift article link to your clipboard">
 						Copy link
 					</button>
@@ -44,7 +50,13 @@ export default ({
 					href={mailtoUrl}
 					target="_blank"
 					rel="noopener noreferrer"
-					onClick={shareType === ShareType.gift ? actions.emailGiftUrl : actions.emailNonGiftUrl}>
+					onClick={
+						shareType === ShareType.gift
+							? actions.emailGiftUrl
+							: shareType === ShareType.enterprise
+							? actions.emailEnterpriseUrl
+							: actions.emailNonGiftUrl
+					}>
 					Email link <span className={styles['visually-hidden']}>to Share this article</span>
 				</a>
 			</div>

--- a/components/x-gift-article/src/Buttons.jsx
+++ b/components/x-gift-article/src/Buttons.jsx
@@ -35,8 +35,7 @@ export default ({
 						className={ButtonWithGapClassNames}
 						type="button"
 						onClick={shareType === ShareType.gift ? actions.copyGiftUrl : actions.copyNonGiftUrl}
-						aria-label="Copy the gift article link to your clipboard"
-					>
+						aria-label="Copy the gift article link to your clipboard">
 						Copy link
 					</button>
 				)}
@@ -45,8 +44,7 @@ export default ({
 					href={mailtoUrl}
 					target="_blank"
 					rel="noopener noreferrer"
-					onClick={shareType === ShareType.gift ? actions.emailGiftUrl : actions.emailNonGiftUrl}
-				>
+					onClick={shareType === ShareType.gift ? actions.emailGiftUrl : actions.emailNonGiftUrl}>
 					Email link <span className={styles['visually-hidden']}>to Share this article</span>
 				</a>
 			</div>
@@ -59,8 +57,7 @@ export default ({
 				className={ButtonClassNames}
 				disabled={!giftCredits}
 				type="button"
-				onClick={shareType === ShareType.enterprise ? actions.createEnterpriseUrl : actions.createGiftUrl}
-			>
+				onClick={shareType === ShareType.enterprise ? actions.createEnterpriseUrl : actions.createGiftUrl}>
 				Create {shareType === ShareType.enterprise ? 'enterprise' : 'gift'} link
 			</button>
 		</div>

--- a/components/x-gift-article/src/Buttons.jsx
+++ b/components/x-gift-article/src/Buttons.jsx
@@ -35,7 +35,8 @@ export default ({
 						className={ButtonWithGapClassNames}
 						type="button"
 						onClick={shareType === ShareType.gift ? actions.copyGiftUrl : actions.copyNonGiftUrl}
-						aria-label="Copy the gift article link to your clipboard">
+						aria-label="Copy the gift article link to your clipboard"
+					>
 						Copy link
 					</button>
 				)}
@@ -44,7 +45,8 @@ export default ({
 					href={mailtoUrl}
 					target="_blank"
 					rel="noopener noreferrer"
-					onClick={shareType === ShareType.gift ? actions.emailGiftUrl : actions.emailNonGiftUrl}>
+					onClick={shareType === ShareType.gift ? actions.emailGiftUrl : actions.emailNonGiftUrl}
+				>
 					Email link <span className={styles['visually-hidden']}>to Share this article</span>
 				</a>
 			</div>
@@ -57,8 +59,9 @@ export default ({
 				className={ButtonClassNames}
 				disabled={!giftCredits}
 				type="button"
-				onClick={actions.createGiftUrl}>
-				Create gift link
+				onClick={shareType === ShareType.enterprise ? actions.createEnterpriseUrl : actions.createGiftUrl}
+			>
+				Create {shareType === ShareType.enterprise ? 'enterprise' : 'gift'} link
 			</button>
 		</div>
 	)

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -20,6 +20,7 @@ export default (props) => (
 						showEnterpriseUrlSection={props.actions.showEnterpriseUrlSection}
 						showNonGiftUrlSection={props.actions.showNonGiftUrlSection}
 						enterpriseLimit={props.enterpriseLimit}
+						enterpriseHasCredits={props.enterpriseHasCredits}
 						enterpriseEnabled={props.enterpriseEnabled}
 					/>
 				)}

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -17,7 +17,9 @@ export default (props) => (
 						shareType={props.shareType}
 						isArticleSharingUxUpdates={props.isArticleSharingUxUpdates}
 						showGiftUrlSection={props.actions.showGiftUrlSection}
+						showEnterpriseUrlSection={props.actions.showEnterpriseUrlSection}
 						showNonGiftUrlSection={props.actions.showNonGiftUrlSection}
+						enterpriseLimit={props.enterpriseLimit}
 					/>
 				)}
 

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -20,6 +20,7 @@ export default (props) => (
 						showEnterpriseUrlSection={props.actions.showEnterpriseUrlSection}
 						showNonGiftUrlSection={props.actions.showNonGiftUrlSection}
 						enterpriseLimit={props.enterpriseLimit}
+						enterpriseEnabled={props.enterpriseEnabled}
 					/>
 				)}
 

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -21,6 +21,7 @@ export default (props) => (
 						showNonGiftUrlSection={props.actions.showNonGiftUrlSection}
 						enterpriseLimit={props.enterpriseLimit}
 						enterpriseHasCredits={props.enterpriseHasCredits}
+						enterpriseRequestAccess={props.enterpriseRequestAccess}
 						enterpriseAlert={!props.enterpriseHasCredits && !props.enterpriseRequestAccess}
 						enterpriseEnabled={props.enterpriseEnabled}
 					/>

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -21,6 +21,7 @@ export default (props) => (
 						showNonGiftUrlSection={props.actions.showNonGiftUrlSection}
 						enterpriseLimit={props.enterpriseLimit}
 						enterpriseHasCredits={props.enterpriseHasCredits}
+						enterpriseAlert={!props.enterpriseHasCredits && !props.enterpriseRequestAccess}
 						enterpriseEnabled={props.enterpriseEnabled}
 					/>
 				)}

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -9,6 +9,7 @@ import EnterpriseApiClient from './lib/enterpriseApi'
 import { copyToClipboard, createMailtoUrl } from './lib/share-link-actions'
 import tracking from './lib/tracking'
 import * as updaters from './lib/updaters'
+import { ShareType } from './lib/constants'
 
 const isCopySupported =
 	typeof document !== 'undefined' && document.queryCommandSupported && document.queryCommandSupported('copy')
@@ -148,6 +149,7 @@ const withGiftFormActions = withActions(
 						if (giftCredits > 0 || giftCredits === 0) {
 							return {
 								...updaters.setAllowance(giftCredits, monthlyAllowance, nextRenewalDate),
+								shareType: enabled ? ShareType.enterprise : ShareType.gift,
 								enterpriseEnabled: enabled,
 								enterpriseLimit: limit,
 								enterpriseHasCredits: hasCredits,

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -63,11 +63,11 @@ const withGiftFormActions = withActions(
 			},
 
 			async createEnterpriseUrl() {
-				const { redemptionUrl } = await enterpriseApi.getESUrl(initialProps.article.id)
+				const { redemptionUrl, redemptionLimit } = await enterpriseApi.getESUrl(initialProps.article.id)
 
 				if (redemptionUrl) {
 					tracking.createESLink(redemptionUrl)
-					return updaters.setGiftUrl(redemptionUrl, 0, false)
+					return updaters.setGiftUrl(redemptionUrl, redemptionLimit, false)
 				} else {
 					// TODO do something
 				}

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -117,19 +117,24 @@ const withGiftFormActions = withActions(
 						}
 					} else {
 						const { giftCredits, monthlyAllowance, nextRenewalDate } = await api.getGiftArticleAllowance()
-						const { limit, hasCredits } = await enterpriseApi.getEnterpriseArticleAllowance()
+						const { enabled, limit, hasCredits, firstTimeUser } =
+							await enterpriseApi.getEnterpriseArticleAllowance()
 						// avoid to use giftCredits >= 0 because it returns true when null and ""
 						if (giftCredits > 0 || giftCredits === 0) {
 							return {
 								...updaters.setAllowance(giftCredits, monthlyAllowance, nextRenewalDate),
+								enterpriseEnabled: enabled,
 								enterpriseLimit: limit,
-								enterpriseHasCredits: hasCredits
+								enterpriseHasCredits: hasCredits,
+								enterpriseFirstTimeUser: firstTimeUser
 							}
 						} else {
 							return {
 								invalidResponseFromApi: true,
+								enterpriseEnabled: enabled,
 								enterpriseLimit: limit,
-								enterpriseHasCredits: hasCredits
+								enterpriseHasCredits: hasCredits,
+								enterpriseFirstTimeUser: firstTimeUser
 							}
 						}
 					}

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -22,10 +22,7 @@ const withGiftFormActions = withActions(
 			protocol: initialProps.apiProtocol,
 			domain: initialProps.apiDomain
 		})
-		const enterpriseApi = new EnterpriseApiClient({
-			protocol: initialProps.apiProtocol,
-			domain: initialProps.enterpriseApiDomain
-		})
+		const enterpriseApi = new EnterpriseApiClient(initialProps.enterpriseApiBaseUrl)
 
 		return {
 			showGiftUrlSection() {

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -67,7 +67,7 @@ const withGiftFormActions = withActions(
 
 				if (redemptionUrl) {
 					tracking.createESLink(redemptionUrl)
-					return updaters.setGiftUrl(redemptionUrl, redemptionLimit, false)
+					return updaters.setGiftUrl(redemptionUrl, redemptionLimit, false, true)
 				} else {
 					// TODO do something
 				}
@@ -79,6 +79,17 @@ const withGiftFormActions = withActions(
 				return (state) => {
 					const giftUrl = state.urls.gift
 					tracking.copyLink('giftLink', giftUrl)
+
+					return { showCopyConfirmation: true }
+				}
+			},
+
+			copyEnterpriseUrl(event) {
+				copyToClipboard(event)
+
+				return (state) => {
+					const enterpriseUrl = state.urls.enterprise
+					tracking.copyLink('enterpriseLink', enterpriseUrl)
 
 					return { showCopyConfirmation: true }
 				}
@@ -98,6 +109,12 @@ const withGiftFormActions = withActions(
 			emailGiftUrl() {
 				return (state) => {
 					tracking.emailLink('giftLink', state.urls.gift)
+				}
+			},
+
+			emailEnterpriseUrl() {
+				return (state) => {
+					tracking.emailLink('enterpriseLink', state.urls.enterprise)
 				}
 			},
 

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -117,7 +117,7 @@ const withGiftFormActions = withActions(
 						}
 					} else {
 						const { giftCredits, monthlyAllowance, nextRenewalDate } = await api.getGiftArticleAllowance()
-						const { enabled, limit, hasCredits, firstTimeUser } =
+						const { enabled, limit, hasCredits, firstTimeUser, requestAccess } =
 							await enterpriseApi.getEnterpriseArticleAllowance()
 						// avoid to use giftCredits >= 0 because it returns true when null and ""
 						if (giftCredits > 0 || giftCredits === 0) {
@@ -126,7 +126,8 @@ const withGiftFormActions = withActions(
 								enterpriseEnabled: enabled,
 								enterpriseLimit: limit,
 								enterpriseHasCredits: hasCredits,
-								enterpriseFirstTimeUser: firstTimeUser
+								enterpriseFirstTimeUser: firstTimeUser,
+								enterpriseRequestAccess: requestAccess
 							}
 						} else {
 							return {
@@ -134,7 +135,8 @@ const withGiftFormActions = withActions(
 								enterpriseEnabled: enabled,
 								enterpriseLimit: limit,
 								enterpriseHasCredits: hasCredits,
-								enterpriseFirstTimeUser: firstTimeUser
+								enterpriseFirstTimeUser: firstTimeUser,
+								enterpriseRequestAccess: requestAccess
 							}
 						}
 					}

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -59,7 +59,7 @@ const withGiftFormActions = withActions(
 
 					return updaters.setGiftUrl(url, redemptionLimit, isShortened)
 				} else {
-					// TODO do something
+					return updaters.setErrorState(true)
 				}
 			},
 
@@ -70,7 +70,7 @@ const withGiftFormActions = withActions(
 					tracking.createESLink(redemptionUrl)
 					return updaters.setGiftUrl(redemptionUrl, redemptionLimit, false, true)
 				} else {
-					// TODO do something
+					return updaters.setErrorState(true)
 				}
 			},
 

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -65,6 +65,17 @@ const withGiftFormActions = withActions(
 				}
 			},
 
+			async createEnterpriseUrl() {
+				const { redemptionUrl } = await enterpriseApi.getESUrl(initialProps.article.id)
+
+				if (redemptionUrl) {
+					tracking.createESLink(redemptionUrl)
+					return updaters.setGiftUrl(redemptionUrl, 0, false)
+				} else {
+					// TODO do something
+				}
+			},
+
 			copyGiftUrl(event) {
 				copyToClipboard(event)
 

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -77,14 +77,6 @@ $o-icons-is-silent: true;
 	.share-option-title {
 		@include oNormaliseVisuallyHidden();
 	}
-
-	.o-forms-field{
-		@media only screen and (min-width: 600px) {
-			label[for$="Link"]{
-				margin-bottom: 0;
-			}
-		}	
-	}
 }
 
 @media only screen and (min-width: 600px) {

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -35,11 +35,13 @@ $o-icons-is-silent: true;
 
 .o-icons__enterprise-no-credits {
 	@include oIconsContent(
-		$icon-name: 'info',
-		$color: oColorsByName('claret'),
-		$size: 32
+		$icon-name: 'warning',
+		$color: oColorsByName('crimson'),
+		$size: 16
 	);
-	margin: -11px -11px -11px 0px;
+	border-radius: 50%;
+	border: 2px solid oColorsByName('crimson');
+	margin-bottom: -5px;
 }
 
 
@@ -60,6 +62,12 @@ $o-icons-is-silent: true;
         'content-premium'
     ),
 		));
+
+		.enterprise-label {
+			background-color: oColorsByName('black-10');
+			color: oColorsByName('black');
+			margin: 0px 6px;
+		}
 	}
 
 	.share-option-title {
@@ -139,7 +147,7 @@ $o-icons-is-silent: true;
 
 .buttons {
 	grid-area: buttons;
-	text-align: right;
+	text-align: left;
 	white-space: nowrap;
 	margin-top: 12px;
 }

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -116,6 +116,7 @@ $o-icons-is-silent: true;
 }
 
 .enterprise-message {
+	grid-area: message;
 	background: oColorsByName('white-40');
 	border: 1px solid oColorsByName('black-5');
 	margin-top: oSpacingByName('s4');

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -16,6 +16,10 @@ $o-message-is-silent: true;
 $o-typography-is-silent: true;
 @import 'o-typography/main';
 
+$o-labels-is-silent: true;
+@import 'o-labels/main';
+
+
 .container {
 	@include oTypographySans;
 	strong {
@@ -36,6 +40,11 @@ $o-typography-is-silent: true;
 
 	.radio-button-section {
 		margin-bottom: 12px;
+		@include oLabels($opts: (
+			'states': (
+        'content-premium'
+    ),
+		));
 	}
 
 	.share-option-title {

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -22,12 +22,24 @@ $o-labels-is-silent: true;
 $o-colors-is-silent: true;
 @import 'o-colors/main';
 
+$o-icons-is-silent: true;
+@import 'o-icons/main';
+
 
 .container {
 	@include oTypographySans;
 	strong {
 		font-weight: 600;
 	}
+}
+
+.o-icons__enterprise-no-credits {
+	@include oIconsContent(
+		$icon-name: 'info',
+		$color: oColorsByName('claret'),
+		$size: 32
+	);
+	margin: -11px -11px -11px 0px;
 }
 
 
@@ -114,13 +126,17 @@ $o-colors-is-silent: true;
 .enterprise-message {
 	background: oColorsByName('white-40');
 	border: 1px solid oColorsByName('black-5');
-	padding: oSpacingByName('s2') oSpacingByName('s3');
+	margin-top: oSpacingByName('s4');
+	padding: oSpacingByName('s4');
 
 	h4 {
 		@include oTypographySans($scale: 1, $weight: 'semibold');
-		color: oColorsByName('black');
+		color: oColorsByName('black-90');
+		font-size: 16px;
 		margin: 0;
-		padding: 2px 0px 10px;
+	}
+	p {
+		margin: oSpacingByName('s2') 0px;
 	}
 }
 

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -19,6 +19,9 @@ $o-typography-is-silent: true;
 $o-labels-is-silent: true;
 @import 'o-labels/main';
 
+$o-colors-is-silent: true;
+@import 'o-colors/main';
+
 
 .container {
 	@include oTypographySans;
@@ -106,6 +109,19 @@ $o-labels-is-silent: true;
 	grid-area: message;
 	font-size: 16px;
 	margin-top: 12px;
+}
+
+.enterprise-message {
+	background: oColorsByName('white-40');
+	border: 1px solid oColorsByName('black-5');
+	padding: oSpacingByName('s2') oSpacingByName('s3');
+
+	h4 {
+		@include oTypographySans($scale: 1, $weight: 'semibold');
+		color: oColorsByName('black');
+		margin: 0;
+		padding: 2px 0px 10px;
+	}
 }
 
 .buttonBaseStyle {

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -20,6 +20,10 @@ export default ({
 			return null
 		}
 
+		if (shareType === ShareType.enterprise) {
+			return null
+		}
+
 		if (shareType === ShareType.gift) {
 			if (giftCredits === 0) {
 				return (
@@ -87,6 +91,10 @@ export default ({
 				left this month
 			</div>
 		)
+	}
+
+	if (shareType === ShareType.enterprise) {
+		return null
 	}
 
 	if (shareType === ShareType.nonGift) {

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -113,9 +113,29 @@ export default ({
 							target="_blank"
 							rel="noreferrer"
 							className={styles['buttonBaseStyle']}
-							type="button"
 						>
 							Request Access
+						</a>
+					</div>
+				)
+			}
+
+			if (enterpriseHasCredits === false) {
+				return (
+					<div className={styles['enterprise-message']}>
+						<h4>Your organisation has run out of share credits.</h4>
+						<p>
+							Request more credits and our Enterprise team will get in touch with the admin of your FT
+							subscription to arrange a top-up of sharing credits.
+						</p>
+						<a
+							href="https://enterprise.ft.com/ft-enterprise-sharing-request-access/?segmentId=c87259e0-7073-3ea8-7f83-b988f05c3f94"
+							target="_blank"
+							rel="noreferrer"
+							className={styles['buttonBaseStyle']}
+							type="button"
+						>
+							Request more credits
 						</a>
 					</div>
 				)

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -139,27 +139,24 @@ export default ({
 					</div>
 				)
 			}
-
-			if (enterpriseHasCredits === false) {
-				return (
-					<div className={styles['enterprise-message']}>
-						<h4>Your organisation has run out of share credits.</h4>
-						<p>
-							Request more credits and our Enterprise team will get in touch with the admin of your FT
-							subscription to arrange a top-up of sharing credits.
-						</p>
-						<a
-							href="https://enterprise.ft.com/ft-enterprise-sharing-request-access/?segmentId=c87259e0-7073-3ea8-7f83-b988f05c3f94"
-							target="_blank"
-							rel="noreferrer"
-							className={styles['buttonBaseStyle']}
-							type="button"
-						>
-							Request more credits
-						</a>
-					</div>
-				)
-			}
+			return (
+				<div className={styles['enterprise-message']}>
+					<h4>Your organisation has run out of share credits.</h4>
+					<p>
+						Request more credits and our Enterprise team will get in touch with the admin of your FT
+						subscription to arrange a top-up of sharing credits.
+					</p>
+					<a
+						href="https://enterprise.ft.com/ft-enterprise-sharing-request-access/?segmentId=c87259e0-7073-3ea8-7f83-b988f05c3f94"
+						target="_blank"
+						rel="noreferrer"
+						className={styles['buttonBaseStyle']}
+						type="button"
+					>
+						Request more credits
+					</a>
+				</div>
+			)
 		}
 	}
 

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -15,7 +15,8 @@ export default ({
 	invalidResponseFromApi,
 	isArticleSharingUxUpdates,
 	enterpriseHasCredits,
-	enterpriseRequestAccess
+	enterpriseRequestAccess,
+	enterpriseFirstTimeUser
 }) => {
 	if (isArticleSharingUxUpdates) {
 		if (isFreeArticle) {
@@ -93,6 +94,17 @@ export default ({
 
 	if (shareType === ShareType.enterprise) {
 		if (enterpriseHasCredits === true) {
+			if (enterpriseFirstTimeUser) {
+				return (
+					<div className={styles['enterprise-message']}>
+						<h4>Engage more effectively with clients and colleagues.</h4>
+						<p>
+							Enterprise Sharing lets members of your organisation share FT article links with up to 100
+							people, even if they don’t have a FT subscription.
+						</p>
+					</div>
+				)
+			}
 			return (
 				<div className={messageClassName}>
 					Your organisation has <strong>Enterprise Sharing credits</strong> available for you to use

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -14,6 +14,7 @@ export default ({
 	redemptionLimit,
 	invalidResponseFromApi,
 	isArticleSharingUxUpdates,
+	enterpriseLimit,
 	enterpriseHasCredits,
 	enterpriseRequestAccess,
 	enterpriseFirstTimeUser
@@ -93,6 +94,13 @@ export default ({
 	}
 
 	if (shareType === ShareType.enterprise) {
+		if (isGiftUrlCreated === true) {
+			return (
+				<div className={messageClassName}>
+					This link can be opened by up to {enterpriseLimit} people and is valid for 90 days
+				</div>
+			)
+		}
 		if (enterpriseHasCredits === true) {
 			if (enterpriseFirstTimeUser) {
 				return (

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -14,7 +14,8 @@ export default ({
 	redemptionLimit,
 	invalidResponseFromApi,
 	isArticleSharingUxUpdates,
-	enterpriseHasCredits
+	enterpriseHasCredits,
+	enterpriseRequestAccess
 }) => {
 	if (isArticleSharingUxUpdates) {
 		if (isFreeArticle) {
@@ -97,6 +98,28 @@ export default ({
 					Your organisation has <strong>Enterprise Sharing credits</strong> available for you to use
 				</div>
 			)
+		} else {
+			if (enterpriseRequestAccess) {
+				//Activation Message
+				return (
+					<div className={styles['enterprise-message']}>
+						<h4>Engage more effectively with clients and colleagues.</h4>
+						<p>
+							Enterprise Sharing lets members of your organisation share FT article links with up to 100
+							people, even if they don't have a FT subscription.
+						</p>
+						<a
+							href="https://enterprise.ft.com/ft-enterprise-sharing-request-access/?segmentId=c87259e0-7073-3ea8-7f83-b988f05c3f94"
+							target="_blank"
+							rel="noreferrer"
+							className={styles['buttonBaseStyle']}
+							type="button"
+						>
+							Request Access
+						</a>
+					</div>
+				)
+			}
 		}
 	}
 

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -94,6 +94,10 @@ export default ({
 	}
 
 	if (shareType === ShareType.enterprise) {
+		if (invalidResponseFromApi) {
+			return <div className={messageClassName}>Unable to create enterprise link. Please try again later</div>
+		}
+
 		if (isGiftUrlCreated === true) {
 			return (
 				<div className={messageClassName}>

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -84,7 +84,7 @@ export default ({
 
 		return (
 			<div className={messageClassName}>
-				You have{' '}
+				Uses 1 gift credit. You have{' '}
 				<strong>
 					{giftCredits} gift article {giftCredits === 1 ? 'credit' : 'credits'}
 				</strong>{' '}

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -13,14 +13,11 @@ export default ({
 	nextRenewalDateText,
 	redemptionLimit,
 	invalidResponseFromApi,
-	isArticleSharingUxUpdates
+	isArticleSharingUxUpdates,
+	enterpriseHasCredits
 }) => {
 	if (isArticleSharingUxUpdates) {
 		if (isFreeArticle) {
-			return null
-		}
-
-		if (shareType === ShareType.enterprise) {
 			return null
 		}
 
@@ -94,7 +91,13 @@ export default ({
 	}
 
 	if (shareType === ShareType.enterprise) {
-		return null
+		if (enterpriseHasCredits === true) {
+			return (
+				<div className={messageClassName}>
+					Your organisation has <strong>Enterprise Sharing credits</strong> available for you to use
+				</div>
+			)
+		}
 	}
 
 	if (shareType === ShareType.nonGift) {

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -107,8 +107,8 @@ export default ({
 					<div className={styles['enterprise-message']}>
 						<h4>Engage more effectively with clients and colleagues.</h4>
 						<p>
-							Enterprise Sharing lets members of your organisation share FT article links with up to 100
-							people, even if they don’t have a FT subscription.
+							Enterprise Sharing lets members of your organisation share FT article links with up to{' '}
+							{enterpriseLimit} people, even if they don’t have a FT subscription.
 						</p>
 					</div>
 				)
@@ -123,17 +123,17 @@ export default ({
 				//Activation Message
 				return (
 					<div className={styles['enterprise-message']}>
-						<h4>Engage more effectively with clients and colleagues.</h4>
+						<h4>Enterprise Sharing is not enabled for your team</h4>
 						<p>
-							Enterprise Sharing lets members of your organisation share FT article links with up to 100
-							people, even if they don't have a FT subscription.
+							Enterprise Sharing lets members of your organisation share FT article links with potentially
+							thousands people, even if they don’t have a FT subscription
 						</p>
 						<a
 							href="https://enterprise.ft.com/ft-enterprise-sharing-request-access/?segmentId=c87259e0-7073-3ea8-7f83-b988f05c3f94"
 							target="_blank"
 							rel="noreferrer"
 							className={styles['buttonBaseStyle']}>
-							Request Access
+							Learn more
 						</a>
 					</div>
 				)

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -132,8 +132,7 @@ export default ({
 							href="https://enterprise.ft.com/ft-enterprise-sharing-request-access/?segmentId=c87259e0-7073-3ea8-7f83-b988f05c3f94"
 							target="_blank"
 							rel="noreferrer"
-							className={styles['buttonBaseStyle']}
-						>
+							className={styles['buttonBaseStyle']}>
 							Request Access
 						</a>
 					</div>
@@ -151,8 +150,7 @@ export default ({
 						target="_blank"
 						rel="noreferrer"
 						className={styles['buttonBaseStyle']}
-						type="button"
-					>
+						type="button">
 						Request more credits
 					</a>
 				</div>

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -10,7 +10,14 @@ const radioSectionClassNames = [
 	styles['radio-button-section']
 ].join(' ')
 
-export default ({ shareType, showGiftUrlSection, isArticleSharingUxUpdates, showNonGiftUrlSection }) => (
+export default ({
+	shareType,
+	showGiftUrlSection,
+	showEnterpriseUrlSection,
+	isArticleSharingUxUpdates,
+	showNonGiftUrlSection,
+	enterpriseLimit = null
+}) => (
 	<div className={radioSectionClassNames} role="group" aria-labelledby="article-share-options">
 		<span className={styles['share-option-title']} id="article-share-options">
 			Article share options
@@ -30,10 +37,38 @@ export default ({ shareType, showGiftUrlSection, isArticleSharingUxUpdates, show
 				</span>
 			) : (
 				<span className={styles['o-forms-input__label']}>
-					with <strong>anyone</strong> (uses 1 gift credit)
+					with up to <strong>3 people</strong> (uses 1 gift credit)
 				</span>
 			)}
 		</label>
+
+		{enterpriseLimit !== null && (
+			<label htmlFor="enterpriseLink">
+				<input
+					type="radio"
+					name="gift-form__radio"
+					value="enterpriseLink"
+					id="enterpriseLink"
+					checked={shareType === ShareType.enterprise}
+					onChange={showEnterpriseUrlSection}
+				/>
+				{isArticleSharingUxUpdates ? (
+					<span className={styles['o-forms-input__label']}>
+						Gift to <strong>{enterpriseLimit}</strong> people{' '}
+						<span className={[styles['o-labels'], styles['o-labels--content-premium']].join(' ')}>
+							Enterprise
+						</span>
+					</span>
+				) : (
+					<span className={styles['o-forms-input__label']}>
+						with up to <strong>{enterpriseLimit} people</strong>{' '}
+						<span className={[styles['o-labels'], styles['o-labels--content-premium']].join(' ')}>
+							Enterprise
+						</span>
+					</span>
+				)}
+			</label>
+		)}
 
 		<label htmlFor="nonGiftLink">
 			<input

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -34,11 +34,11 @@ export default ({
 			/>
 			{isArticleSharingUxUpdates ? (
 				<span className={styles['o-forms-input__label']}>
-					Gift to <strong>anyone</strong> (uses <strong>1 credit</strong>)
+					Gift to <strong>anyone</strong>
 				</span>
 			) : (
 				<span className={styles['o-forms-input__label']}>
-					with up to <strong>3 people</strong> (uses 1 gift credit)
+					with up to <strong>3 people</strong>
 				</span>
 			)}
 		</label>
@@ -78,7 +78,7 @@ export default ({
 				</span>
 			) : (
 				<span className={styles['o-forms-input__label']}>
-					with <strong>other FT subscribers</strong>
+					with <strong>other FT subscribers</strong> only
 				</span>
 			)}
 		</label>

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -13,11 +13,9 @@ export default ({
 	shareType,
 	showGiftUrlSection,
 	showEnterpriseUrlSection,
-	isArticleSharingUxUpdates,
 	showNonGiftUrlSection,
 	enterpriseEnabled = false,
-	enterpriseHasCredits = true,
-	enterpriseLimit = 100 //if limit is not set enterprise will show 100 for default (value used for activation)
+	enterpriseAlert = false
 }) => (
 	<div className={radioSectionClassNames} role="group" aria-labelledby="article-share-options">
 		<span className={styles['share-option-title']} id="article-share-options">
@@ -32,15 +30,7 @@ export default ({
 				checked={shareType === ShareType.gift}
 				onChange={showGiftUrlSection}
 			/>
-			{isArticleSharingUxUpdates ? (
-				<span className={styles['o-forms-input__label']}>
-					Gift to <strong>anyone</strong>
-				</span>
-			) : (
-				<span className={styles['o-forms-input__label']}>
-					with up to <strong>3 people</strong>
-				</span>
-			)}
+			<span className={styles['o-forms-input__label']}>Single recipient</span>
 		</label>
 
 		{enterpriseEnabled === true && (
@@ -54,11 +44,9 @@ export default ({
 					onChange={showEnterpriseUrlSection}
 				/>
 				<span className={styles['o-forms-input__label']}>
-					with up to <strong>{enterpriseLimit} people</strong>{' '}
-					<span className={[styles['o-labels'], styles['o-labels--content-premium']].join(' ')}>
-						Enterprise
-					</span>
-					{!enterpriseHasCredits && <span className={styles['o-icons__enterprise-no-credits']}></span>}
+					Multiple recipients
+					<span className={[styles['o-labels'], styles['enterprise-label']].join(' ')}>Enterprise</span>
+					{enterpriseAlert && <span className={styles['o-icons__enterprise-no-credits']}></span>}
 				</span>
 			</label>
 		)}
@@ -72,15 +60,7 @@ export default ({
 				checked={shareType === ShareType.nonGift}
 				onChange={showNonGiftUrlSection}
 			/>
-			{isArticleSharingUxUpdates ? (
-				<span className={styles['o-forms-input__label']}>
-					Share with <strong>other FT subscribers</strong>
-				</span>
-			) : (
-				<span className={styles['o-forms-input__label']}>
-					with <strong>other FT subscribers</strong> only
-				</span>
-			)}
+			<span className={styles['o-forms-input__label']}>FT subscribers only</span>
 		</label>
 	</div>
 )

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -5,7 +5,6 @@ import styles from './GiftArticle.scss'
 const radioSectionClassNames = [
 	styles['o-forms-input'],
 	styles['o-forms-input--radio-round'],
-	styles['o-forms-input--inline'],
 	styles['o-forms-field'],
 	styles['radio-button-section']
 ].join(' ')

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -17,6 +17,7 @@ export default ({
 	isArticleSharingUxUpdates,
 	showNonGiftUrlSection,
 	enterpriseEnabled = false,
+	enterpriseHasCredits = true,
 	enterpriseLimit = 100 //if limit is not set enterprise will show 100 for default (value used for activation)
 }) => (
 	<div className={radioSectionClassNames} role="group" aria-labelledby="article-share-options">
@@ -58,6 +59,7 @@ export default ({
 					<span className={[styles['o-labels'], styles['o-labels--content-premium']].join(' ')}>
 						Enterprise
 					</span>
+					{!enterpriseHasCredits && <span className={styles['o-icons__enterprise-no-credits']}></span>}
 				</span>
 			</label>
 		)}

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -16,7 +16,8 @@ export default ({
 	showEnterpriseUrlSection,
 	isArticleSharingUxUpdates,
 	showNonGiftUrlSection,
-	enterpriseLimit = null
+	enterpriseEnabled = false,
+	enterpriseLimit = 100 //if limit is not set enterprise will show 100 for default (value used for activation)
 }) => (
 	<div className={radioSectionClassNames} role="group" aria-labelledby="article-share-options">
 		<span className={styles['share-option-title']} id="article-share-options">
@@ -42,7 +43,7 @@ export default ({
 			)}
 		</label>
 
-		{enterpriseLimit !== null && (
+		{enterpriseEnabled === true && (
 			<label htmlFor="enterpriseLink">
 				<input
 					type="radio"
@@ -52,21 +53,12 @@ export default ({
 					checked={shareType === ShareType.enterprise}
 					onChange={showEnterpriseUrlSection}
 				/>
-				{isArticleSharingUxUpdates ? (
-					<span className={styles['o-forms-input__label']}>
-						Gift to <strong>{enterpriseLimit}</strong> people{' '}
-						<span className={[styles['o-labels'], styles['o-labels--content-premium']].join(' ')}>
-							Enterprise
-						</span>
+				<span className={styles['o-forms-input__label']}>
+					with up to <strong>{enterpriseLimit} people</strong>{' '}
+					<span className={[styles['o-labels'], styles['o-labels--content-premium']].join(' ')}>
+						Enterprise
 					</span>
-				) : (
-					<span className={styles['o-forms-input__label']}>
-						with up to <strong>{enterpriseLimit} people</strong>{' '}
-						<span className={[styles['o-labels'], styles['o-labels--content-premium']].join(' ')}>
-							Enterprise
-						</span>
-					</span>
-				)}
+				</span>
 			</label>
 		)}
 

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -15,23 +15,14 @@ export default ({
 	showEnterpriseUrlSection,
 	showNonGiftUrlSection,
 	enterpriseEnabled = false,
+	enterpriseLimit = 100,
+	enterpriseRequestAccess = false,
 	enterpriseAlert = false
 }) => (
 	<div className={radioSectionClassNames} role="group" aria-labelledby="article-share-options">
 		<span className={styles['share-option-title']} id="article-share-options">
 			Article share options
 		</span>
-		<label htmlFor="giftLink">
-			<input
-				type="radio"
-				name="gift-form__radio"
-				value="giftLink"
-				id="giftLink"
-				checked={shareType === ShareType.gift}
-				onChange={showGiftUrlSection}
-			/>
-			<span className={styles['o-forms-input__label']}>Single recipient</span>
-		</label>
 
 		{enterpriseEnabled === true && (
 			<label htmlFor="enterpriseLink">
@@ -44,12 +35,28 @@ export default ({
 					onChange={showEnterpriseUrlSection}
 				/>
 				<span className={styles['o-forms-input__label']}>
-					Multiple recipients
+					{enterpriseLimit && !enterpriseRequestAccess
+						? `Up to ${enterpriseLimit} recipients`
+						: `Multiple recipients`}
 					<span className={[styles['o-labels'], styles['enterprise-label']].join(' ')}>Enterprise</span>
 					{enterpriseAlert && <span className={styles['o-icons__enterprise-no-credits']}></span>}
 				</span>
 			</label>
 		)}
+
+		<label htmlFor="giftLink">
+			<input
+				type="radio"
+				name="gift-form__radio"
+				value="giftLink"
+				id="giftLink"
+				checked={shareType === ShareType.gift}
+				onChange={showGiftUrlSection}
+			/>
+			<span className={styles['o-forms-input__label']}>
+				{enterpriseEnabled ? `Single recipient` : `with anyone`}
+			</span>
+		</label>
 
 		<label htmlFor="nonGiftLink">
 			<input

--- a/components/x-gift-article/src/Url.jsx
+++ b/components/x-gift-article/src/Url.jsx
@@ -14,7 +14,7 @@ export default ({ shareType, isGiftUrlCreated, url, urlType }) => {
 				name={urlType}
 				value={url}
 				className={urlClassNames}
-				disabled={shareType === ShareType.gift && !isGiftUrlCreated}
+				disabled={(shareType === ShareType.gift || shareType === ShareType.enterprise) && !isGiftUrlCreated}
 				readOnly
 				aria-label="Gift article shareable link"
 			/>

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -25,7 +25,8 @@ export default ({
 	actions,
 	enterpriseLimit,
 	enterpriseHasCredits,
-	enterpriseRequestAccess
+	enterpriseRequestAccess,
+	enterpriseFirstTimeUser
 }) => {
 	const hideUrlShareElements =
 		(giftCredits === 0 && shareType === ShareType.gift) ||
@@ -62,7 +63,8 @@ export default ({
 					isArticleSharingUxUpdates,
 					enterpriseHasCredits,
 					enterpriseLimit,
-					enterpriseRequestAccess
+					enterpriseRequestAccess,
+					enterpriseFirstTimeUser
 				}}
 			/>
 

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -24,9 +24,12 @@ export default ({
 	isArticleSharingUxUpdates,
 	actions,
 	enterpriseLimit,
-	enterpriseHasCredits
+	enterpriseHasCredits,
+	enterpriseRequestAccess
 }) => {
-	const hideUrlShareElements = giftCredits === 0 && shareType === ShareType.gift
+	const hideUrlShareElements =
+		(giftCredits === 0 && shareType === ShareType.gift) ||
+		(enterpriseRequestAccess && shareType === ShareType.enterprise)
 	const showUrlShareElements = !hideUrlShareElements
 
 	return (
@@ -58,7 +61,8 @@ export default ({
 					invalidResponseFromApi,
 					isArticleSharingUxUpdates,
 					enterpriseHasCredits,
-					enterpriseLimit
+					enterpriseLimit,
+					enterpriseRequestAccess
 				}}
 			/>
 

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -29,7 +29,7 @@ export default ({
 }) => {
 	const hideUrlShareElements =
 		(giftCredits === 0 && shareType === ShareType.gift) ||
-		(enterpriseRequestAccess && shareType === ShareType.enterprise)
+		((enterpriseRequestAccess || !enterpriseHasCredits) && shareType === ShareType.enterprise)
 	const showUrlShareElements = !hideUrlShareElements
 
 	return (

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -22,7 +22,9 @@ export default ({
 	nativeShare,
 	invalidResponseFromApi,
 	isArticleSharingUxUpdates,
-	actions
+	actions,
+	enterpriseLimit,
+	enterpriseHasCredits
 }) => {
 	const hideUrlShareElements = giftCredits === 0 && shareType === ShareType.gift
 	const showUrlShareElements = !hideUrlShareElements
@@ -31,7 +33,8 @@ export default ({
 		<div
 			className={urlSectionClassNames}
 			data-section-id={shareType + 'Link'}
-			data-trackable={shareType + 'Link'}>
+			data-trackable={shareType + 'Link'}
+		>
 			{showUrlShareElements && (
 				<Url
 					{...{
@@ -53,7 +56,9 @@ export default ({
 					nextRenewalDateText,
 					redemptionLimit,
 					invalidResponseFromApi,
-					isArticleSharingUxUpdates
+					isArticleSharingUxUpdates,
+					enterpriseHasCredits,
+					enterpriseLimit
 				}}
 			/>
 

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -37,8 +37,7 @@ export default ({
 		<div
 			className={urlSectionClassNames}
 			data-section-id={shareType + 'Link'}
-			data-trackable={shareType + 'Link'}
-		>
+			data-trackable={shareType + 'Link'}>
 			{showUrlShareElements && (
 				<Url
 					{...{

--- a/components/x-gift-article/src/lib/constants.js
+++ b/components/x-gift-article/src/lib/constants.js
@@ -1,5 +1,6 @@
 export const ShareType = {
 	gift: 'gift',
+	enterprise: 'enterprise',
 	nonGift: 'nonGift'
 }
 

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -1,0 +1,44 @@
+export default class EnterpriseApiClient {
+	constructor({ protocol, domain } = {}) {
+		this.protocol = protocol
+		this.domain = domain
+	}
+
+	getFetchUrl(path) {
+		let base = ''
+		if (this.domain) {
+			base = `//${this.domain}`
+
+			if (this.protocol) {
+				base = `${this.protocol}:${base}`
+			}
+		}
+
+		return `${base}${path}`
+	}
+
+	fetchJson(path, additionalOptions) {
+		const url = this.getFetchUrl(path)
+		const options = Object.assign(
+			{
+				credentials: 'include'
+			},
+			additionalOptions
+		)
+
+		return fetch(url, options).then((response) => response.json())
+	}
+
+	async getEnterpriseArticleAllowance() {
+		try {
+			const json = await this.fetchJson('/allowance')
+
+			return {
+				limit: json.limit,
+				hasCredits: json.hasCredits
+			}
+		} catch (e) {
+			return { limit: null, hasCredits: false }
+		}
+	}
+}

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -60,7 +60,7 @@ export default class EnterpriseApiClient {
 	 */
 	async getEnterpriseArticleAllowance() {
 		try {
-			const json = await this.fetchJson('/v1/allowance')
+			const json = await this.fetchJson('/v1/users/me/allowance')
 
 			return {
 				limit: json.limit,

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -35,10 +35,12 @@ export default class EnterpriseApiClient {
 
 			return {
 				limit: json.limit,
-				hasCredits: json.hasCredits
+				hasCredits: json.hasCredits,
+				firstTimeUser: json.firstTimeUser,
+				enabled: json.enabled
 			}
 		} catch (e) {
-			return { limit: null, hasCredits: false }
+			return { enabled: false, limit: null, hasCredits: false, firstTimeUser: false }
 		}
 	}
 }

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -51,7 +51,7 @@ export default class EnterpriseApiClient {
 	 */
 	async getEnterpriseArticleAllowance() {
 		try {
-			const json = await this.fetchJson('/allowance')
+			const json = await this.fetchJson('/v1/allowance')
 
 			return {
 				limit: json.limit,
@@ -71,7 +71,7 @@ export default class EnterpriseApiClient {
 	 * @returns {string} enterprise sharing redeem link URL
 	 */
 	async getESUrl(contentId) {
-		const json = await this.fetchJson('/', { method: 'POST', body: JSON.stringify({ contentId }) })
+		const json = await this.fetchJson('/v1/shares', { method: 'POST', body: JSON.stringify({ contentId }) })
 
 		return {
 			redemptionUrl: json.url

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -74,7 +74,8 @@ export default class EnterpriseApiClient {
 		const json = await this.fetchJson('/v1/shares', { method: 'POST', body: JSON.stringify({ contentId }) })
 
 		return {
-			redemptionUrl: json.url
+			redemptionUrl: json.url,
+			redemptionLimit: json.redeemLimit
 		}
 	}
 }

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -44,4 +44,12 @@ export default class EnterpriseApiClient {
 			return { enabled: false, limit: null, hasCredits: false, firstTimeUser: false, requestAccess: false }
 		}
 	}
+
+	async getESUrl(contentId) {
+		const json = await this.fetchJson('/', { method: 'POST', body: JSON.stringify({ contentId }) })
+
+		return {
+			redemptionUrl: json.url
+		}
+	}
 }

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -37,10 +37,11 @@ export default class EnterpriseApiClient {
 				limit: json.limit,
 				hasCredits: json.hasCredits,
 				firstTimeUser: json.firstTimeUser,
-				enabled: json.enabled
+				enabled: json.enabled,
+				requestAccess: json.enabled && json.limit === null
 			}
 		} catch (e) {
-			return { enabled: false, limit: null, hasCredits: false, firstTimeUser: false }
+			return { enabled: false, limit: null, hasCredits: false, firstTimeUser: false, requestAccess: false }
 		}
 	}
 }

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -67,7 +67,7 @@ export default class EnterpriseApiClient {
 				hasCredits: json.hasCredits,
 				firstTimeUser: json.firstTimeUser,
 				enabled: true,
-				requestAccess: json.enabled && json.limit === null
+				requestAccess: false
 			}
 		} catch (e) {
 			if (e?.message === 'ShowRequestAccess') {

--- a/components/x-gift-article/src/lib/tracking.js
+++ b/components/x-gift-article/src/lib/tracking.js
@@ -17,6 +17,14 @@ module.exports = {
 			longUrl
 		}),
 
+	createESLink: (link) =>
+		dispatchEvent({
+			category: 'enterprise-sharing-link',
+			action: 'create',
+			linkType: 'enterpriseSharingLink',
+			link
+		}),
+
 	copyLink: (linkType, link) =>
 		dispatchEvent({
 			category: 'gift-link',

--- a/components/x-gift-article/src/lib/tracking.js
+++ b/components/x-gift-article/src/lib/tracking.js
@@ -19,7 +19,7 @@ module.exports = {
 
 	createESLink: (link) =>
 		dispatchEvent({
-			category: 'enterprise-sharing-link',
+			category: 'gift-link',
 			action: 'create',
 			linkType: 'enterpriseSharingLink',
 			link

--- a/components/x-gift-article/src/lib/updaters.js
+++ b/components/x-gift-article/src/lib/updaters.js
@@ -24,6 +24,14 @@ export const showGiftUrlSection = (props) => ({
 	showCopyConfirmation: false
 })
 
+export const showGiftEnterpriseSection = (props) => ({
+	shareType: ShareType.enterprise,
+	url: props.urls.enterprise || props.urls.dummy,
+	urlType: props.urls.enterprise ? UrlType.gift : UrlType.dummy,
+	mailtoUrl: props.mailtoUrls.enterprise,
+	showCopyConfirmation: false
+})
+
 export const showNonGiftUrlSection = (props) => ({
 	shareType: ShareType.nonGift,
 	url: props.urls.nonGift,

--- a/components/x-gift-article/src/lib/updaters.js
+++ b/components/x-gift-article/src/lib/updaters.js
@@ -21,6 +21,7 @@ export const showGiftUrlSection = (props) => ({
 	url: props.urls.gift || props.urls.dummy,
 	urlType: props.urls.gift ? UrlType.gift : UrlType.dummy,
 	mailtoUrl: props.mailtoUrls.gift,
+	isGiftUrlCreated: !!props.urls.gift,
 	showCopyConfirmation: false
 })
 
@@ -29,6 +30,7 @@ export const showGiftEnterpriseSection = (props) => ({
 	url: props.urls.enterprise || props.urls.dummy,
 	urlType: props.urls.enterprise ? UrlType.gift : UrlType.dummy,
 	mailtoUrl: props.mailtoUrls.enterprise,
+	isGiftUrlCreated: !!props.urls.enterprise,
 	showCopyConfirmation: false
 })
 
@@ -37,29 +39,32 @@ export const showNonGiftUrlSection = (props) => ({
 	url: props.urls.nonGift,
 	urlType: UrlType.nonGift,
 	mailtoUrl: props.mailtoUrls.nonGift,
+	isGiftUrlCreated: false,
 	showCopyConfirmation: false
 })
 
-export const setGiftUrl = (url, redemptionLimit, isShortened) => (props) => {
-	const mailtoUrl = createMailtoUrl(props.article.title, url)
+export const setGiftUrl =
+	(url, redemptionLimit, isShortened, isEnterprise = false) =>
+	(props) => {
+		const mailtoUrl = createMailtoUrl(props.article.title, url)
 
-	return {
-		url,
-		mailtoUrl,
-		redemptionLimit,
-		isGiftUrlCreated: true,
-		isGiftUrlShortened: isShortened,
-		urlType: UrlType.gift,
+		return {
+			url,
+			mailtoUrl,
+			redemptionLimit: isEnterprise ? props.redemptionLimit : redemptionLimit, //note: when creating an enterprise link we do not change the redemption limit (this value is only used in the gift message)
+			isGiftUrlCreated: true,
+			isGiftUrlShortened: isShortened,
+			urlType: isEnterprise ? UrlType.enterprise : UrlType.gift,
 
-		urls: Object.assign(props.urls, {
-			gift: url
-		}),
+			urls: Object.assign(props.urls, {
+				[isEnterprise ? 'enterprise' : 'gift']: url
+			}),
 
-		mailtoUrls: Object.assign(props.mailtoUrls, {
-			gift: mailtoUrl
-		})
+			mailtoUrls: Object.assign(props.mailtoUrls, {
+				[isEnterprise ? 'enterprise' : 'gift']: mailtoUrl
+			})
+		}
 	}
-}
 
 export const setAllowance = (giftCredits, monthlyAllowance, nextRenewalDate) => {
 	const date = new Date(nextRenewalDate)
@@ -82,11 +87,11 @@ export const setShortenedNonGiftUrl = (shortenedUrl) => (props) => {
 		isNonGiftUrlShortened: true,
 
 		urls: Object.assign(props.urls, {
-			gift: shortenedUrl
+			nonGift: shortenedUrl
 		}),
 
 		mailtoUrls: Object.assign(props.mailtoUrls, {
-			gift: mailtoUrl
+			nonGift: mailtoUrl
 		})
 	}
 }

--- a/components/x-gift-article/src/lib/updaters.js
+++ b/components/x-gift-article/src/lib/updaters.js
@@ -22,7 +22,8 @@ export const showGiftUrlSection = (props) => ({
 	urlType: props.urls.gift ? UrlType.gift : UrlType.dummy,
 	mailtoUrl: props.mailtoUrls.gift,
 	isGiftUrlCreated: !!props.urls.gift,
-	showCopyConfirmation: false
+	showCopyConfirmation: false,
+	invalidResponseFromApi: false
 })
 
 export const showGiftEnterpriseSection = (props) => ({
@@ -31,7 +32,8 @@ export const showGiftEnterpriseSection = (props) => ({
 	urlType: props.urls.enterprise ? UrlType.gift : UrlType.dummy,
 	mailtoUrl: props.mailtoUrls.enterprise,
 	isGiftUrlCreated: !!props.urls.enterprise,
-	showCopyConfirmation: false
+	showCopyConfirmation: false,
+	invalidResponseFromApi: false
 })
 
 export const showNonGiftUrlSection = (props) => ({
@@ -40,7 +42,8 @@ export const showNonGiftUrlSection = (props) => ({
 	urlType: UrlType.nonGift,
 	mailtoUrl: props.mailtoUrls.nonGift,
 	isGiftUrlCreated: false,
-	showCopyConfirmation: false
+	showCopyConfirmation: false,
+	invalidResponseFromApi: false
 })
 
 export const setGiftUrl =
@@ -62,7 +65,8 @@ export const setGiftUrl =
 
 			mailtoUrls: Object.assign(props.mailtoUrls, {
 				[isEnterprise ? 'enterprise' : 'gift']: mailtoUrl
-			})
+			}),
+			invalidResponseFromApi: false
 		}
 	}
 
@@ -95,3 +99,7 @@ export const setShortenedNonGiftUrl = (shortenedUrl) => (props) => {
 		})
 	}
 }
+
+export const setErrorState = (errorState) => ({
+	invalidResponseFromApi: errorState
+})

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -132,6 +132,21 @@ export const WithEnterpriseSharingRequestAccess = (args) => {
 WithEnterpriseSharingRequestAccess.storyName = 'With enterprise sharing (request access)'
 WithEnterpriseSharingRequestAccess.args = require('./with-enterprise-request-access').args
 
+export const WithEnterpriseSharingLink = (args) => {
+	require('./with-enterprise-sharing-link').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<Helmet>
+				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
+			</Helmet>
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharingLink.storyName = 'With enterprise sharing (link generated)'
+WithEnterpriseSharingLink.args = require('./with-enterprise-sharing-link').args
+
 FreeArticle.storyName = 'Free article'
 FreeArticle.args = require('./free-article').args
 

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -87,6 +87,51 @@ export const FreeArticle = (args) => {
 	)
 }
 
+export const WithEnterpriseSharingWithoutCredits = (args) => {
+	require('./with-enterprise-no-credits').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<Helmet>
+				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
+			</Helmet>
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharingWithoutCredits.storyName = 'With enterprise sharing (no credits)'
+WithEnterpriseSharingWithoutCredits.args = require('./with-enterprise-no-credits').args
+
+export const WithEnterpriseSharingFirstTimeUser = (args) => {
+	require('./with-enterprise-first-time-user').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<Helmet>
+				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
+			</Helmet>
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharingFirstTimeUser.storyName = 'With enterprise sharing (first time user)'
+WithEnterpriseSharingFirstTimeUser.args = require('./with-enterprise-first-time-user').args
+
+export const WithEnterpriseSharingRequestAccess = (args) => {
+	require('./with-enterprise-request-access').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<Helmet>
+				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
+			</Helmet>
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharingRequestAccess.storyName = 'With enterprise sharing (request access)'
+WithEnterpriseSharingRequestAccess.args = require('./with-enterprise-request-access').args
+
 FreeArticle.storyName = 'Free article'
 FreeArticle.args = require('./free-article').args
 

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -27,21 +27,6 @@ export const WithGiftCredits = (args) => {
 WithGiftCredits.storyName = 'With gift credits'
 WithGiftCredits.args = require('./with-gift-credits').args
 
-export const WithEnterpriseSharing = (args) => {
-	require('./with-enterprise').fetchMock(fetchMock)
-	return (
-		<div className="story-container">
-			{dependencies && <BuildService dependencies={dependencies} />}
-			<Helmet>
-				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
-			</Helmet>
-			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-		</div>
-	)
-}
-WithEnterpriseSharing.storyName = 'With enterprise sharing'
-WithEnterpriseSharing.args = require('./with-enterprise').args
-
 export const WithoutGiftCredits = (args) => {
 	require('./without-gift-credits').fetchMock(fetchMock)
 	return (
@@ -86,6 +71,21 @@ export const FreeArticle = (args) => {
 		</div>
 	)
 }
+
+export const WithEnterpriseSharing = (args) => {
+	require('./with-enterprise').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<Helmet>
+				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
+			</Helmet>
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharing.storyName = 'With enterprise sharing'
+WithEnterpriseSharing.args = require('./with-enterprise').args
 
 export const WithEnterpriseSharingWithoutCredits = (args) => {
 	require('./with-enterprise-no-credits').fetchMock(fetchMock)

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -27,6 +27,21 @@ export const WithGiftCredits = (args) => {
 WithGiftCredits.storyName = 'With gift credits'
 WithGiftCredits.args = require('./with-gift-credits').args
 
+export const WithEnterpriseSharing = (args) => {
+	require('./with-enterprise').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<Helmet>
+				<link rel="stylesheet" href={`components/x-gift-article/dist/GiftArticle.css`} />
+			</Helmet>
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharing.storyName = 'With enterprise sharing'
+WithEnterpriseSharing.args = require('./with-enterprise').args
+
 export const WithoutGiftCredits = (args) => {
 	require('./without-gift-credits').fetchMock(fetchMock)
 	return (

--- a/components/x-gift-article/storybook/with-enterprise-first-time-user.js
+++ b/components/x-gift-article/storybook/with-enterprise-first-time-user.js
@@ -39,7 +39,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/v1/users/me/allowance`, {
 			limit: 120,
 			hasCredits: true,
 			firstTimeUser: true

--- a/components/x-gift-article/storybook/with-enterprise-first-time-user.js
+++ b/components/x-gift-article/storybook/with-enterprise-first-time-user.js
@@ -1,0 +1,47 @@
+const articleId = 'article id'
+const articleUrl = 'https://www.ft.com/content/blahblahblah'
+const articleUrlRedeemed = 'https://gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article (with enterprise sharing)',
+	isFreeArticle: false,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Title Title Title Title'
+	},
+	showMobileShareLinks: true,
+	id: 'base-gift-article-static-id'
+}
+
+// This reference is only required for hot module loading in development
+// <https://webpack.js.org/concepts/hot-module-replacement/>
+exports.m = module
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			remainingAllowance: 1
+		})
+		.get(`/allowance`, {
+			limit: 120,
+			hasCredits: true,
+			firstTimeUser: true,
+			enabled: true
+		})
+}

--- a/components/x-gift-article/storybook/with-enterprise-first-time-user.js
+++ b/components/x-gift-article/storybook/with-enterprise-first-time-user.js
@@ -42,7 +42,6 @@ exports.fetchMock = (fetchMock) => {
 		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
 			limit: 120,
 			hasCredits: true,
-			firstTimeUser: true,
-			enabled: true
+			firstTimeUser: true
 		})
 }

--- a/components/x-gift-article/storybook/with-enterprise-first-time-user.js
+++ b/components/x-gift-article/storybook/with-enterprise-first-time-user.js
@@ -12,7 +12,8 @@ exports.args = {
 		title: 'Title Title Title Title'
 	},
 	showMobileShareLinks: true,
-	id: 'base-gift-article-static-id'
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }
 
 // This reference is only required for hot module loading in development
@@ -38,7 +39,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
 			limit: 120,
 			hasCredits: true,
 			firstTimeUser: true,

--- a/components/x-gift-article/storybook/with-enterprise-first-time-user.js
+++ b/components/x-gift-article/storybook/with-enterprise-first-time-user.js
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article (with enterprise sharing)',
+	title: 'Share this article (with enterprise sharing - first time user journey)',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/with-enterprise-first-time-user.js
+++ b/components/x-gift-article/storybook/with-enterprise-first-time-user.js
@@ -39,7 +39,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
 			limit: 120,
 			hasCredits: true,
 			firstTimeUser: true,

--- a/components/x-gift-article/storybook/with-enterprise-no-credits.js
+++ b/components/x-gift-article/storybook/with-enterprise-no-credits.js
@@ -39,7 +39,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/v1/users/me/allowance`, {
 			limit: 120,
 			hasCredits: false,
 			firstTimeUser: false

--- a/components/x-gift-article/storybook/with-enterprise-no-credits.js
+++ b/components/x-gift-article/storybook/with-enterprise-no-credits.js
@@ -39,7 +39,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
 			limit: 120,
 			hasCredits: false,
 			firstTimeUser: false,

--- a/components/x-gift-article/storybook/with-enterprise-no-credits.js
+++ b/components/x-gift-article/storybook/with-enterprise-no-credits.js
@@ -42,7 +42,6 @@ exports.fetchMock = (fetchMock) => {
 		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
 			limit: 120,
 			hasCredits: false,
-			firstTimeUser: false,
-			enabled: true
+			firstTimeUser: false
 		})
 }

--- a/components/x-gift-article/storybook/with-enterprise-no-credits.js
+++ b/components/x-gift-article/storybook/with-enterprise-no-credits.js
@@ -1,0 +1,47 @@
+const articleId = 'article id'
+const articleUrl = 'https://www.ft.com/content/blahblahblah'
+const articleUrlRedeemed = 'https://gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article (Enterprise Sharing without credits)',
+	isFreeArticle: false,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Title Title Title Title'
+	},
+	showMobileShareLinks: true,
+	id: 'base-gift-article-static-id'
+}
+
+// This reference is only required for hot module loading in development
+// <https://webpack.js.org/concepts/hot-module-replacement/>
+exports.m = module
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			remainingAllowance: 1
+		})
+		.get(`/allowance`, {
+			limit: 120,
+			hasCredits: false,
+			firstTimeUser: false,
+			enabled: true
+		})
+}

--- a/components/x-gift-article/storybook/with-enterprise-no-credits.js
+++ b/components/x-gift-article/storybook/with-enterprise-no-credits.js
@@ -12,7 +12,8 @@ exports.args = {
 		title: 'Title Title Title Title'
 	},
 	showMobileShareLinks: true,
-	id: 'base-gift-article-static-id'
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }
 
 // This reference is only required for hot module loading in development
@@ -38,7 +39,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
 			limit: 120,
 			hasCredits: false,
 			firstTimeUser: false,

--- a/components/x-gift-article/storybook/with-enterprise-request-access.js
+++ b/components/x-gift-article/storybook/with-enterprise-request-access.js
@@ -39,5 +39,5 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, 403)
+		.get(`https://enterprise-sharing-api.ft.com/v1/users/me/allowance`, 403)
 }

--- a/components/x-gift-article/storybook/with-enterprise-request-access.js
+++ b/components/x-gift-article/storybook/with-enterprise-request-access.js
@@ -12,7 +12,8 @@ exports.args = {
 		title: 'Title Title Title Title'
 	},
 	showMobileShareLinks: true,
-	id: 'base-gift-article-static-id'
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }
 
 // This reference is only required for hot module loading in development
@@ -38,7 +39,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
 			limit: null,
 			hasCredits: false,
 			firstTimeUser: false,

--- a/components/x-gift-article/storybook/with-enterprise-request-access.js
+++ b/components/x-gift-article/storybook/with-enterprise-request-access.js
@@ -39,10 +39,5 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
-			limit: null,
-			hasCredits: false,
-			firstTimeUser: false,
-			enabled: true
-		})
+		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, 403)
 }

--- a/components/x-gift-article/storybook/with-enterprise-request-access.js
+++ b/components/x-gift-article/storybook/with-enterprise-request-access.js
@@ -1,0 +1,47 @@
+const articleId = 'article id'
+const articleUrl = 'https://www.ft.com/content/blahblahblah'
+const articleUrlRedeemed = 'https://gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article (with enterprise sharing)',
+	isFreeArticle: false,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Title Title Title Title'
+	},
+	showMobileShareLinks: true,
+	id: 'base-gift-article-static-id'
+}
+
+// This reference is only required for hot module loading in development
+// <https://webpack.js.org/concepts/hot-module-replacement/>
+exports.m = module
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			remainingAllowance: 1
+		})
+		.get(`/allowance`, {
+			limit: null,
+			hasCredits: false,
+			firstTimeUser: false,
+			enabled: true
+		})
+}

--- a/components/x-gift-article/storybook/with-enterprise-request-access.js
+++ b/components/x-gift-article/storybook/with-enterprise-request-access.js
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article (with enterprise sharing)',
+	title: 'Share this article (with enterprise sharing - request access journey)',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/with-enterprise-request-access.js
+++ b/components/x-gift-article/storybook/with-enterprise-request-access.js
@@ -39,7 +39,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
 			limit: null,
 			hasCredits: false,
 			firstTimeUser: false,

--- a/components/x-gift-article/storybook/with-enterprise-sharing-link.js
+++ b/components/x-gift-article/storybook/with-enterprise-sharing-link.js
@@ -41,7 +41,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
 			limit: 120,
 			hasCredits: true,
 			firstTimeUser: false,

--- a/components/x-gift-article/storybook/with-enterprise-sharing-link.js
+++ b/components/x-gift-article/storybook/with-enterprise-sharing-link.js
@@ -1,0 +1,48 @@
+const articleId = 'article id'
+const articleUrl = 'https://www.ft.com/content/blahblahblah'
+const articleUrlRedeemed = 'https://gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article (with enterprise sharing link)',
+	isFreeArticle: false,
+	isGiftUrlCreated: true,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Title Title Title Title'
+	},
+	showMobileShareLinks: true,
+	id: 'base-gift-article-static-id'
+}
+
+// This reference is only required for hot module loading in development
+// <https://webpack.js.org/concepts/hot-module-replacement/>
+exports.m = module
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			remainingAllowance: 1
+		})
+		.get(`/allowance`, {
+			limit: 120,
+			hasCredits: true,
+			firstTimeUser: false,
+			enabled: true
+		})
+}

--- a/components/x-gift-article/storybook/with-enterprise-sharing-link.js
+++ b/components/x-gift-article/storybook/with-enterprise-sharing-link.js
@@ -13,7 +13,8 @@ exports.args = {
 		title: 'Title Title Title Title'
 	},
 	showMobileShareLinks: true,
-	id: 'base-gift-article-static-id'
+	id: 'base-gift-article-static-id',
+	shareType: 'enterprise'
 }
 
 // This reference is only required for hot module loading in development

--- a/components/x-gift-article/storybook/with-enterprise-sharing-link.js
+++ b/components/x-gift-article/storybook/with-enterprise-sharing-link.js
@@ -41,7 +41,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/v1/users/me/allowance`, {
 			limit: 120,
 			hasCredits: true,
 			firstTimeUser: false

--- a/components/x-gift-article/storybook/with-enterprise-sharing-link.js
+++ b/components/x-gift-article/storybook/with-enterprise-sharing-link.js
@@ -44,7 +44,6 @@ exports.fetchMock = (fetchMock) => {
 		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
 			limit: 120,
 			hasCredits: true,
-			firstTimeUser: false,
-			enabled: true
+			firstTimeUser: false
 		})
 }

--- a/components/x-gift-article/storybook/with-enterprise-sharing-link.js
+++ b/components/x-gift-article/storybook/with-enterprise-sharing-link.js
@@ -14,6 +14,7 @@ exports.args = {
 	},
 	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
 	shareType: 'enterprise'
 }
 
@@ -40,7 +41,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
 			limit: 120,
 			hasCredits: true,
 			firstTimeUser: false,

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -39,13 +39,13 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
 			limit: 120,
 			hasCredits: true,
 			firstTimeUser: false,
 			enabled: true
 		})
-		.post(`https://enterprise-sharing-api.ft.com/`, {
+		.post(`https://enterprise-sharing-api.ft.com/v1/shares`, {
 			url: articleUrlRedeemed
 		})
 }

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -1,6 +1,6 @@
 const articleId = 'article id'
 const articleUrl = 'https://www.ft.com/content/blahblahblah'
-const articleUrlRedeemed = 'https://gift-url-redeemed'
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
@@ -43,5 +43,8 @@ exports.fetchMock = (fetchMock) => {
 			hasCredits: true,
 			firstTimeUser: false,
 			enabled: true
+		})
+		.post(`/`, {
+			url: articleUrlRedeemed
 		})
 }

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -40,6 +40,8 @@ exports.fetchMock = (fetchMock) => {
 		})
 		.get(`/allowance`, {
 			limit: 120,
-			hasCredits: true
+			hasCredits: true,
+			firstTimeUser: false,
+			enabled: true
 		})
 }

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -1,0 +1,45 @@
+const articleId = 'article id'
+const articleUrl = 'https://www.ft.com/content/blahblahblah'
+const articleUrlRedeemed = 'https://gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article (with enterprise sharing)',
+	isFreeArticle: false,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Title Title Title Title'
+	},
+	showMobileShareLinks: true,
+	id: 'base-gift-article-static-id'
+}
+
+// This reference is only required for hot module loading in development
+// <https://webpack.js.org/concepts/hot-module-replacement/>
+exports.m = module
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			remainingAllowance: 1
+		})
+		.get(`/allowance`, {
+			limit: 120,
+			hasCredits: true
+		})
+}

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -40,7 +40,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionLimit: 3,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/v1/users/me/allowance`, {
 			limit: 120,
 			hasCredits: true,
 			firstTimeUser: false

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -12,7 +12,8 @@ exports.args = {
 		title: 'Title Title Title Title'
 	},
 	showMobileShareLinks: true,
-	id: 'base-gift-article-static-id'
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }
 
 // This reference is only required for hot module loading in development
@@ -38,13 +39,13 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`/allowance`, {
+		.get(`https://enterprise-sharing-api.ft.com/allowance`, {
 			limit: 120,
 			hasCredits: true,
 			firstTimeUser: false,
 			enabled: true
 		})
-		.post(`/`, {
+		.post(`https://enterprise-sharing-api.ft.com/`, {
 			url: articleUrlRedeemed
 		})
 }

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -46,6 +46,7 @@ exports.fetchMock = (fetchMock) => {
 			enabled: true
 		})
 		.post(`https://enterprise-sharing-api.ft.com/v1/shares`, {
-			url: articleUrlRedeemed
+			url: articleUrlRedeemed,
+			redeemLimit: 120
 		})
 }

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -37,6 +37,7 @@ exports.fetchMock = (fetchMock) => {
 		})
 		.get(`/article/gift-link/${encodeURIComponent(articleId)}`, {
 			redemptionUrl: articleUrlRedeemed,
+			redemptionLimit: 3,
 			remainingAllowance: 1
 		})
 		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -43,8 +43,7 @@ exports.fetchMock = (fetchMock) => {
 		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, {
 			limit: 120,
 			hasCredits: true,
-			firstTimeUser: false,
-			enabled: true
+			firstTimeUser: false
 		})
 		.post(`https://enterprise-sharing-api.ft.com/v1/shares`, {
 			url: articleUrlRedeemed,

--- a/components/x-gift-article/storybook/with-gift-credits.js
+++ b/components/x-gift-article/storybook/with-gift-credits.js
@@ -12,7 +12,8 @@ exports.args = {
 		title: 'Title Title Title Title'
 	},
 	showMobileShareLinks: true,
-	id: 'base-gift-article-static-id'
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }
 
 // This reference is only required for hot module loading in development
@@ -38,4 +39,5 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
+		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, 404)
 }

--- a/components/x-gift-article/storybook/with-gift-credits.js
+++ b/components/x-gift-article/storybook/with-gift-credits.js
@@ -39,5 +39,5 @@ exports.fetchMock = (fetchMock) => {
 			redemptionUrl: articleUrlRedeemed,
 			remainingAllowance: 1
 		})
-		.get(`https://enterprise-sharing-api.ft.com/v1/allowance`, 404)
+		.get(`https://enterprise-sharing-api.ft.com/v1/users/me/allowance`, 404)
 }


### PR DESCRIPTION
This PR adds the enterprise sharing option to x-gift-article.

We are moving enterprise sharing from its own [micro-site](https://enterprise-sharing.ft.com/) to FT.com. This change has been discussed with the accounts team in advance.

## Summary of Changes

* x-gift article will make a request to the enterprise-sharing API and add an new option to the sharing modal if the user is a B2B user:
![image](https://user-images.githubusercontent.com/1255723/150339198-c579531a-5baa-4b9e-80bf-13aa3a280604.png)


* Users will be able to compare and choose the best sharing option for their use case.

* There is no breaking changes, If property `enterpriseApiBaseUrl` is not included or enterprise API request fails the modal will just work as usual, without the enterprise option.

I added 4 stories to the x-gift-article storybook, covering the main feature and some edge cases:

| Story | Use Case |
|-------|----------|
| With enterprise sharing | User has access to enterprise sharing, all interactions with ES API are mocked in the storybook |
| With enterprise sharing (no credits) | User has access but B2B licence has run out of credits, user can't use the feature but they will see a message to request more credits  |
| With enterprise sharing (first time user) | User has access to enterprise sharing but has never used the feature, they will see a message explaining its purpose |
| With enterprise sharing (request access) | User has a B2B licence without access to enterprise sharing, they will see a message explaining the feature and how to get access |
| With enterprise sharing (link generated) | An example of with the link generated |

** I also updated the story `With gift credits` to mock a `404` response from the Enterprise Sharing API. This is the default behaviour when a B2B user opens the link.

## How it works

* When opening the modal, a request to the enterprise sharing API will return if the user should see the enterprise option and some other properties like the number of shares allowed for their licence and if it is a first time user or not. Default values are set to not show the option if the API fails.
* The gift article component will make calls to different APIs based on the selected option (gift link or enterprise link)
* Enterprise and Gift links use different states, so the user can, in theory, create both links in the same session/view.
* Enterprise Link doesn't use the URL shortener service (we don't want to add a dependency to that and we are planning to implement something similar in our backend and return a shorter link by default)

## Tracking

Code changes include the broadcast of events when an enterprise link is created, based on the same payload for gift links but changing the `linkType` property.

## Testing

We created stories for all states, and the first one (`With enterprise sharing`) includes a mock for the response of our API when the user clicks on "create enterprise link". 