### PR TITLE
CI-1371 - Change div to H2s and H4 to H3s

### DIFF
--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -130,7 +130,7 @@ export default ({
 				//Activation Message
 				return (
 					<div className="x-gift-article-message x-gift-article-message--enterprise">
-						<h4>Enterprise Sharing is not enabled for your team</h4>
+						<h3>Enterprise Sharing is not enabled for your team</h3>
 						<p>
 							Enterprise Sharing lets members of your organisation share FT article links with potentially
 							thousands people, even if they don’t have a FT subscription

--- a/components/x-gift-article/src/Title.jsx
+++ b/components/x-gift-article/src/Title.jsx
@@ -18,15 +18,15 @@ export default ({
 		}
 
 		return (
-			<div className="x-gift-article__title" id="gift-article-title">
+			<h2 className="x-gift-article__title" id="gift-article-title">
 				{title}
-			</div>
+			</h2>
 		)
 	} else {
 		return (
-			<div className="x-gift-article__title" id="gift-article-title">
+			<h2 className="x-gift-article__title" id="gift-article-title">
 				{title}
-			</div>
+			</h2>
 		)
 	}
 }


### PR DESCRIPTION
This updates the dialog heading "Share this Article" to be an H2 to provide a clearer indication for screen reader users of the structure of the content.

The h4 was changed to an h3 to follow a logical and numerical hierarchical structure. 


![image](https://user-images.githubusercontent.com/17812050/198959681-5d105ac3-242e-47d8-851f-c43159ba8685.png)
