### PR TITLE
Improve type comments

### DIFF
--- a/components/x-teaser-timeline/src/lib/transform.js
+++ b/components/x-teaser-timeline/src/lib/transform.js
@@ -1,21 +1,12 @@
-/**
- * @typedef {import("../../typings/x-teaser-timeline").Item} Item
- * @typedef {import("../../typings/x-teaser-timeline").GroupOfItems} GroupOfItems
- * @typedef {import("../../typings/x-teaser-timeline").ItemInGroup} ItemInGroup
- * @typedef {import("../../typings/x-teaser-timeline").PositionInGroup} PositionInGroup
- * @typedef {import("../../typings/x-teaser-timeline").CustomSlotContent} CustomSlotContent
- * @typedef {import("../../typings/x-teaser-timeline").CustomSlotPosition} CustomSlotPosition
- */
-
 import { getLocalisedISODate, getTitleForItemGroup, getDateOnly } from './date'
 
 /**
  * @param {number} indexOffset
  * @param {boolean} replaceLocalDate
  * @param {string} localTodayDateTime
- * @param {Item[]} items
+ * @param {import('../../typings/x-teaser-timeline').Item[]} items
  * @param {number} timezoneOffset
- * @returns {GroupOfItems[]}
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 const groupItemsByLocalisedDate = (
 	indexOffset,
@@ -46,9 +37,9 @@ const groupItemsByLocalisedDate = (
 }
 
 /**
- * @param {Item[]} items
+ * @param {import('../../typings/x-teaser-timeline').Item[]} items
  * @param {string} latestItemsTime
- * @returns {[ItemInGroup[], Item[]]>}
+ * @returns {[import('../../typings/x-teaser-timeline').ItemInGroup[], import('../../typings/x-teaser-timeline').Item[]]>}
  */
 const splitLatestItems = (items, latestItemsTime) => {
 	const latestNews = []
@@ -67,9 +58,9 @@ const splitLatestItems = (items, latestItemsTime) => {
 }
 
 /**
- * @param {GroupOfItems[]} itemGroups
+ * @param {import('../../typings/x-teaser-timeline').GroupOfItems[]} itemGroups
  * @param {string} localTodayDate
- * @returns {GroupOfItems[]}
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 const addItemGroupTitles = (itemGroups, localTodayDate) => {
 	return itemGroups.map((group) => {
@@ -127,12 +118,12 @@ const isLatestNewsSectionAllowed = (localTodayDate, latestItemsTime, latestItems
  * Will include a "Latest News" group if allowed by `latestItemsTime` and `latestItemsAgeRange`.
  *
  * @param {Object} props  An array of news articles.
- * @param {Item[]} props.items  An array of news articles.
+ * @param {import('../../typings/x-teaser-timeline').Item[]} props.items  An array of news articles.
  * @param {number} props.timezoneOffset  Minutes ahead (negative) or behind UTC
  * @param {string} props.localTodayDate  Today's date in client timezone. ISO Date string format.
  * @param {string} props.latestItemsTime  Cutoff time for items to be treated as "Latest News". ISO Date string format.
  * @param {number} props.latestItemsAgeHours  Maximum age allowed for items in "Latest News". Hours.
- * @returns {GroupOfItems[]} An array of group objects, each containing the group's title, date and items.
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]} An array of group objects, each containing the group's title, date and items.
  */
 const getItemGroups = ({
 	items,
@@ -192,9 +183,9 @@ const getItemGroups = ({
  * and the position 5 as arguments to the function,
  * then it would return `{ group: 1, index: 2 }`, which corresponds to item5
  * in the illustration above.
- * @param {GroupOfItems[]} groups
+ * @param {import('../../typings/x-teaser-timeline').GroupOfItems[]} groups
  * @param {number} position
- * @returns {PositionInGroup}
+ * @returns {import('../../typings/x-teaser-timeline').PositionInGroup}
  */
 const getGroupAndIndex = (groups, position) => {
 	if (position === 0) {
@@ -220,8 +211,8 @@ const getGroupAndIndex = (groups, position) => {
 
 /**
  * Creates a deep copy of an array of GroupOfItems data structure.
- * @param {GroupOfItems[]} groupedItems
- * @return {GroupOfItems[]}
+ * @param {import('../../typings/x-teaser-timeline').GroupOfItems[]} groupedItems
+ * @return {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 const deepCopyGroupedItems = (groupedItems) =>
 	Array.from(groupedItems, (v, k) => ({
@@ -233,11 +224,11 @@ const deepCopyGroupedItems = (groupedItems) =>
  * Inserts each custom slot into the appropriate group of items,
  * so that the custom slot will appear in the expected
  * position - specified via the positions array arg - in the teaser timeline.
- * @param {CustomSlotContent} customSlotContentArray
- * @param {CustomSlotPosition} customSlotPositionArray
- * @param {GroupOfItems[]} itemGroups
- * @param {Item[]} items
- * @returns {GroupOfItems[]}
+ * @param {import('../../typings/x-teaser-timeline').CustomSlotContent} customSlotContentArray
+ * @param {import('../../typings/x-teaser-timeline').CustomSlotPosition} customSlotPositionArray
+ * @param {import('../../typings/x-teaser-timeline').GroupOfItems[]} itemGroups
+ * @param {import('../../typings/x-teaser-timeline').Item[]} items
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 export const interleaveAllSlotsWithCustomSlots = (
 	customSlotContentArray,
@@ -266,14 +257,14 @@ export const interleaveAllSlotsWithCustomSlots = (
  * Custom slots - e.g., ads - are also inserted into their expected position.
  *
  * @param {Object} props
- * @param {Item[]} props.items
- * @param {CustomSlotContent} props.customSlotContent
- * @param {CustomSlotPosition} props.customSlotPosition
+ * @param {import('../../typings/x-teaser-timeline').Item[]} props.items
+ * @param {import('../../typings/x-teaser-timeline').CustomSlotContent} props.customSlotContent
+ * @param {import('../../typings/x-teaser-timeline').CustomSlotPosition} props.customSlotPosition
  * @param {number} props.timezoneOffset
  * @param {string} props.localTodayDate e.g., '2020-01-14'
  * @param {string} props.latestItemsTime e.g., '2020-01-13T10:00:00+00:00'
  * @param {number} props.latestItemsAgeHours e.g., 36
- * @returns {GroupOfItems[]}
+ * @returns {import('../../typings/x-teaser-timeline').GroupOfItems[]}
  */
 export const buildModel = ({
 	items,

--- a/components/x-teaser-timeline/typings/x-teaser-timeline.d.ts
+++ b/components/x-teaser-timeline/typings/x-teaser-timeline.d.ts
@@ -24,11 +24,6 @@ export interface GroupOfItems {
   items: ItemInGroup[] // An array of news articles
 }
 
-/**
- * @typedef {Object} PositionInGroup
- * @property {number} group
- * @property {number} index
- */
 export interface PositionInGroup {
   group: number
   index: number

--- a/components/x-teaser-timeline/typings/x-teaser-timeline.d.ts
+++ b/components/x-teaser-timeline/typings/x-teaser-timeline.d.ts
@@ -1,52 +1,27 @@
-/**
- * @typedef {  } CustomSlotContent
- * @typedef { Array<number> | number } CustomSlotPosition
- */
-
 export type CustomSlotContent = string[] | Object[] | Object | string
 export type CustomSlotPosition = number[] | number
 
 /**
- * A news item (an article).
- * @typedef {Object} Item
- * @property {string} id e.g., '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4'
- * @property {string} title e.g.,'Europeans step up pressure on Iran over nuclear deal'
- * @property {string} publishedDate e.g., '2020-01-14T11:10:26.000Z'
+ * A news item (i.e. an article)
  */
 export interface Item {
-  id: string
-  title: string
-  publishedDate: string
-  localisedLastUpdated: string
+  id: string // e.g. '01f0b004-36b9-11ea-a6d3-9a26f8c3cba4'
+  title: string // e.g.,'Europeans step up pressure on Iran over nuclear deal'
+  publishedDate: string // ISO8601 date string
+  localisedLastUpdated: string // ISO8601 date string
 }
 
-/**
- * Extra props added to an item in groups.
- * @typedef {Object} ItemInGroupInfo
- * @property {number} articleIndex
- * @property {string} localisedLastUpdated e.g., '2020-01-14T11:10:26.000+00:00'
- */
 export interface ItemInGroupInfo {
   articleIndex: number
-  localisedLastUpdated: string
+  localisedLastUpdated: string // ISO8601 date string
 }
 
-/** A news item (an article) in a group of items.
- * @typedef {(Item & ItemInGroupInfo)} ItemInGroup
- */
 export interface ItemInGroup extends Item, ItemInGroupInfo {}
 
-/**
- * A list of news published on the same date.
- * @typedef {Object} GroupOfItems
- * @property {string} title e.g., 'Earlier Today'
- * @property {string} date e.g., '2020-01-14'
- * @property {Array<ItemInGroup>} items An array of news articles.
- */
 export interface GroupOfItems {
-  title?: string
-  date: string
-  items: ItemInGroup[]
+  title?: string // e.g. 'Earlier Today'
+  date: string // e.g. '2020-01-14'
+  items: ItemInGroup[] // An array of news articles
 }
 
 /**


### PR DESCRIPTION
![Screenshot 2022-01-10 at 17 35 55](https://user-images.githubusercontent.com/21795/148812254-6a0c9a24-5b6a-41a2-b946-d6461fea2489.png)

JSDoc-style comments aren't reflected in type previews whereas inline comments are
