### PR TITLE
Allow anonymous users to set a consent preference without needing to

### DIFF
--- a/components/x-privacy-manager/src/__tests__/helpers.js
+++ b/components/x-privacy-manager/src/__tests__/helpers.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../../typings/x-privacy-manager').BasePrivacyManagerProps} BasePrivacyManagerProps
+ */
+
 const React = require('react')
 
 // eslint-disable-next-line no-unused-vars
@@ -10,7 +14,6 @@ export const CONSENT_PROXY_HOST = 'https://consent.ft.com'
 export const CONSENT_PROXY_ENDPOINT = 'https://consent.ft.com/__consent/consent-record/FTPINK/abcde'
 
 /**
- *
  * @param {{
  *   setConsentCookie: boolean,
  *   consent: boolean
@@ -18,41 +21,28 @@ export const CONSENT_PROXY_ENDPOINT = 'https://consent.ft.com/__consent/consent-
  * @returns
  */
 export const buildPayload = ({ setConsentCookie, consent }) => {
+	const categoryPayload = {
+		onsite: {
+			fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
+			lbi: true,
+			source: 'consuming-app',
+			status: consent
+		}
+	}
 	return {
 		setConsentCookie,
 		consentSource: 'consuming-app',
 		data: {
-			behaviouralAds: {
-				onsite: {
-					fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
-					lbi: true,
-					source: 'consuming-app',
-					status: consent
-				}
-			},
-			demographicAds: {
-				onsite: {
-					fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
-					lbi: true,
-					source: 'consuming-app',
-					status: consent
-				}
-			},
-			programmaticAds: {
-				onsite: {
-					fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
-					lbi: true,
-					source: 'consuming-app',
-					status: consent
-				}
-			}
+			behaviouralAds: categoryPayload,
+			demographicAds: categoryPayload,
+			programmaticAds: categoryPayload
 		},
 		cookieDomain: '.ft.com',
 		formOfWordsId: 'privacyCCPA'
 	}
 }
 
-/** @type {XPrivacyManager.BasePrivacyManagerProps} */
+/** @type {BasePrivacyManagerProps} */
 export const defaultProps = {
 	userId: 'abcde',
 	legislationId: 'ccpa',
@@ -75,11 +65,11 @@ export const defaultProps = {
  * - Handlers for submit events
  * - Post-submission callbacks
  *
- * @param {Partial<XPrivacyManager.BasePrivacyManagerProps>} propOverrides
+ * @param {Partial<BasePrivacyManagerProps>} propOverrides
  *
  * @returns {{
  *   subject: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
- *   callbacks: XPrivacyManager.OnSaveCallback[] | jest.Mock<any, any>[];
+ *   callbacks: OnSaveCallback[] | jest.Mock<any, any>[];
  *   submitConsent(value: boolean): Promise<void>;
  * }}
  */

--- a/components/x-privacy-manager/src/__tests__/state.test.jsx
+++ b/components/x-privacy-manager/src/__tests__/state.test.jsx
@@ -39,9 +39,9 @@ describe('x-privacy-manager', () => {
 			expect(callbacks[0]).toHaveBeenCalledWith(null, { payload: expectedPayload, consent: true })
 			expect(callbacks[1]).toHaveBeenCalledWith(null, { payload: expectedPayload, consent: true })
 
-			// Verify that confimatory nmessage is displayed
-			const message = subject.find('[data-o-component="o-message"]').first()
-			const link = message.find('[data-component="redirect-link"]')
+			// Verify that confimatory message is displayed
+			const message = await subject.find('[data-o-component="o-message"]').first()
+			const link = await message.find('[data-component="redirect-link"]')
 			expect(message).toHaveClassName('o-message--success')
 			expect(link).toHaveProp('href', '/')
 			expect(optInInput).toHaveProp('checked', true)

--- a/components/x-privacy-manager/src/__tests__/utils.test.js
+++ b/components/x-privacy-manager/src/__tests__/utils.test.js
@@ -1,4 +1,40 @@
-const { getTrackingKeys, getConsentProxyEndpoints } = require('../utils')
+const { getTrackingKeys, getConsentProxyEndpoints, getPayload, onConsentSavedFn } = require('../utils')
+
+const fixtures = {
+	fow: { id: 'xxxx', version: 1 },
+	consentSource: 'test-source',
+	getCategoryPayload(status) {
+		return {
+			onsite: {
+				lbi: true,
+				status,
+				source: fixtures.consentSource,
+				fow: `${fixtures.fow.id}/${fixtures.fow.version}`
+			}
+		}
+	}
+}
+
+function getExpectedPayload({ consent }) {
+	const input = {
+		consent,
+		consentSource: fixtures.consentSource,
+		fow: fixtures.fow,
+		setConsentCookie: true
+	}
+
+	const expectedCategoryPayload = fixtures.getCategoryPayload(input.consent)
+	return {
+		setConsentCookie: input.setConsentCookie,
+		formOfWordsId: fixtures.fow.id,
+		consentSource: fixtures.consentSource,
+		data: {
+			behaviouralAds: expectedCategoryPayload,
+			demographicAds: expectedCategoryPayload,
+			programmaticAds: expectedCategoryPayload
+		}
+	}
+}
 
 describe('getTrackingKeys', () => {
 	it('Creates legislation-specific tracking event names', () => {
@@ -43,6 +79,55 @@ describe('getConsentProxyEndpoints', () => {
 			core: defaultEndpoint,
 			enhanced: defaultEndpoint,
 			createOrUpdateRecord: defaultEndpoint
+		})
+	})
+
+	it('generates a payload', () => {
+		const input = {
+			fow: fixtures.fow,
+			consentSource: fixtures.consentSource,
+			consent: true,
+			setConsentCookie: false
+		}
+
+		const expectedCategoryPayload = fixtures.getCategoryPayload(input.consent)
+
+		const expected = {
+			setConsentCookie: input.setConsentCookie,
+			formOfWordsId: fixtures.fow.id,
+			consentSource: fixtures.consentSource,
+			data: {
+				behaviouralAds: expectedCategoryPayload,
+				demographicAds: expectedCategoryPayload,
+				programmaticAds: expectedCategoryPayload
+			}
+		}
+
+		expect(getPayload(input)).toEqual(expected)
+	})
+
+	describe('Runs callbacks with user input', () => {
+		test.each([
+			['{ payload: null }', { consent: false, payload: null }],
+			['{ consent: true }', { consent: true, payload: getExpectedPayload({ consent: true }) }],
+			['{ consent: false }', { consent: false, payload: getExpectedPayload({ consent: false }) }],
+			[
+				"{ err: 'error', ok: false }",
+				{ consent: true, err: 'error', ok: false, payload: getExpectedPayload({ consent: true }) }
+			]
+		])('onConsentSaved(%s)', (_label, input) => {
+			const fnA = jest.fn()
+			const fnB = jest.fn()
+			const fnC = jest.fn()
+			const onConsentSaved = onConsentSavedFn([fnA, fnB, fnC])
+
+			const { consent, payload, err = null, ok = true } = input
+			const { _response } = onConsentSaved(input)
+
+			expect(fnA).toHaveBeenCalledWith(err, { consent, payload })
+			expect(fnB).toHaveBeenCalledWith(err, { consent, payload })
+			expect(fnC).toHaveBeenCalledWith(err, { consent, payload })
+			expect(_response).toEqual({ ok })
 		})
 	})
 })

--- a/components/x-privacy-manager/src/privacy-manager.jsx
+++ b/components/x-privacy-manager/src/privacy-manager.jsx
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import('../typings/x-privacy-manager').BasePrivacyManagerProps} BasePrivacyManagerProps
+ * @typedef {import('../typings/x-privacy-manager').FormProps} FormProps
+ */
+
 import { h } from '@financial-times/x-engine'
 
 import { renderLoggedOutWarning, renderMessage } from './components/messages'
@@ -13,7 +18,7 @@ const defaultButtonText = {
 }
 
 /**
- * @param {XPrivacyManager.BasePrivacyManagerProps} Props
+ * @param {BasePrivacyManagerProps} Props
  */
 export function BasePrivacyManager({
 	userId,
@@ -58,7 +63,9 @@ export function BasePrivacyManager({
 		onChange: onConsentChange
 	})
 
-	/** @type {XPrivacyManager.FormProps} */
+	const onConsentSaved = utils.onConsentSavedFn(onConsentSavedCallbacks)
+
+	/** @type {FormProps} */
 	const formProps = {
 		consent,
 		consentApiUrl,
@@ -68,7 +75,7 @@ export function BasePrivacyManager({
 			return sendConsent({
 				setConsentCookie: legislationId === 'gdpr',
 				consentApiUrl,
-				onConsentSavedCallbacks,
+				onConsentSaved,
 				consentSource,
 				cookieDomain,
 				fow

--- a/components/x-privacy-manager/typings/x-privacy-manager.d.ts
+++ b/components/x-privacy-manager/typings/x-privacy-manager.d.ts
@@ -1,14 +1,10 @@
 import * as React from 'react'
+import { trackingKeys } from '../src/utils'
 
 export type ConsentProxyEndpoint = Record<'core' | 'enhanced' | 'createOrUpdateRecord', string>
 export type ConsentProxyEndpoints = Partial<{ [key in keyof ConsentProxyEndpoint]: string }>
 
-export type TrackingKey =
-  | 'advertising-toggle-allow'
-  | 'advertising-toggle-block'
-  | 'consent-allow'
-  | 'consent-block'
-
+export type TrackingKey = typeof trackingKeys[number]
 export type TrackingKeys = Record<TrackingKey, string>
 
 export interface CategoryPayload {
@@ -29,16 +25,33 @@ interface ConsentPayload {
   data: ConsentData
 }
 
-export type OnSaveCallback = (err: null | Error, data: { consent: boolean; payload: ConsentPayload }) => void
+export type ConsentSavedCallback = (
+  err: Error | null,
+  data: { consent: boolean; payload: ConsentPayload | null }
+) => void
+
+export interface ConsentSavedProps {
+  consent: boolean
+  payload: ConsentPayload | null
+  err: Error | null
+  ok: boolean
+}
 
 export interface SendConsentProps {
-  setConsentCookie: boolean
   consentApiUrl: string
-  onConsentSavedCallbacks: OnSaveCallback[]
   consentSource: string
   cookieDomain: string
   fow: FoWConfig
+  setConsentCookie: boolean
+  onConsentSaved: (props: ConsentSavedProps) => _Response
 }
+
+interface ConsentResponseProps {
+  isLoading: boolean
+  consent: boolean
+}
+
+export type SendConsentResponse = (props: ConsentResponseProps) => Promise<{ _response: _Response }>
 
 export interface _Response {
   ok: boolean
@@ -95,7 +108,3 @@ export interface FormProps {
   buttonText: ButtonText
   children: React.ReactElement
 }
-
-export { PrivacyManager } from '../src/privacy-manager'
-
-export as namespace XPrivacyManager


### PR DESCRIPTION
access the Consent API

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
