### PR TITLE
ADSDEV-963 insert custom slots only if related teaser position is found

### DIFF
--- a/components/x-teaser-timeline/__tests__/lib/transform.test.js
+++ b/components/x-teaser-timeline/__tests__/lib/transform.test.js
@@ -1,4 +1,4 @@
-import { buildModel } from '../../src/lib/transform'
+import { interleaveAllSlotsWithCustomSlots, buildModel } from '../../src/lib/transform'
 
 const items = [
 	{
@@ -372,5 +372,51 @@ describe('buildModel', () => {
 				}
 			])
 		})
+	})
+})
+
+describe('interleaveAllSlotsWithCustomSlots', () => {
+	test('inserts custom slots in group-article indexes', () => {
+		const customSlotContent = [{ foo: 1 }, { bar: 2 }]
+		const customSlotPosition = [0, 10]
+
+		const interleavedGroupedItems = interleaveAllSlotsWithCustomSlots(
+			customSlotContent,
+			customSlotPosition,
+			groupedItems,
+			items
+		)
+
+		expect(interleavedGroupedItems).toEqual([
+			{
+				...groupedItems[0],
+				items: [
+					{ foo: 1 },
+					groupedItems[0].items[0],
+					groupedItems[0].items[1],
+					groupedItems[0].items[2],
+					groupedItems[0].items[3]
+				]
+			},
+			groupedItems[1],
+			{
+				...groupedItems[2],
+				items: [...groupedItems[2].items, { bar: 2 }]
+			}
+		])
+	})
+
+	test('does not insert custom slots in out-of-bound group-article indexes', () => {
+		const customSlotContent = [{ foo: 1 }, { bar: 2 }]
+		const customSlotPosition = [-5, 15]
+
+		const interleavedGroupedItems = interleaveAllSlotsWithCustomSlots(
+			customSlotContent,
+			customSlotPosition,
+			groupedItems,
+			items
+		)
+
+		expect(groupedItems).toEqual(interleavedGroupedItems)
 	})
 })

--- a/components/x-teaser-timeline/package.json
+++ b/components/x-teaser-timeline/package.json
@@ -6,6 +6,7 @@
   "module": "dist/TeaserTimeline.esm.js",
   "browser": "dist/TeaserTimeline.es5.js",
   "style": "dist/TeaserTimeline.css",
+  "types": "typings/x-teaser-timeline.d.ts",
   "scripts": {
     "prepare": "bower install && npm run build",
     "build": "node rollup.js",

--- a/components/x-teaser-timeline/src/TeaserTimeline.jsx
+++ b/components/x-teaser-timeline/src/TeaserTimeline.jsx
@@ -6,6 +6,21 @@ import { getDateOnly } from './lib/date'
 import styles from './TeaserTimeline.scss'
 import classNames from 'classnames'
 
+/**
+ * @typedef {Object} Props
+ * @property {string} csrfToken
+ * @property {boolean} showSaveButtons
+ * @property {Array<Object> | Array<string> | Object | string} customSlotContent
+ * @property {Array<number> | number} customSlotPosition
+ * @property {Array<Item>} items
+ * @property {number} timezoneOffset
+ * @property {string} localTodayDate
+ * @property {string} latestItemsTime,
+ * @property {number} latestItemsAgeHours
+ *
+ * @param {Props} props
+ * @returns
+ */
 const TeaserTimeline = (props) => {
 	const now = new Date()
 	const {

--- a/components/x-teaser-timeline/src/lib/date.js
+++ b/components/x-teaser-timeline/src/lib/date.js
@@ -17,6 +17,11 @@ export const getLocalisedISODate = (isoDate, timezoneOffset) => {
 	return `${dateWithoutTimezone}${future ? '+' : '-'}${pad(hours)}:${pad(minutes)}`
 }
 
+/**
+ * @param {string} localDate
+ * @param {string} localTodayDate
+ * @returns {string}
+ */
 export const getTitleForItemGroup = (localDate, localTodayDate) => {
 	if (localDate === 'today-latest') {
 		return 'Latest News'
@@ -48,4 +53,8 @@ export const splitLatestEarlier = (items, splitDate) => {
 	return { latestItems, earlierItems }
 }
 
+/**
+ * @param {string} date
+ * @returns {string}
+ */
 export const getDateOnly = (date) => date.substr(0, 10)

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -1,21 +1,12 @@
-/**
- * @typedef {import("../../typings/x-teaser-timeline").Item} Item
- * @typedef {import("../../typings/x-teaser-timeline").GroupOfItems} GroupOfItems
- * @typedef {import("../../typings/x-teaser-timeline").ItemInGroup} ItemInGroup
- * @typedef {import("../../typings/x-teaser-timeline").PositionInGroup} PositionInGroup
- * @typedef {import("../../typings/x-teaser-timeline").CustomSlotContent} CustomSlotContent
- * @typedef {import("../../typings/x-teaser-timeline").CustomSlotPosition} CustomSlotPosition
- */
-
 import { getLocalisedISODate, getTitleForItemGroup, getDateOnly } from './date'
 
 /**
  * @param {number} indexOffset
  * @param {boolean} replaceLocalDate
  * @param {string} localTodayDateTime
- * @param {Item[]} items
+ * @param {import('../../typings/x-teaser-timeline').Item[]} items
  * @param {number} timezoneOffset
- * @returns {GroupOfItems[]}
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 const groupItemsByLocalisedDate = (
 	indexOffset,
@@ -46,9 +37,9 @@ const groupItemsByLocalisedDate = (
 }
 
 /**
- * @param {Item[]} items
+ * @param {import('../../typings/x-teaser-timeline').Item[]} items
  * @param {string} latestItemsTime
- * @returns {[ItemInGroup[], Item[]]>}
+ * @returns {[import('../../typings/x-teaser-timeline').ItemInGroup[], import('../../typings/x-teaser-timeline').Item[]]>}
  */
 const splitLatestItems = (items, latestItemsTime) => {
 	const latestNews = []
@@ -67,9 +58,9 @@ const splitLatestItems = (items, latestItemsTime) => {
 }
 
 /**
- * @param {GroupOfItems[]} itemGroups
+ * @param {import('../../typings/x-teaser-timeline').GroupOfItems[]} itemGroups
  * @param {string} localTodayDate
- * @returns {GroupOfItems[]}
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 const addItemGroupTitles = (itemGroups, localTodayDate) => {
 	return itemGroups.map((group) => {
@@ -127,12 +118,12 @@ const isLatestNewsSectionAllowed = (localTodayDate, latestItemsTime, latestItems
  * Will include a "Latest News" group if allowed by `latestItemsTime` and `latestItemsAgeRange`.
  *
  * @param {Object} props  An array of news articles.
- * @param {Item[]} props.items  An array of news articles.
+ * @param {import('../../typings/x-teaser-timeline').Item[]} props.items  An array of news articles.
  * @param {number} props.timezoneOffset  Minutes ahead (negative) or behind UTC
  * @param {string} props.localTodayDate  Today's date in client timezone. ISO Date string format.
  * @param {string} props.latestItemsTime  Cutoff time for items to be treated as "Latest News". ISO Date string format.
  * @param {number} props.latestItemsAgeHours  Maximum age allowed for items in "Latest News". Hours.
- * @returns {GroupOfItems[]} An array of group objects, each containing the group's title, date and items.
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]} An array of group objects, each containing the group's title, date and items.
  */
 const getItemGroups = ({
 	items,
@@ -192,9 +183,9 @@ const getItemGroups = ({
  * and the position 5 as arguments to the function,
  * then it would return `{ group: 1, index: 2 }`, which corresponds to item5
  * in the illustration above.
- * @param {GroupOfItems[]} groups
+ * @param {import('../../typings/x-teaser-timeline').GroupOfItems[]} groups
  * @param {number} position
- * @returns {PositionInGroup}
+ * @returns {import('../../typings/x-teaser-timeline').PositionInGroup}
  */
 const getGroupAndIndex = (groups, position) => {
 	if (position === 0) {
@@ -220,8 +211,8 @@ const getGroupAndIndex = (groups, position) => {
 
 /**
  * Creates a deep copy of an array of GroupOfItems data structure.
- * @param {GroupOfItems[]} groupedItems
- * @return {GroupOfItems[]}
+ * @param {import('../../typings/x-teaser-timeline').GroupOfItems[]} groupedItems
+ * @return {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 const deepCopyGroupedItems = (groupedItems) =>
 	Array.from(groupedItems, (v, k) => ({
@@ -233,11 +224,11 @@ const deepCopyGroupedItems = (groupedItems) =>
  * Inserts each custom slot into the appropriate group of items,
  * so that the custom slot will appear in the expected
  * position - specified via the positions array arg - in the teaser timeline.
- * @param {CustomSlotContent} customSlotContentArray
- * @param {CustomSlotPosition} customSlotPositionArray
- * @param {GroupOfItems[]} itemGroups
- * @param {Item[]} items
- * @returns {GroupOfItems[]}
+ * @param {import('../../typings/x-teaser-timeline').CustomSlotContent} customSlotContentArray
+ * @param {import('../../typings/x-teaser-timeline').CustomSlotPosition} customSlotPositionArray
+ * @param {import('../../typings/x-teaser-timeline').GroupOfItems[]} itemGroups
+ * @param {import('../../typings/x-teaser-timeline').Item[]} items
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 export const interleaveAllSlotsWithCustomSlots = (
 	customSlotContentArray,
@@ -266,14 +257,14 @@ export const interleaveAllSlotsWithCustomSlots = (
  * Custom slots - e.g., ads - are also inserted into their expected position.
  *
  * @param {Object} props
- * @param {Item[]} props.items
- * @param {CustomSlotContent} props.customSlotContent
- * @param {CustomSlotPosition} props.customSlotPosition
+ * @param {import('../../typings/x-teaser-timeline').Item[]} props.items
+ * @param {import('../../typings/x-teaser-timeline').CustomSlotContent} props.customSlotContent
+ * @param {import('../../typings/x-teaser-timeline').CustomSlotPosition} props.customSlotPosition
  * @param {number} props.timezoneOffset
  * @param {string} props.localTodayDate e.g., '2020-01-14'
  * @param {string} props.latestItemsTime e.g., '2020-01-13T10:00:00+00:00'
  * @param {number} props.latestItemsAgeHours e.g., 36
- * @returns {GroupOfItems[]}
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 export const buildModel = ({
 	items,

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -44,7 +44,7 @@ import { getLocalisedISODate, getTitleForItemGroup, getDateOnly } from './date'
  * @param {string} localTodayDateTime
  * @param {Array<Item>} items
  * @param {number} timezoneOffset
- * @returns {GroupOfItems}
+ * @returns {Array<GroupOfItems>}
  */
 const groupItemsByLocalisedDate = (
 	indexOffset,
@@ -96,9 +96,9 @@ const splitLatestItems = (items, latestItemsTime) => {
 }
 
 /**
- * @param {GroupOfItems} itemGroups
+ * @param {Array<GroupOfItems>} itemGroups
  * @param {string} localTodayDate
- * @returns {GroupOfItems}
+ * @returns {Array<GroupOfItems>}
  */
 const addItemGroupTitles = (itemGroups, localTodayDate) => {
 	return itemGroups.map((group) => {
@@ -197,9 +197,23 @@ const getItemGroups = ({
 }
 
 /**
- * Looks up for a article index that matches the provided position
- * and returns its group index and its item index withing the group.
- * @param {GroupOfItems} groups
+ * Looks up for an item that matches the position provided as arg,
+ * and returns its `coordinates` within the array of group of items:
+ * the group index and the item index
+ *
+ * e.g., given the array of group of items below
+ * ```
+ * Array<GroupOfItems> [
+ * 	{date, title, items: [item0, item1, item2]},				// <-- #0 group
+ * 	{date, title, items: [item3, item4, item5, item6, item7]},  // <-- #1 group
+ * 	{date, title, items: [item8, item9]},						// <-- #2 group
+ * ]
+ * ```
+ *
+ * and the position 5 as arguments to the function,
+ * then it would return `{ group: 1, index: 2 }`, which corresponds to item5
+ * in the illustration above.
+ * @param {Array<GroupOfItems>} groups
  * @param {number} position
  * @returns {PositionInGroup}
  */
@@ -226,9 +240,9 @@ const getGroupAndIndex = (groups, position) => {
 }
 
 /**
- * Creates a deep copy of a GroupOfItems data structure.
- * @param {GroupOfItems} groupedItems
- * @return {GroupOfItems}
+ * Creates a deep copy of an array of GroupOfItems data structure.
+ * @param {Array<GroupOfItems>} groupedItems
+ * @return {Array<GroupOfItems>}
  */
 const deepCopyGroupedItems = (groupedItems) =>
 	Array.from(groupedItems, (v, k) => ({
@@ -236,6 +250,16 @@ const deepCopyGroupedItems = (groupedItems) =>
 		items: [...groupedItems[k].items]
 	}))
 
+/**
+ * Inserts each custom slot into the appropriate group of items,
+ * so that the custom slot will appear in the expected
+ * position - specified via the positions array arg - in the teaser timeline.
+ * @param {CustomSlotContent} customSlotContentArray
+ * @param {CustomSlotPosition} customSlotPositionArray
+ * @param {Array<GroupOfItems>} itemGroups
+ * @param {Array<Items>} items
+ * @returns {Array<GroupOfItems>}
+ */
 export const interleaveAllSlotsWithCustomSlots = (
 	customSlotContentArray,
 	customSlotPositionArray,
@@ -266,8 +290,12 @@ export const interleaveAllSlotsWithCustomSlots = (
  * @property {string} latestItemsTime e.g., '2020-01-13T10:00:00+00:00'
  * @property {number} latestItemsAgeHours e.g., 36
  *
+ * Builds the XTeaserTimeline data model.
+ * The list of news items passed as argument is divided into groups of items,
+ * where each group identifies a specific date when the subset of news was published.
+ * Custom slots - e.g., ads - are also inserted into their expected position.
  * @param {buildModelProps}
- * @returns {GroupOfItems}
+ * @returns {Array<GroupOfItems>}
  */
 export const buildModel = ({
 	items,

--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -1,50 +1,21 @@
+/**
+ * @typedef {import("../../typings/x-teaser-timeline").Item} Item
+ * @typedef {import("../../typings/x-teaser-timeline").GroupOfItems} GroupOfItems
+ * @typedef {import("../../typings/x-teaser-timeline").ItemInGroup} ItemInGroup
+ * @typedef {import("../../typings/x-teaser-timeline").PositionInGroup} PositionInGroup
+ * @typedef {import("../../typings/x-teaser-timeline").CustomSlotContent} CustomSlotContent
+ * @typedef {import("../../typings/x-teaser-timeline").CustomSlotPosition} CustomSlotPosition
+ */
+
 import { getLocalisedISODate, getTitleForItemGroup, getDateOnly } from './date'
-
-/**
- * @typedef { Array<string> | Array<Object> | Object | string } CustomSlotContent
- * @typedef { Array<number> | number } CustomSlotPosition
- */
-
-/**
- * A news item (an article).
- * @typedef {Object} Item
- * @property {string} id e.g., '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4'
- * @property {string} title e.g.,'Europeans step up pressure on Iran over nuclear deal'
- * @property {string} publishedDate e.g., '2020-01-14T11:10:26.000Z'
- */
-
-/**
- * Extra props added to an item in groups.
- * @typedef {Object} ItemInGroupInfo
- * @property {number} articleIndex
- * @property {string} localisedLastUpdated e.g., '2020-01-14T11:10:26.000+00:00'
- */
-
-/** A news item (an article) in a group of items.
- * @typedef {(Item & ItemInGroupInfo)} ItemInGroup
- */
-
-/**
- * A list of news published on the same date.
- * @typedef {Object} GroupOfItems
- * @property {string} title e.g., 'Earlier Today'
- * @property {string} date e.g., '2020-01-14'
- * @property {Array<ItemInGroup>} items An array of news articles.
- */
-
-/**
- * @typedef {Object} PositionInGroup
- * @property {number} group
- * @property {number} index
- */
 
 /**
  * @param {number} indexOffset
  * @param {boolean} replaceLocalDate
  * @param {string} localTodayDateTime
- * @param {Array<Item>} items
+ * @param {Item[]} items
  * @param {number} timezoneOffset
- * @returns {Array<GroupOfItems>}
+ * @returns {GroupOfItems[]}
  */
 const groupItemsByLocalisedDate = (
 	indexOffset,
@@ -75,9 +46,9 @@ const groupItemsByLocalisedDate = (
 }
 
 /**
- * @param {Array<Item>} items
+ * @param {Item[]} items
  * @param {string} latestItemsTime
- * @returns {Array<Array<ItemInGroup>,Array<Item>>}
+ * @returns {[ItemInGroup[], Item[]]>}
  */
 const splitLatestItems = (items, latestItemsTime) => {
 	const latestNews = []
@@ -96,9 +67,9 @@ const splitLatestItems = (items, latestItemsTime) => {
 }
 
 /**
- * @param {Array<GroupOfItems>} itemGroups
+ * @param {GroupOfItems[]} itemGroups
  * @param {string} localTodayDate
- * @returns {Array<GroupOfItems>}
+ * @returns {GroupOfItems[]}
  */
 const addItemGroupTitles = (itemGroups, localTodayDate) => {
 	return itemGroups.map((group) => {
@@ -112,10 +83,17 @@ const addItemGroupTitles = (itemGroups, localTodayDate) => {
  * @param {string} time
  * @param {string} localTodayDate
  * @param {number} ageRangeHours
- * @returns {Date}
+ * @returns {boolean}
  */
-const isTimeWithinAgeRange = (time, localTodayDate, ageRangeHours) =>
-	time && new Date(localTodayDate) - new Date(time) < ageRangeHours * 60 * 60 * 1000
+const isTimeWithinAgeRange = (time, localTodayDate, ageRangeHours) => {
+	if (time) {
+		const timeStamp = new Date(time).getTime()
+		const localTime = new Date(localTodayDate).getTime()
+		return localTime - timeStamp < ageRangeHours * 60 * 60 * 1000
+	}
+
+	return false
+}
 
 /**
  * @param {string} time
@@ -148,12 +126,13 @@ const isLatestNewsSectionAllowed = (localTodayDate, latestItemsTime, latestItems
  * Gives the groups presentable titles, e.g. "Earlier Today", and "Yesterday".
  * Will include a "Latest News" group if allowed by `latestItemsTime` and `latestItemsAgeRange`.
  *
- * @param {Array<Item>} items  An array of news articles.
- * @param {number} timezoneOffset  Minutes ahead (negative) or behind UTC
- * @param {string} localTodayDate  Today's date in client timezone. ISO Date string format.
- * @param {string} latestItemsTime  Cutoff time for items to be treated as "Latest News". ISO Date string format.
- * @param {number} latestItemsAgeRange  Maximum age allowed for items in "Latest News". Hours.
- * @returns {Array<GroupOfItems>} An array of group objects, each containing the group's title, date and items.
+ * @param {Object} props  An array of news articles.
+ * @param {Item[]} props.items  An array of news articles.
+ * @param {number} props.timezoneOffset  Minutes ahead (negative) or behind UTC
+ * @param {string} props.localTodayDate  Today's date in client timezone. ISO Date string format.
+ * @param {string} props.latestItemsTime  Cutoff time for items to be treated as "Latest News". ISO Date string format.
+ * @param {number} props.latestItemsAgeHours  Maximum age allowed for items in "Latest News". Hours.
+ * @returns {GroupOfItems[]} An array of group objects, each containing the group's title, date and items.
  */
 const getItemGroups = ({
 	items,
@@ -213,7 +192,7 @@ const getItemGroups = ({
  * and the position 5 as arguments to the function,
  * then it would return `{ group: 1, index: 2 }`, which corresponds to item5
  * in the illustration above.
- * @param {Array<GroupOfItems>} groups
+ * @param {GroupOfItems[]} groups
  * @param {number} position
  * @returns {PositionInGroup}
  */
@@ -241,8 +220,8 @@ const getGroupAndIndex = (groups, position) => {
 
 /**
  * Creates a deep copy of an array of GroupOfItems data structure.
- * @param {Array<GroupOfItems>} groupedItems
- * @return {Array<GroupOfItems>}
+ * @param {GroupOfItems[]} groupedItems
+ * @return {GroupOfItems[]}
  */
 const deepCopyGroupedItems = (groupedItems) =>
 	Array.from(groupedItems, (v, k) => ({
@@ -256,9 +235,9 @@ const deepCopyGroupedItems = (groupedItems) =>
  * position - specified via the positions array arg - in the teaser timeline.
  * @param {CustomSlotContent} customSlotContentArray
  * @param {CustomSlotPosition} customSlotPositionArray
- * @param {Array<GroupOfItems>} itemGroups
- * @param {Array<Items>} items
- * @returns {Array<GroupOfItems>}
+ * @param {GroupOfItems[]} itemGroups
+ * @param {Item[]} items
+ * @returns {GroupOfItems[]}
  */
 export const interleaveAllSlotsWithCustomSlots = (
 	customSlotContentArray,
@@ -281,21 +260,20 @@ export const interleaveAllSlotsWithCustomSlots = (
 }
 
 /**
- * @typedef {Object} buildModelProps
- * @property {Array<Item>} items
- * @property {CustomSlotContent} customSlotContent
- * @property {CustomSlotPosition} customSlotPosition
- * @property {number} timezoneOffset
- * @property {string} localTodayDate e.g., '2020-01-14'
- * @property {string} latestItemsTime e.g., '2020-01-13T10:00:00+00:00'
- * @property {number} latestItemsAgeHours e.g., 36
- *
  * Builds the XTeaserTimeline data model.
  * The list of news items passed as argument is divided into groups of items,
  * where each group identifies a specific date when the subset of news was published.
  * Custom slots - e.g., ads - are also inserted into their expected position.
- * @param {buildModelProps}
- * @returns {Array<GroupOfItems>}
+ *
+ * @param {Object} props
+ * @param {Item[]} props.items
+ * @param {CustomSlotContent} props.customSlotContent
+ * @param {CustomSlotPosition} props.customSlotPosition
+ * @param {number} props.timezoneOffset
+ * @param {string} props.localTodayDate e.g., '2020-01-14'
+ * @param {string} props.latestItemsTime e.g., '2020-01-13T10:00:00+00:00'
+ * @param {number} props.latestItemsAgeHours e.g., 36
+ * @returns {GroupOfItems[]}
  */
 export const buildModel = ({
 	items,

--- a/components/x-teaser-timeline/typings/x-teaser-timeline.d.ts
+++ b/components/x-teaser-timeline/typings/x-teaser-timeline.d.ts
@@ -1,59 +1,29 @@
-/**
- * @typedef {  } CustomSlotContent
- * @typedef { Array<number> | number } CustomSlotPosition
- */
-
 export type CustomSlotContent = string[] | Object[] | Object | string
 export type CustomSlotPosition = number[] | number
 
 /**
- * A news item (an article).
- * @typedef {Object} Item
- * @property {string} id e.g., '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4'
- * @property {string} title e.g.,'Europeans step up pressure on Iran over nuclear deal'
- * @property {string} publishedDate e.g., '2020-01-14T11:10:26.000Z'
+ * A news item (i.e. an article)
  */
 export interface Item {
-  id: string
-  title: string
-  publishedDate: string
-  localisedLastUpdated: string
+  id: string // e.g. '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4'
+  title: string // e.g.,'Europeans step up pressure on Iran over nuclear deal'
+  publishedDate: string // ISO8601 date string
+  localisedLastUpdated: string // ISO8601 date string
 }
 
-/**
- * Extra props added to an item in groups.
- * @typedef {Object} ItemInGroupInfo
- * @property {number} articleIndex
- * @property {string} localisedLastUpdated e.g., '2020-01-14T11:10:26.000+00:00'
- */
 export interface ItemInGroupInfo {
   articleIndex: number
-  localisedLastUpdated: string
+  localisedLastUpdated: string // ISO8601 date string
 }
 
-/** A news item (an article) in a group of items.
- * @typedef {(Item & ItemInGroupInfo)} ItemInGroup
- */
 export interface ItemInGroup extends Item, ItemInGroupInfo {}
 
-/**
- * A list of news published on the same date.
- * @typedef {Object} GroupOfItems
- * @property {string} title e.g., 'Earlier Today'
- * @property {string} date e.g., '2020-01-14'
- * @property {Array<ItemInGroup>} items An array of news articles.
- */
 export interface GroupOfItems {
-  title?: string
-  date: string
-  items: ItemInGroup[]
+  title?: string // e.g. 'Earlier Today'
+  date: string // e.g. '2020-01-14'
+  items: ItemInGroup[] // An array of news articles
 }
 
-/**
- * @typedef {Object} PositionInGroup
- * @property {number} group
- * @property {number} index
- */
 export interface PositionInGroup {
   group: number
   index: number

--- a/components/x-teaser-timeline/typings/x-teaser-timeline.d.ts
+++ b/components/x-teaser-timeline/typings/x-teaser-timeline.d.ts
@@ -1,0 +1,60 @@
+/**
+ * @typedef {  } CustomSlotContent
+ * @typedef { Array<number> | number } CustomSlotPosition
+ */
+
+export type CustomSlotContent = string[] | Object[] | Object | string
+export type CustomSlotPosition = number[] | number
+
+/**
+ * A news item (an article).
+ * @typedef {Object} Item
+ * @property {string} id e.g., '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4'
+ * @property {string} title e.g.,'Europeans step up pressure on Iran over nuclear deal'
+ * @property {string} publishedDate e.g., '2020-01-14T11:10:26.000Z'
+ */
+export interface Item {
+  id: string
+  title: string
+  publishedDate: string
+  localisedLastUpdated: string
+}
+
+/**
+ * Extra props added to an item in groups.
+ * @typedef {Object} ItemInGroupInfo
+ * @property {number} articleIndex
+ * @property {string} localisedLastUpdated e.g., '2020-01-14T11:10:26.000+00:00'
+ */
+export interface ItemInGroupInfo {
+  articleIndex: number
+  localisedLastUpdated: string
+}
+
+/** A news item (an article) in a group of items.
+ * @typedef {(Item & ItemInGroupInfo)} ItemInGroup
+ */
+export interface ItemInGroup extends Item, ItemInGroupInfo {}
+
+/**
+ * A list of news published on the same date.
+ * @typedef {Object} GroupOfItems
+ * @property {string} title e.g., 'Earlier Today'
+ * @property {string} date e.g., '2020-01-14'
+ * @property {Array<ItemInGroup>} items An array of news articles.
+ */
+export interface GroupOfItems {
+  title?: string
+  date: string
+  items: ItemInGroup[]
+}
+
+/**
+ * @typedef {Object} PositionInGroup
+ * @property {number} group
+ * @property {number} index
+ */
+export interface PositionInGroup {
+  group: number
+  index: number
+}


### PR DESCRIPTION
[ADSDEV-963](https://financialtimes.atlassian.net/browse/ADSDEV-963)

A bug was reported where the X-Teaser-Timeline component attempts to insert ad slots even if the specified position is greater than the number of available teasers.

This PR improves the functionality for inserting the custom slots in between teasers in the teasers timeline, by making sure that the custom slot is inserted only when a suitable position is successfully identified.

### Description of the bug
This issue mainly impacted the FT App, and the FT App team added a temporary patch in the PR https://github.com/Financial-Times/ft-app/pull/1729

Below I replicated the error by passing a custom slot position value - 15 - greater than the length of the array of items - 10. The X-Teaser-Timeline should skip the insertion of the out-of-bound slot, while in this case it errors out.
```javascript
TypeError: Cannot read property 'items' of undefined

      136 | 	if (position > 0) {
      137 | 		const group = groups.findIndex((g) => g.items.some((item) => item.articleIndex === position - 1))
    > 138 | 		const index = groups[group].items.findIndex((item) => item.articleIndex === position - 1)
          | 		                            ^
      139 |
      140 | 		return {
      141 | 			group: group,

      at getGroupAndIndex (components/x-teaser-timeline/src/lib/transform.js:138:31)
      at interleaveAllSlotsWithCustomSlots (components/x-teaser-timeline/src/lib/transform.js:160:18)
      at buildModel (components/x-teaser-timeline/src/lib/transform.js:192:16)
      at Object.<anonymous> (components/x-teaser-timeline/__tests__/lib/transform.test.js:350:19)
```
Specifically, the `getGroupAndIndex()` function takes as arguments an array of group of items - each group is basically a list of news that happened on the same date - and it attempts to identify the correct group and article index, based on its linear position - ie., where the custom slot needs to appear within the teaser timeline whole list.
In this case an error happens because the `getGroupAndIndex()` functionality - which is responsible for adding the custom slot to the correct group of items - fails to identify that the provided position is out-of bounds - meaning that the position is either < 0 or >= total items length.

Although not strictly necessary, a deep copy of the grouped items data structure is created to avoid mutating the items in the groups list passed as argument to the `interleaveAllSlotsWithCustomSlots()` function. Creating a deep copy makes the function `interleaveAllSlotsWithCustomSlots()` more easily testable. Let me know what you think about deep copying the structure; if any concern arises I can remove it and change the unit tests accordingly.