### PR TITLE
ENTST-139 Add Enterprise Sharing to FTR Articles

### DIFF
--- a/components/x-gift-article/src/Buttons.jsx
+++ b/components/x-gift-article/src/Buttons.jsx
@@ -8,7 +8,8 @@ export default ({
 	showCopyButton,
 	nativeShare,
 	actions,
-	giftCredits
+	giftCredits,
+	isFreeArticle
 }) => {
 	if (isGiftUrlCreated || shareType === ShareType.nonGift) {
 		if (nativeShare) {
@@ -58,6 +59,16 @@ export default ({
 				>
 					Email link <span className="x-gift-article--visually-hidden">to Share this article</span>
 				</a>
+			</div>
+		)
+	}
+
+	if (isFreeArticle && ShareType.enterprise) {
+		return (
+			<div className="x-gift-article__buttons">
+				<button className="x-gift-article__button" type="button" onClick={actions.createEnterpriseUrl}>
+					Create enterprise link
+				</button>
 			</div>
 		)
 	}

--- a/components/x-gift-article/src/Buttons.jsx
+++ b/components/x-gift-article/src/Buttons.jsx
@@ -67,7 +67,7 @@ export default ({
 		return (
 			<div className="x-gift-article__buttons">
 				<button className="x-gift-article__button" type="button" onClick={actions.createEnterpriseUrl}>
-					Create enterprise link
+					Create Enterprise Link
 				</button>
 			</div>
 		)

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -12,20 +12,19 @@ export default (props) => (
 			<div role="group" arialabelledby="gift-article-title">
 				<Title {...props} />
 
-				{!props.isFreeArticle && (
-					<RadioButtonsSection
-						shareType={props.shareType}
-						isArticleSharingUxUpdates={props.isArticleSharingUxUpdates}
-						showGiftUrlSection={props.actions.showGiftUrlSection}
-						showEnterpriseUrlSection={props.actions.showEnterpriseUrlSection}
-						showNonGiftUrlSection={props.actions.showNonGiftUrlSection}
-						enterpriseLimit={props.enterpriseLimit}
-						enterpriseHasCredits={props.enterpriseHasCredits}
-						enterpriseRequestAccess={props.enterpriseRequestAccess}
-						enterpriseAlert={!props.enterpriseHasCredits && !props.enterpriseRequestAccess}
-						enterpriseEnabled={props.enterpriseEnabled}
-					/>
-				)}
+				<RadioButtonsSection
+					shareType={props.shareType}
+					isArticleSharingUxUpdates={props.isArticleSharingUxUpdates}
+					showGiftUrlSection={props.actions.showGiftUrlSection}
+					showEnterpriseUrlSection={props.actions.showEnterpriseUrlSection}
+					showNonGiftUrlSection={props.actions.showNonGiftUrlSection}
+					enterpriseLimit={props.enterpriseLimit}
+					enterpriseHasCredits={props.enterpriseHasCredits}
+					enterpriseRequestAccess={props.enterpriseRequestAccess}
+					enterpriseAlert={!props.enterpriseHasCredits && !props.enterpriseRequestAccess}
+					enterpriseEnabled={props.enterpriseEnabled}
+					isFreeArticle={props.isFreeArticle}
+				/>
 
 				<UrlSection {...props} />
 			</div>

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -153,6 +153,13 @@ const withGiftFormActions = withActions(
 					const { enabled, limit, hasCredits, firstTimeUser, requestAccess } =
 						await enterpriseApi.getEnterpriseArticleAllowance()
 
+					const enterpriseState = {
+						enterpriseLimit: limit,
+						enterpriseHasCredits: hasCredits,
+						enterpriseFirstTimeUser: firstTimeUser,
+						enterpriseRequestAccess: requestAccess
+					}
+
 					if (enabled) {
 						tracking.initEnterpriseSharing(
 							requestAccess
@@ -174,10 +181,7 @@ const withGiftFormActions = withActions(
 						return {
 							invalidResponseFromApi: true,
 							enterpriseEnabled: enabled,
-							enterpriseLimit: limit,
-							enterpriseHasCredits: hasCredits,
-							enterpriseFirstTimeUser: firstTimeUser,
-							enterpriseRequestAccess: requestAccess
+							...enterpriseState
 						}
 					} else {
 						const { giftCredits, monthlyAllowance, nextRenewalDate } = await api.getGiftArticleAllowance()
@@ -188,19 +192,13 @@ const withGiftFormActions = withActions(
 								...updaters.setAllowance(giftCredits, monthlyAllowance, nextRenewalDate),
 								shareType: enabled && hasCredits ? ShareType.enterprise : ShareType.gift,
 								enterpriseEnabled: enabled,
-								enterpriseLimit: limit,
-								enterpriseHasCredits: hasCredits,
-								enterpriseFirstTimeUser: firstTimeUser,
-								enterpriseRequestAccess: requestAccess
+								...enterpriseState
 							}
 						} else {
 							return {
 								invalidResponseFromApi: true,
 								enterpriseEnabled: enabled,
-								enterpriseLimit: limit,
-								enterpriseHasCredits: hasCredits,
-								enterpriseFirstTimeUser: firstTimeUser,
-								enterpriseRequestAccess: requestAccess
+								...enterpriseState
 							}
 						}
 					}

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -50,12 +50,6 @@
 	);
 }
 
-.x-gift-article__enterprise-label {
-	background-color: oColorsByName('black-10');
-	color: oColorsByName('black');
-	margin: 0px 6px;
-}
-
 .x-gift-article__enterprise-no-credits-icon {
 	@include oIconsContent($icon-name: 'warning', $color: oColorsByName('crimson'), $size: 16);
 	border-radius: 50%;

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -54,7 +54,7 @@
 	@include oIconsContent($icon-name: 'warning', $color: oColorsByName('crimson'), $size: 16);
 	border-radius: 50%;
 	border: 2px solid oColorsByName('crimson');
-	margin-bottom: -5px;
+	margin: 0 0 -5px 5px;
 }
 
 @media only screen and (min-width: 600px) {

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -153,18 +153,17 @@ export default ({
 				<div className="x-gift-article-message x-gift-article-message--enterprise">
 					<h4>Your organisation has run out of share credits.</h4>
 					<p>
-						Request more credits and our Enterprise team will get in touch with the admin of your FT
-						subscription to arrange a top-up of sharing credits.
+						Request more credits and our team will get in touch with the admin of your FT subscription to
+						arrange a top-up of sharing credits.
 					</p>
 					<a
-						href="https://enterprise.ft.com/ft-enterprise-sharing-request-access/?segmentId=c87259e0-7073-3ea8-7f83-b988f05c3f94"
-						target="_blank"
+						href="mailto:customer.success@ft.com"
 						rel="noreferrer"
 						data-trackable="enterprise-out-of-credits"
 						className="x-gift-article__button"
 						type="button"
 					>
-						Request more credits
+						Contact support
 					</a>
 				</div>
 			)

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -118,6 +118,7 @@ export default ({
 					<br />
 					<br />
 					<a
+						className="x-gift-article-message--link"
 						href="https://enterprise-sharing-dashboard.ft.com"
 						target="_blank"
 						rel="noreferrer"

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -123,6 +123,16 @@ export default ({
 			return (
 				<div className="x-gift-article-message">
 					Your organisation has <strong>Enterprise Sharing credits</strong> available for you to use
+					<br />
+					<br />
+					<a
+						href="https://enterprise-sharing-dashboard.ft.com"
+						target="_blank"
+						rel="noreferrer"
+						data-trackable="enterprise-sharing-dashboard"
+					>
+						View all Enterprise Links
+					</a>
 				</div>
 			)
 		} else {

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -50,14 +50,6 @@ export default ({
 		}
 	}
 
-	if (isFreeArticle) {
-		return (
-			<div className="x-gift-article-message">
-				This article is currently <strong>free</strong> for anyone to read
-			</div>
-		)
-	}
-
 	if (shareType === ShareType.gift) {
 		if (giftCredits === 0) {
 			return (
@@ -177,6 +169,14 @@ export default ({
 				</div>
 			)
 		}
+	}
+
+	if (isFreeArticle) {
+		return (
+			<div className="x-gift-article-message">
+				This article is currently <strong>free</strong> for anyone to read
+			</div>
+		)
 	}
 
 	if (shareType === ShareType.nonGift) {

--- a/components/x-gift-article/src/Message.scss
+++ b/components/x-gift-article/src/Message.scss
@@ -4,10 +4,10 @@
 	grid-area: message;
 	font-size: 16px;
 	margin-top: oSpacingByName('s3');
+}
 
-	a {
-		color: oColorsByName('teal');
-	}
+.x-gift-article-message--link {
+	color: oColorsByName('teal');
 }
 
 .x-gift-article-message--enterprise {

--- a/components/x-gift-article/src/Message.scss
+++ b/components/x-gift-article/src/Message.scss
@@ -4,6 +4,10 @@
 	grid-area: message;
 	font-size: 16px;
 	margin-top: oSpacingByName('s3');
+
+	a {
+		color: oColorsByName('teal');
+	}
 }
 
 .x-gift-article-message--enterprise {

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -34,7 +34,6 @@ export default ({
 					{enterpriseLimit && !enterpriseRequestAccess
 						? `Up to ${enterpriseLimit} recipients`
 						: `Multiple recipients`}
-					<span className="o-labels x-gift-article__enterprise-label">Enterprise</span>
 					{enterpriseAlert && <span className="x-gift-article__enterprise-no-credits-icon"></span>}
 				</span>
 			</label>

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -73,38 +73,31 @@ export default ({
 		</label>
 	)
 
-	if (isFreeArticle) {
-		if (enterpriseEnabled) {
-			return (
-				<div
-					className="o-forms-input o-forms-input--radio-round o-forms-field x-gift-article__radio_buttons"
-					role="group"
-					aria-labelledby="article-share-options"
-				>
-					<span className="x-gift-article--visually-hidden" id="article-share-options">
-						Article share options
-					</span>
-					{freeToReadField()}
-					{enterpriseField()}
-				</div>
-			)
-		}
-
-		return null
+	if (!isFreeArticle || enterpriseEnabled) {
+		return (
+			<div
+				className="o-forms-input o-forms-input--radio-round o-forms-field x-gift-article__radio_buttons"
+				role="group"
+				aria-labelledby="article-share-options"
+			>
+				<span className="x-gift-article--visually-hidden" id="article-share-options">
+					Article share options
+				</span>
+				{isFreeArticle ? (
+					<>
+						{freeToReadField()}
+						{enterpriseField()}
+					</>
+				) : (
+					<>
+						{enterpriseField()}
+						{giftField()}
+						{nonGiftField()}
+					</>
+				)}
+			</div>
+		)
 	}
 
-	return (
-		<div
-			className="o-forms-input o-forms-input--radio-round o-forms-field x-gift-article__radio_buttons"
-			role="group"
-			aria-labelledby="article-share-options"
-		>
-			<span className="x-gift-article--visually-hidden" id="article-share-options">
-				Article share options
-			</span>
-			{enterpriseField()}
-			{giftField()}
-			{nonGiftField()}
-		</div>
-	)
+	return null
 }

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -9,36 +9,29 @@ export default ({
 	enterpriseEnabled = false,
 	enterpriseLimit = 100,
 	enterpriseRequestAccess = false,
-	enterpriseAlert = false
-}) => (
-	<div
-		className="o-forms-input o-forms-input--radio-round o-forms-field x-gift-article__radio_buttons"
-		role="group"
-		aria-labelledby="article-share-options"
-	>
-		<span className="x-gift-article--visually-hidden" id="article-share-options">
-			Article share options
-		</span>
+	enterpriseAlert = false,
+	isFreeArticle = false
+}) => {
+	const enterpriseField = () => (
+		<label htmlFor="enterpriseLink">
+			<input
+				type="radio"
+				name="gift-form__radio"
+				value="enterpriseLink"
+				id="enterpriseLink"
+				checked={shareType === ShareType.enterprise}
+				onChange={showEnterpriseUrlSection}
+			/>
+			<span className="o-forms-input__label">
+				{enterpriseLimit && !enterpriseRequestAccess
+					? `Up to ${enterpriseLimit} recipients`
+					: `Multiple recipients`}
+				{enterpriseAlert && <span className="x-gift-article__enterprise-no-credits-icon"></span>}
+			</span>
+		</label>
+	)
 
-		{enterpriseEnabled === true && (
-			<label htmlFor="enterpriseLink">
-				<input
-					type="radio"
-					name="gift-form__radio"
-					value="enterpriseLink"
-					id="enterpriseLink"
-					checked={shareType === ShareType.enterprise}
-					onChange={showEnterpriseUrlSection}
-				/>
-				<span className="o-forms-input__label">
-					{enterpriseLimit && !enterpriseRequestAccess
-						? `Up to ${enterpriseLimit} recipients`
-						: `Multiple recipients`}
-					{enterpriseAlert && <span className="x-gift-article__enterprise-no-credits-icon"></span>}
-				</span>
-			</label>
-		)}
-
+	const giftField = () => (
 		<label htmlFor="giftLink">
 			<input
 				type="radio"
@@ -50,7 +43,9 @@ export default ({
 			/>
 			<span className="o-forms-input__label">{enterpriseEnabled ? `Single recipient` : `with anyone`}</span>
 		</label>
+	)
 
+	const nonGiftField = () => (
 		<label htmlFor="nonGiftLink">
 			<input
 				type="radio"
@@ -62,5 +57,54 @@ export default ({
 			/>
 			<span className="o-forms-input__label">FT subscribers only</span>
 		</label>
-	</div>
-)
+	)
+
+	const freeToReadField = () => (
+		<label htmlFor="nonGiftLink">
+			<input
+				type="radio"
+				name="gift-form__radio"
+				value="nonGiftLink"
+				id="nonGiftLink"
+				checked={shareType === ShareType.nonGift}
+				onChange={showNonGiftUrlSection}
+			/>
+			<span className="o-forms-input__label">with anyone</span>
+		</label>
+	)
+
+	if (isFreeArticle) {
+		if (enterpriseEnabled) {
+			return (
+				<div
+					className="o-forms-input o-forms-input--radio-round o-forms-field x-gift-article__radio_buttons"
+					role="group"
+					aria-labelledby="article-share-options"
+				>
+					<span className="x-gift-article--visually-hidden" id="article-share-options">
+						Article share options
+					</span>
+					{freeToReadField()}
+					{enterpriseField()}
+				</div>
+			)
+		}
+
+		return null
+	}
+
+	return (
+		<div
+			className="o-forms-input o-forms-input--radio-round o-forms-field x-gift-article__radio_buttons"
+			role="group"
+			aria-labelledby="article-share-options"
+		>
+			<span className="x-gift-article--visually-hidden" id="article-share-options">
+				Article share options
+			</span>
+			{enterpriseField()}
+			{giftField()}
+			{nonGiftField()}
+		</div>
+	)
+}

--- a/components/x-gift-article/src/Url.jsx
+++ b/components/x-gift-article/src/Url.jsx
@@ -5,7 +5,7 @@ export default ({ shareType, isGiftUrlCreated, url, urlType }) => {
 	return (
 		<span className="o-forms-input o-forms-input--text">
 			<label className="x-gift-article__label-link" htmlFor="share-link">
-				Gift article shareable link
+				{shareType === ShareType.enterprise ? 'Enterprise Sharing link' : 'Gift article shareable link'}
 			</label>
 			<input
 				id="share-link"

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -74,7 +74,8 @@ export default ({
 						showCopyButton,
 						nativeShare,
 						actions,
-						giftCredits
+						giftCredits,
+						isFreeArticle
 					}}
 				/>
 			)}

--- a/components/x-gift-article/storybook/free-article-with-enterprise-sharing.js
+++ b/components/x-gift-article/storybook/free-article-with-enterprise-sharing.js
@@ -1,0 +1,43 @@
+const articleUrl = 'https://www.ft.com/content/blahblahblah'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
+
+exports.args = {
+	title: 'Share this article (free)',
+	isRafActive: false,
+	isFreeArticle: true,
+	raf: { title: 'Custom title' },
+	article: {
+		title: 'Title Title Title Title',
+		id: 'base-gift-article-static-id',
+		url: articleUrl
+	},
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
+}
+
+// This reference is only required for hot module loading in development
+// <https://webpack.js.org/concepts/hot-module-replacement/>
+exports.m = module
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`https://enterprise-sharing-api.ft.com/v1/users/me/allowance`, {
+			limit: 120,
+			hasCredits: true,
+			firstTimeUser: false
+		})
+		.post(`https://enterprise-sharing-api.ft.com/v1/shares`, {
+			url: articleUrlRedeemed,
+			redeemLimit: 120
+		})
+}

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -60,6 +60,20 @@ export const FreeArticle = (args) => {
 		</div>
 	)
 }
+FreeArticle.storyName = 'Free article'
+FreeArticle.args = require('./free-article').args
+
+export const FreeArticleWithEnterpriseSharing = (args) => {
+	require('./free-article-with-enterprise-sharing').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+FreeArticleWithEnterpriseSharing.storyName = 'Free article with enterprise sharing'
+FreeArticleWithEnterpriseSharing.args = require('./free-article-with-enterprise-sharing').args
 
 export const WithEnterpriseSharing = (args) => {
 	require('./with-enterprise').fetchMock(fetchMock)
@@ -120,9 +134,6 @@ export const WithEnterpriseSharingLink = (args) => {
 }
 WithEnterpriseSharingLink.storyName = 'With enterprise sharing (link generated)'
 WithEnterpriseSharingLink.args = require('./with-enterprise-sharing-link').args
-
-FreeArticle.storyName = 'Free article'
-FreeArticle.args = require('./free-article').args
 
 export const NativeShare = (args) => {
 	require('./native-share').fetchMock(fetchMock)


### PR DESCRIPTION
This PR tweaks the behaviour of `x-gift-article` to make a few adjustments concerning Enterprise Sharing. The main difference is that when sharing a free to read article with Enterprise Sharing enabled, users will now see the option to share with Enterprise Sharing alongside the default share option.

This is necessary because articles commonly remain free to read for a short period of time before going behind the paywall and we've had feedback from several Enterprise Sharing clients expressing frustration that the standard links to the article they've shared stop working when this happens. Enterprise Sharing clients can also track how many times their links have been opened and therefore some would prefer to share free to read articles via Enterprise Sharing to have visibility over this.

This behaviour is covered by ticket [ENTST-139](https://financialtimes.atlassian.net/browse/ENTST-139?atlOrigin=eyJpIjoiYTM0ODA1NGMzM2I5NGFkMmI3YjU1NDdlZDY0YTdiM2MiLCJwIjoiaiJ9).

I've added a 'Free with enterprise sharing' option to the Storybook to make this behaviour available to test.

### Styling Tweaks

This PR also makes a few minor styling changes to the `x-gift-article`:

- The 'Enterprise' label has been removed from next to the 'Enterprise Sharing' radio button. Ticket [ENTST-152](https://financialtimes.atlassian.net/browse/ENTST-152?atlOrigin=eyJpIjoiNmEwOThiYzA1NzU1NDJkODkzNjk4ZGJmYjc3NjdkOWEiLCJwIjoiaiJ9).
- The sharing link url field label has been corrected to read 'Enterprise Sharing link' instead of 'Gift article shareable link' when the link has been generated with Enterprise Sharing. Ticket [ENTST-154](https://financialtimes.atlassian.net/browse/ENTST-154?atlOrigin=eyJpIjoiNjhlZTBkOTI0YWEyNDUzM2JmOGI5NzVmZDRkYjRmYjMiLCJwIjoiaiJ9).
- A 'View all Enterprise Links' link which takes users to the [Enterprise Sharing Dashboard](https://enterprise-sharing-dashboard.ft.com/) has been added to the messaging when the Enterprise Sharing option is selected. Ticket [ENTST-135](https://financialtimes.atlassian.net/jira/software/projects/ENTST/boards/1569?selectedIssue=ENTST-135).


[ENTST-139]: https://financialtimes.atlassian.net/browse/ENTST-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENTST-139]: https://financialtimes.atlassian.net/browse/ENTST-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENTST-152]: https://financialtimes.atlassian.net/browse/ENTST-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ