### PR TITLE
Adds refer a friend feature to gift article

### DIFF
--- a/components/x-gift-article/readme.md
+++ b/components/x-gift-article/readme.md
@@ -78,6 +78,8 @@ Property                  | Type    | Required | Note
 `apiProtocol`             | String  | no       | The protocol to use when making requests to the gift article and URL shortening services. Ignored if `apiDomain` is not set.
 `apiDomain`               | String  | no       | The domain to use when making requests to the gift article and URL shortening services.
 `enterpriseApiBaseUrl`    | String  | no       | The base URL to use when making requests to the enterprise sharing service.
+`isRafActive`             | Boolean | no       | Determines whether to show the Refer a friend feature or not
+`raf`                     | Object  | no       | Refer a friend properties, can contain `title`, `description` and `url`
 
 ###
 `isArticleSharingUxUpdates` boolean has been added as part of ACC-749 to enable AB testing of the impact of minor UX improvements to x-gift-article. Once AB testing is done, and decision to keep / remove has been made, the changes made in https://github.com/Financial-Times/x-dash/pull/579 need to be ditched or baked in as default. 

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -4,6 +4,7 @@ import RadioButtonsSection from './RadioButtonsSection'
 import UrlSection from './UrlSection'
 import MobileShareButtons from './MobileShareButtons'
 import CopyConfirmation from './CopyConfirmation'
+import ReferAFriend from './ReferAFriend'
 
 export default (props) => (
 	<div className="x-gift-article">
@@ -35,6 +36,19 @@ export default (props) => (
 				hideCopyConfirmation={props.actions.hideCopyConfirmation}
 				isArticleSharingUxUpdates={props.isArticleSharingUxUpdates}
 			/>
+		)}
+
+		{props.isRafActive && (
+			<>
+				<ReferAFriend {...props} />
+
+				{props.showRafCopyConfirmation && (
+					<CopyConfirmation
+						hideCopyConfirmation={props.actions.hideRafCopyConfirmation}
+						isArticleSharingUxUpdates={props.isArticleSharingUxUpdates}
+					/>
+				)}
+			</>
 		)}
 
 		{props.showMobileShareLinks && <MobileShareButtons mobileShareLinks={props.mobileShareLinks} />}

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -129,6 +129,21 @@ const withGiftFormActions = withActions(
 				return { showCopyConfirmation: false }
 			},
 
+			copyRafUrl(event) {
+				copyToClipboard(event)
+
+				return (state) => {
+					const rafUrl = state.urls.raf
+					tracking.copyLink('rafLink', rafUrl)
+
+					return { showRafCopyConfirmation: true }
+				}
+			},
+
+			hideRafCopyConfirmation() {
+				return { showRafCopyConfirmation: false }
+			},
+
 			shareByNativeShare() {
 				throw new Error(`shareByNativeShare should be implemented by x-gift-article's consumers`)
 			},
@@ -193,8 +208,13 @@ const withGiftFormActions = withActions(
 			isGiftUrlShortened: false,
 			isNonGiftUrlShortened: false,
 			isArticleSharingUxUpdates: false,
+			rafTitle: props.raf?.title || 'Gift 2 months free access to the FT',
+			rafDescription:
+				props.raf?.description ||
+				"Instead of sharing this article, gift free full access. Share this link with your friend or colleague for them to get free access for 60 days. By sharing this link, you confirm that you have your friend's consent to do so.",
 
 			urls: {
+				raf: props.raf?.url || 'https://www.ft.com/join/licence/aa618a29-4699-4aca-ba3c-ce4d0b22e190/details',
 				dummy: 'https://on.ft.com/gift_link',
 				gift: undefined,
 				enterprise: undefined,

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -11,6 +11,7 @@
 @import 'Loading.scss';
 @import 'Message.scss';
 @import 'MobileShareButtons.scss';
+@import 'ReferAFriend.scss';
 
 .x-gift-article {
 	@include oTypographySans;

--- a/components/x-gift-article/src/ReferAFriend.jsx
+++ b/components/x-gift-article/src/ReferAFriend.jsx
@@ -1,0 +1,39 @@
+import { h } from '@financial-times/x-engine'
+import { UrlType } from './lib/constants'
+
+export default ({ rafTitle, rafDescription, urls, actions }) => {
+	return (
+		<>
+			<div className="x-gift-article--raf">
+				<h4>{rafTitle}</h4>
+				<p>{rafDescription}</p>
+				<div
+					className="js-gift-article__url-section x-gift-article__url-section"
+					data-section-id={UrlType.raf + 'Link'}
+					data-trackable={UrlType.raf + 'Link'}
+				>
+					<span className="o-forms-input o-forms-input--text">
+						<input
+							type="text"
+							name={UrlType.raf}
+							value={urls.raf}
+							className="x-gift-article__url-input"
+							readOnly
+							aria-label="Gift free subscription shareable link"
+						/>
+					</span>
+					<div className="x-gift-article__buttons">
+						<button
+							className="js-copy-link x-gift-article__button x-gift-article-button--gap"
+							type="button"
+							onClick={actions.copyRafUrl}
+							aria-label="Copy the free subscription link to your clipboard"
+						>
+							Copy link
+						</button>
+					</div>
+				</div>
+			</div>
+		</>
+	)
+}

--- a/components/x-gift-article/src/ReferAFriend.scss
+++ b/components/x-gift-article/src/ReferAFriend.scss
@@ -1,0 +1,40 @@
+@import '@financial-times/o-spacing/main';
+
+.x-gift-article--raf {
+	background: oColorsByName('white-60');
+	font-size: 16px;
+	margin-top: oSpacingByName('s4');
+	padding: oSpacingByName('s4');
+
+	h4 {
+		@include oTypographySans($scale: 0, $weight: 'semibold');
+		color: oColorsByName('black-90');
+		margin: 0;
+
+		&::before {
+			content: '';
+			display: inline-block;
+			margin-right: 1rem;
+			height: 28px;
+			width: 28px;
+			background-size: contain;
+			background-repeat: no-repeat;
+			background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1%3Agift?source=x-gift-article');
+		}
+	}
+
+	p {
+		margin: oSpacingByName('s2') 0px;
+	}
+
+	@include oForms(
+		$opts: (
+			'elements': (
+				'text'
+			),
+			'features': (
+				'inline'
+			)
+		)
+	);
+}

--- a/components/x-gift-article/src/lib/constants.js
+++ b/components/x-gift-article/src/lib/constants.js
@@ -5,6 +5,7 @@ export const ShareType = {
 }
 
 export const UrlType = {
+	raf: 'refer-a-friend-link',
 	dummy: 'example-gift-link',
 	gift: 'gift-link',
 	nonGift: 'non-gift-link'

--- a/components/x-gift-article/storybook/error-response.js
+++ b/components/x-gift-article/storybook/error-response.js
@@ -3,6 +3,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (unable to fetch credits)',
+	isRafActive: false,
 	isFreeArticle: false,
 	article: {
 		id: 'article id',

--- a/components/x-gift-article/storybook/free-article.js
+++ b/components/x-gift-article/storybook/free-article.js
@@ -3,7 +3,9 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (free)',
+	isRafActive: false,
 	isFreeArticle: true,
+	raf: { title: 'Custom title' },
 	article: {
 		title: 'Title Title Title Title',
 		id: 'base-gift-article-static-id',

--- a/components/x-gift-article/storybook/native-share.js
+++ b/components/x-gift-article/storybook/native-share.js
@@ -5,6 +5,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (on App)',
+	isRafActive: false,
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/with-enterprise-first-time-user.js
+++ b/components/x-gift-article/storybook/with-enterprise-first-time-user.js
@@ -5,6 +5,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (with enterprise sharing - first time user journey)',
+	isRafActive: false,
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/with-enterprise-no-credits.js
+++ b/components/x-gift-article/storybook/with-enterprise-no-credits.js
@@ -5,6 +5,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (Enterprise Sharing without credits)',
+	isRafActive: false,
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/with-enterprise-request-access.js
+++ b/components/x-gift-article/storybook/with-enterprise-request-access.js
@@ -5,6 +5,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (with enterprise sharing - request access journey)',
+	isRafActive: false,
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/with-enterprise-sharing-link.js
+++ b/components/x-gift-article/storybook/with-enterprise-sharing-link.js
@@ -5,6 +5,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (with enterprise sharing link)',
+	isRafActive: false,
 	isFreeArticle: false,
 	isGiftUrlCreated: true,
 	article: {

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -5,6 +5,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (with enterprise sharing)',
+	isRafActive: false,
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/with-gift-credits.js
+++ b/components/x-gift-article/storybook/with-gift-credits.js
@@ -5,6 +5,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (with credit)',
+	isRafActive: false,
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/with-gift-link.js
+++ b/components/x-gift-article/storybook/with-gift-link.js
@@ -4,6 +4,7 @@ const articleUrlRedeemed = 'https://gift-url-redeemed'
 
 exports.args = {
 	title: 'Share this article (with gift link)',
+	isRafActive: false,
 	isFreeArticle: false,
 	isGiftUrlCreated: true,
 	redemptionLimit: 3,

--- a/components/x-gift-article/storybook/without-gift-credits.js
+++ b/components/x-gift-article/storybook/without-gift-credits.js
@@ -3,6 +3,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article (without credit)',
+	isRafActive: false,
 	isFreeArticle: false,
 	article: {
 		id: 'article id',


### PR DESCRIPTION
### Description
This PR adds an additional section to the gift article component.
The section is an optional Refer a Friend feature with a title, description and copyable url.
The intention is to run it as an AB test on `next-article`. 
I've tried keeping the code as isolated as possible, so it can be removed or improved (dynamic urls) later, while also seemingly integrating it with the existing code.

### Ticket
https://financialtimes.atlassian.net/browse/RS-17

### Design
https://www.figma.com/file/YUc6OErd2vMIQocCrt8n0t/Refer-a-friend-(RAF)?node-id=37%3A514

### Screenshot
![Screenshot 2022-07-21 at 14 12 07](https://user-images.githubusercontent.com/1725956/180211812-85989afa-bf66-4390-83e8-46f63763a342.png)

