### PR TITLE
HIVE-449.Fixed same-children issue with react components

### DIFF
--- a/components/x-teaser-timeline/src/TeaserTimeline.jsx
+++ b/components/x-teaser-timeline/src/TeaserTimeline.jsx
@@ -52,7 +52,7 @@ const TeaserTimeline = (props) => {
 					<section key={group.date} className={classNames(styles.itemGroup)}>
 						<h2 className={classNames(styles.itemGroup__heading)}>{group.title}</h2>
 						<ul className={classNames(styles.itemGroup__items)}>
-							{group.items.map((item) => {
+							{group.items.map((item, index) => {
 								if (item.id) {
 									return (
 										<li key={item.id} className={styles.item}>
@@ -71,10 +71,10 @@ const TeaserTimeline = (props) => {
 										</li>
 									)
 								} else if (typeof item === 'string') {
-									return <li key="custom-slot" dangerouslySetInnerHTML={{ __html: item }} />
+									return <li key={`custom-slot-${index}`} dangerouslySetInnerHTML={{ __html: item }} />
 								}
 
-								return <li key="custom-slot">{item}</li>
+								return <li key={`custom-slot-${index}`}>{item}</li>
 							})}
 						</ul>
 					</section>


### PR DESCRIPTION
### Description
Fix small issue during the implementation of [following  PR](https://github.com/Financial-Times/ft-app/pull/1818)
Discussion initiated [here](https://github.com/Financial-Times/ft-app/pull/1818#pullrequestreview-921927904) 
Discussion on Slack with [ft-apps team](https://financialtimes.slack.com/archives/C015X8R9V6Z/p1648560893151869)


If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
