### PR TITLE
Fix gift-article not supported fragments

### DIFF
--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -39,7 +39,7 @@ export default (props) => (
 		)}
 
 		{props.isRafActive && (
-			<>
+			<div>
 				<ReferAFriend {...props} />
 
 				{props.showRafCopyConfirmation && (
@@ -48,7 +48,7 @@ export default (props) => (
 						isArticleSharingUxUpdates={props.isArticleSharingUxUpdates}
 					/>
 				)}
-			</>
+			</div>
 		)}
 
 		{props.showMobileShareLinks && <MobileShareButtons mobileShareLinks={props.mobileShareLinks} />}

--- a/components/x-gift-article/src/ReferAFriend.jsx
+++ b/components/x-gift-article/src/ReferAFriend.jsx
@@ -3,37 +3,35 @@ import { UrlType } from './lib/constants'
 
 export default ({ rafTitle, rafDescription, urls, actions }) => {
 	return (
-		<>
-			<div className="x-gift-article--raf">
-				<h4>{rafTitle}</h4>
-				<p>{rafDescription}</p>
-				<div
-					className="js-gift-article__url-section x-gift-article__url-section"
-					data-section-id={UrlType.raf + 'Link'}
-					data-trackable={UrlType.raf + 'Link'}
-				>
-					<span className="o-forms-input o-forms-input--text">
-						<input
-							type="text"
-							name={UrlType.raf}
-							value={urls.raf}
-							className="x-gift-article__url-input"
-							readOnly
-							aria-label="Gift free subscription shareable link"
-						/>
-					</span>
-					<div className="x-gift-article__buttons">
-						<button
-							className="js-copy-link x-gift-article__button x-gift-article-button--gap"
-							type="button"
-							onClick={actions.copyRafUrl}
-							aria-label="Copy the free subscription link to your clipboard"
-						>
-							Copy link
-						</button>
-					</div>
+		<div className="x-gift-article--raf">
+			<h4>{rafTitle}</h4>
+			<p>{rafDescription}</p>
+			<div
+				className="js-gift-article__url-section x-gift-article__url-section"
+				data-section-id={UrlType.raf + 'Link'}
+				data-trackable={UrlType.raf + 'Link'}
+			>
+				<span className="o-forms-input o-forms-input--text">
+					<input
+						type="text"
+						name={UrlType.raf}
+						value={urls.raf}
+						className="x-gift-article__url-input"
+						readOnly
+						aria-label="Gift free subscription shareable link"
+					/>
+				</span>
+				<div className="x-gift-article__buttons">
+					<button
+						className="js-copy-link x-gift-article__button x-gift-article-button--gap"
+						type="button"
+						onClick={actions.copyRafUrl}
+						aria-label="Copy the free subscription link to your clipboard"
+					>
+						Copy link
+					</button>
 				</div>
 			</div>
-		</>
+		</div>
 	)
 }


### PR DESCRIPTION
### Description

Removes the usage of `<></>` as it works on storybook by creating React.Fragment but it breaks on other apps that don't use react. 