### PR TITLE
fix aria-label text to have entirely the text of the button within th…

### DIFF
--- a/components/x-gift-article/src/Buttons.jsx
+++ b/components/x-gift-article/src/Buttons.jsx
@@ -38,7 +38,7 @@ export default ({
 								? actions.copyEnterpriseUrl
 								: actions.copyNonGiftUrl
 						}
-						aria-label="Copy the gift article link to your clipboard"
+						aria-label="Copy link of the gift article to your clipboard"
 					>
 						Copy link
 					</button>

--- a/components/x-gift-article/src/ReferAFriend.jsx
+++ b/components/x-gift-article/src/ReferAFriend.jsx
@@ -26,7 +26,7 @@ export default ({ rafTitle, rafDescription, urls, actions }) => {
 						className="js-copy-link x-gift-article__button x-gift-article-button--gap"
 						type="button"
 						onClick={actions.copyRafUrl}
-						aria-label="Copy the free subscription link to your clipboard"
+						aria-label="Copy link of the free subscription to your clipboard"
 					>
 						Copy link
 					</button>


### PR DESCRIPTION
Fix accesible label on gift buttons to contain entirely the text of the button within without split it or break words.
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1316?modal=detail&selectedIssue=CI-1365)
