### PR TITLE
[CI-1368] fix accessibility errors

### DIFF
--- a/components/x-gift-article/src/Buttons.scss
+++ b/components/x-gift-article/src/Buttons.scss
@@ -14,6 +14,8 @@
 	text-align: left;
 	white-space: nowrap;
 	margin-top: 12px;
+	display: flex;
+	align-items: end;
 }
 
 .x-gift-article-button--gap {

--- a/components/x-gift-article/src/ReferAFriend.jsx
+++ b/components/x-gift-article/src/ReferAFriend.jsx
@@ -12,7 +12,9 @@ export default ({ rafTitle, rafDescription, urls, actions }) => {
 				data-trackable={UrlType.raf + 'Link'}
 			>
 				<span className="o-forms-input o-forms-input--text">
-					<label for="refer-friend-link">{rafTitle}</label>
+					<label className="x-gift-article__label-link" htmlFor="refer-friend-link">
+						Gift 2 month free access link
+					</label>
 					<input
 						id="refer-friend-link"
 						type="text"

--- a/components/x-gift-article/src/ReferAFriend.jsx
+++ b/components/x-gift-article/src/ReferAFriend.jsx
@@ -12,13 +12,14 @@ export default ({ rafTitle, rafDescription, urls, actions }) => {
 				data-trackable={UrlType.raf + 'Link'}
 			>
 				<span className="o-forms-input o-forms-input--text">
+					<label for="refer-friend-link">{rafTitle}</label>
 					<input
+						id="refer-friend-link"
 						type="text"
 						name={UrlType.raf}
 						value={urls.raf}
 						className="x-gift-article__url-input"
 						readOnly
-						aria-label={rafTitle}
 					/>
 				</span>
 				<div className="x-gift-article__buttons">

--- a/components/x-gift-article/src/Url.jsx
+++ b/components/x-gift-article/src/Url.jsx
@@ -4,14 +4,15 @@ import { ShareType } from './lib/constants'
 export default ({ shareType, isGiftUrlCreated, url, urlType, ariaLabel }) => {
 	return (
 		<span className="o-forms-input o-forms-input--text">
+			<label for="share-link">{ariaLabel}</label>
 			<input
+				id="share-link"
 				type="text"
 				name={urlType}
 				value={url}
 				className="x-gift-article__url-input"
 				disabled={(shareType === ShareType.gift || shareType === ShareType.enterprise) && !isGiftUrlCreated}
 				readOnly
-				aria-label={ariaLabel}
 			/>
 		</span>
 	)

--- a/components/x-gift-article/src/Url.jsx
+++ b/components/x-gift-article/src/Url.jsx
@@ -1,10 +1,12 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from './lib/constants'
 
-export default ({ shareType, isGiftUrlCreated, url, urlType, ariaLabel }) => {
+export default ({ shareType, isGiftUrlCreated, url, urlType }) => {
 	return (
 		<span className="o-forms-input o-forms-input--text">
-			<label for="share-link">{ariaLabel}</label>
+			<label className="x-gift-article__label-link" htmlFor="share-link">
+				Gift article shareable link
+			</label>
 			<input
 				id="share-link"
 				type="text"

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -23,8 +23,7 @@ export default ({
 	enterpriseLimit,
 	enterpriseHasCredits,
 	enterpriseRequestAccess,
-	enterpriseFirstTimeUser,
-	title
+	enterpriseFirstTimeUser
 }) => {
 	const hideUrlShareElements =
 		(giftCredits === 0 && shareType === ShareType.gift) ||
@@ -43,8 +42,7 @@ export default ({
 						shareType,
 						isGiftUrlCreated,
 						url,
-						urlType,
-						ariaLabel: title
+						urlType
 					}}
 				/>
 			)}


### PR DESCRIPTION
After a user activates the share option, and chooses the ‘FT subscribers only’ option in the modal, they are presented with a form field containing the link for the article. However, the form field has not been provided with a visual label to inform users of the purpose of the field.
This also means that voice activation users are unable to discern what voice command is required to access the form field.
Users were not presented instructions or labels to identify the controls in a form and describe what input data is expected. Those with cognitive, language, and learning disabilities may find labels help them to enter information correctly. Labels may also help to prevent users from making submission errors. For voice activation users, visible labels can be used to indicate the accessible name by which this component may be referenced to assistive technology. Otherwise, users are required to use general commands such as ‘click box’. 

[ticket](https://financialtimes.atlassian.net/browse/CI-1368)


BEFORE
![image](https://user-images.githubusercontent.com/102036944/199005246-aedf81ae-2bed-4f34-b7db-af4e691d326a.png)

AFTER
![image](https://user-images.githubusercontent.com/102036944/199005127-8ccbf342-2b44-4c46-af35-73db43a3201f.png)

