### PR TITLE
CON-2075, CON-2076: Refactor follow-button aria-label

### DIFF
--- a/components/x-follow-button/__tests__/x-follow-button.test.jsx
+++ b/components/x-follow-button/__tests__/x-follow-button.test.jsx
@@ -76,14 +76,16 @@ describe('x-follow-button', () => {
 				expect(subject.find('button').prop('aria-pressed')).toEqual('true')
 			})
 
-			it('button title is "Remove ConceptName from myFT"', () => {
+			it('button title is "Added ConceptName to myFT: click to remove"', () => {
 				const subject = mount(<FollowButton isFollowed={true} conceptName={'ConceptName'} />)
-				expect(subject.find('button').prop('title')).toEqual('Remove ConceptName from myFT')
+				expect(subject.find('button').prop('title')).toEqual('Added ConceptName to myFT: click to remove')
 			})
 
-			it('button aria-label is "Remove conceptName from myFT"', () => {
+			it('button aria-label is "Added ConceptName to myFT: click to remove"', () => {
 				const subject = mount(<FollowButton isFollowed={true} conceptName={'ConceptName'} />)
-				expect(subject.find('button').prop('aria-label')).toEqual('Remove ConceptName from myFT')
+				expect(subject.find('button').prop('aria-label')).toEqual(
+					'Added ConceptName to myFT: click to remove'
+				)
 			})
 		})
 
@@ -98,14 +100,14 @@ describe('x-follow-button', () => {
 				expect(subject.find('button').prop('aria-pressed')).toEqual('false')
 			})
 
-			it('button title is "Add ConceptName to myFT"', () => {
+			it('button title is "Add to myFT: ConceptName"', () => {
 				const subject = mount(<FollowButton isFollowed={false} conceptName={'ConceptName'} />)
-				expect(subject.find('button').prop('title')).toEqual('Add ConceptName to myFT')
+				expect(subject.find('button').prop('title')).toEqual('Add to myFT: ConceptName')
 			})
 
-			it('button aria-label is "Add ConceptName to myFT"', () => {
+			it('button aria-label is "Add to myFT: ConceptName"', () => {
 				const subject = mount(<FollowButton isFollowed={false} conceptName={'ConceptName'} />)
-				expect(subject.find('button').prop('aria-label')).toEqual('Add ConceptName to myFT')
+				expect(subject.find('button').prop('aria-label')).toEqual('Add to myFT: ConceptName')
 			})
 		})
 	})

--- a/components/x-follow-button/__tests__/x-follow-button.test.jsx
+++ b/components/x-follow-button/__tests__/x-follow-button.test.jsx
@@ -87,6 +87,11 @@ describe('x-follow-button', () => {
 					'Added ConceptName to myFT: click to remove'
 				)
 			})
+
+			it('button aria-label contains the visual label string', () => {
+				const subject = mount(<FollowButton isFollowed={true} conceptName={'ConceptName'} />)
+				expect(subject.find('button').prop('aria-label')).toContain(subject.find('button').text())
+			})
 		})
 
 		describe('when false', () => {
@@ -108,6 +113,11 @@ describe('x-follow-button', () => {
 			it('button aria-label is "Add to myFT: ConceptName"', () => {
 				const subject = mount(<FollowButton isFollowed={false} conceptName={'ConceptName'} />)
 				expect(subject.find('button').prop('aria-label')).toEqual('Add to myFT: ConceptName')
+			})
+
+			it('button aria-label contains the visual label string', () => {
+				const subject = mount(<FollowButton isFollowed={false} conceptName={'ConceptName'} />)
+				expect(subject.find('button').prop('aria-label')).toContain(subject.find('button').text())
 			})
 		})
 	})

--- a/components/x-follow-button/src/FollowButton.jsx
+++ b/components/x-follow-button/src/FollowButton.jsx
@@ -33,7 +33,7 @@ export const FollowButton = (props) => {
 	}
 
 	const getAccessibleText = () =>
-		isFollowed ? `Remove ${conceptName} from myFT` : `Add ${conceptName} to myFT`
+		isFollowed ? `Added ${conceptName} to myFT: click to remove` : `Add to myFT: ${conceptName}`
 
 	return (
 		<form


### PR DESCRIPTION
# The issue

[Jira ticket 1](https://financialtimes.atlassian.net/browse/CON-2075)  
[Jira ticket 2](https://financialtimes.atlassian.net/browse/CON-2076)

The label in name criterion requires that the visible label be contained in the accessible name. At the moment they are different: "Added" vs "Remove from myFT".

# The solution

Use the strings "Add to myFT: conceptName" and  "Added conceptName to myFT: click to remove". Here the visual labels 'Added' and 'Add to myFT' are the first in the aria label.   
The information "click to remove" allows to be aware of the action when clicking the button.  
The visual string is no longer broken. 

# Test

Run storybook and inspect the x-follow-button to see the aria-label
![Screenshot 2022-12-09 at 12 00 43](https://user-images.githubusercontent.com/107469842/206720510-0fc7abef-23df-4f04-ac42-c58d66a5f1ca.png)
![Screenshot 2022-12-09 at 12 01 16](https://user-images.githubusercontent.com/107469842/206720515-b13fab10-e458-467e-a4f7-f41205b9daff.png)

