### PR TITLE
Update copy and error handling in enterprise sharing x gift article

### DIFF
--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -145,11 +145,22 @@ const withGiftFormActions = withActions(
 						const { giftCredits, monthlyAllowance, nextRenewalDate } = await api.getGiftArticleAllowance()
 						const { enabled, limit, hasCredits, firstTimeUser, requestAccess } =
 							await enterpriseApi.getEnterpriseArticleAllowance()
+						if (enabled) {
+							tracking.initEnterpriseSharing(
+								requestAccess
+									? 'enterprise-request-access'
+									: !hasCredits
+									? 'enterprise-no-credits'
+									: 'enterprise-enabled'
+							)
+						} else {
+							tracking.initEnterpriseSharing('enterprise-disabled')
+						}
 						// avoid to use giftCredits >= 0 because it returns true when null and ""
 						if (giftCredits > 0 || giftCredits === 0) {
 							return {
 								...updaters.setAllowance(giftCredits, monthlyAllowance, nextRenewalDate),
-								shareType: enabled ? ShareType.enterprise : ShareType.gift,
+								shareType: enabled && hasCredits ? ShareType.enterprise : ShareType.gift,
 								enterpriseEnabled: enabled,
 								enterpriseLimit: limit,
 								enterpriseHasCredits: hasCredits,

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -134,6 +134,7 @@ export default ({
 							href="https://enterprise.ft.com/ft-enterprise-sharing-request-access/?segmentId=c87259e0-7073-3ea8-7f83-b988f05c3f94"
 							target="_blank"
 							rel="noreferrer"
+							data-trackable="enterprise-request-access"
 							className={styles['buttonBaseStyle']}>
 							Learn more
 						</a>
@@ -151,6 +152,7 @@ export default ({
 						href="https://enterprise.ft.com/ft-enterprise-sharing-request-access/?segmentId=c87259e0-7073-3ea8-7f83-b988f05c3f94"
 						target="_blank"
 						rel="noreferrer"
+						data-trackable="enterprise-out-of-credits"
 						className={styles['buttonBaseStyle']}
 						type="button">
 						Request more credits

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -100,9 +100,7 @@ export default ({
 
 		if (isGiftUrlCreated === true) {
 			return (
-				<div className={messageClassName}>
-					This link can be opened by up to {enterpriseLimit} people and is valid for 90 days
-				</div>
+				<div className={messageClassName}>This link can be opened by up to {enterpriseLimit} people.</div>
 			)
 		}
 		if (enterpriseHasCredits === true) {

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -59,7 +59,7 @@ export default class EnterpriseApiClient {
 
 	/**
 	 * Retrieves the Enterprise Sharing allowance for an user
-	 * @returns {EnterpriseSharingAllowance} the Enterprise Sharing allowance for an user
+	 * @returns {Promise<EnterpriseSharingAllowance>} the Enterprise Sharing allowance for an user
 	 */
 	async getEnterpriseArticleAllowance() {
 		try {
@@ -84,7 +84,7 @@ export default class EnterpriseApiClient {
 	/**
 	 * Generates an enterprise sharing redeem link for the contentId
 	 * @param {string} contentId Article ID
-	 * @returns {{ redeemLimit: number, redemptionUrl: string }} object with enterprise sharing redeem link URL and limit
+	 * @returns {Promise<{ redeemLimit: number, redemptionUrl: string }>} object with enterprise sharing redeem link URL and limit
 	 */
 	async getESUrl(contentId) {
 		try {

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -27,7 +27,10 @@ export default class EnterpriseApiClient {
 		const url = this.getFetchUrl(path)
 		const options = Object.assign(
 			{
-				credentials: 'include'
+				credentials: 'include',
+				headers: {
+					'Content-Type': 'application/json'
+				}
 			},
 			additionalOptions
 		)
@@ -81,14 +84,18 @@ export default class EnterpriseApiClient {
 	/**
 	 * Generates an enterprise sharing redeem link for the contentId
 	 * @param {string} contentId Article ID
-	 * @returns {string} enterprise sharing redeem link URL
+	 * @returns {{ redeemLimit: number, redemptionUrl: string }} object with enterprise sharing redeem link URL and limit
 	 */
 	async getESUrl(contentId) {
-		const json = await this.fetchJson('/v1/shares', { method: 'POST', body: JSON.stringify({ contentId }) })
+		try {
+			const json = await this.fetchJson('/v1/shares', { method: 'POST', body: JSON.stringify({ contentId }) })
 
-		return {
-			redemptionUrl: json.url,
-			redemptionLimit: json.redeemLimit
+			return {
+				redemptionUrl: json.url,
+				redemptionLimit: json.redeemLimit
+			}
+		} catch (e) {
+			return { redemptionUrl: undefined, redemptionLimit: undefined }
 		}
 	}
 }

--- a/components/x-gift-article/src/lib/tracking.js
+++ b/components/x-gift-article/src/lib/tracking.js
@@ -25,6 +25,13 @@ module.exports = {
 			link
 		}),
 
+	initEnterpriseSharing: (status) =>
+		dispatchEvent({
+			category: 'gift-link',
+			action: 'open',
+			status
+		}),
+
 	copyLink: (linkType, link) =>
 		dispatchEvent({
 			category: 'gift-link',

--- a/components/x-gift-article/src/lib/tracking.js
+++ b/components/x-gift-article/src/lib/tracking.js
@@ -21,7 +21,7 @@ module.exports = {
 		dispatchEvent({
 			category: 'gift-link',
 			action: 'create',
-			linkType: 'enterpriseSharingLink',
+			linkType: 'enterpriseLink',
 			link
 		}),
 


### PR DESCRIPTION
This is a small PR with couple of minor fixes in enterprise sharing, including:

* Remove '90 days' from enterprise sharing confirmation message. This was a mistake in our prototype when the message was copied from the standard gift link. Enterprise sharing links do not expire at the moment da91c04643d5e9d56367c5b1c5f2d0963c997ef8
* Fix error message not appearing if create enterprise link fails due to wrong return value when request to create enterprise sharing link fails 55d345f7c24ebf3ed1ac35ee036864d5ebca3bc9
* Fix inconsistency in tracking and add few data-trackable values (suggested by analytics) b3fe9b69b83bf9290dc26937801ca17393399f4d
* Add tracking when initialising enterprise sharing for better estimation of conversion rates  (suggested by analytics) be5097089f6a92aff93de66bbff726f2e06da67f
* Fix some types declaration in async functions 6afa00022718345790e1fcb1a0e1803ab5cbbfce

There are no changes on how the feature works or any breaking change. I can be released as a patch.

