### PR TITLE
Fix x-topic-search font size bug

### DIFF
--- a/components/x-topic-search/src/TopicSearch.scss
+++ b/components/x-topic-search/src/TopicSearch.scss
@@ -93,7 +93,7 @@ $system-code:'github:Financial-Times/x-dash' !default;
 }
 
 .suggestion__name {
-	@include oTypographySans($scale: -2, $weight: 'semibold');
+	@include oTypographySans($scale: 0, $weight: 'semibold');
 	@include oEditorialTypographyTag($type: 'topic');
 	padding: 5px 0;
 	max-width: 50%;


### PR DESCRIPTION
The suggestion topic font size was accidentally changed by https://github.com/Financial-Times/x-dash/commit/e1908d6e17f2adbd7aad052e9aecbec7cbeeb8d1 (when `oTypographyTopic` was migrated to `oEditorialTypographyTag`).

` oTypographyTopic` sets [`oTypographySansBold($scale: 0);`](https://github.com/Financial-Times/o-typography/blob/9dacce1dd9f6256fcad21c1ffc36ce8cce47f936/src/scss/use-cases/_article.scss#L63) however `oEditorialTypographyTag` doesn’t.

Slack conversation about this bug
[with App team](https://financialtimes.slack.com/archives/CEA66G11T/p1643625873478199)
[with Origami team](https://financialtimes.slack.com/archives/C02FU5ARJ/p1643626463652129)

|Before|After|
|---|---|
|![Screenshot 2022-02-01 at 12 09 08](https://user-images.githubusercontent.com/21194161/151966186-d76c4c26-86cf-484b-97fc-4e10ce05b577.png)|![Screenshot 2022-02-01 at 12 06 21](https://user-images.githubusercontent.com/21194161/151966175-e808cb74-cb8f-4045-b838-ff8fb660b647.png)|