### PR TITLE
remove unused o-grid-dependency from teaser list

### DIFF
--- a/components/x-teaser-list/bower.json
+++ b/components/x-teaser-list/bower.json
@@ -3,7 +3,6 @@
   "private": true,
   "main": "dist/TeaserList.es5.js",
   "dependencies": {
-    "o-colors": "^5.4.1",
-    "o-grid": "^4.4.4"
+    "o-colors": "^5.4.1"
   }
 }


### PR DESCRIPTION
this was the only Origami component not on its latest Bower version; but, it's not actually using it, so,