### PR TITLE
fix: handle live blog posts without a byline

### DIFF
--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -70,7 +70,7 @@ const LiveBlogPost = ({
 			/>
 		)
 	}
-	if (typeof byline === 'object' && 'tree' in byline) {
+	if (byline && typeof byline === 'object' && 'tree' in byline) {
 		postByline = (
 			<p className="x-live-blog-post__byline">
 				<RichText structuredContent={byline} />

--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -252,6 +252,13 @@ describe('x-live-blog-post', () => {
 			expect(liveBlogPost.html()).toContain('class="x-live-blog-post__body')
 			expect(liveBlogPost.html()).toContain('<p>structured live blog body</p>')
 		})
+
+		it('handles posts without bylines', () => {
+			const postWithoutByline = { ...regularPostContentPipeline, byline: null }
+			const liveBlogPost = mount(<LiveBlogPost {...postWithoutByline} />)
+			expect(liveBlogPost.html()).toContain('class="x-live-blog-post__body')
+			expect(liveBlogPost.html()).toContain('<p>structured live blog body</p>')
+		})
 	})
 
 	it('adds a data-x-component attribute', () => {


### PR DESCRIPTION
Turns out `typeof null === 'object'`, so this would throw an error when that happens 
