### PR TITLE
Hotfix: Remove Fragment

### DIFF
--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -84,16 +84,16 @@ export default ({
 					Article share options
 				</span>
 				{isFreeArticle ? (
-					<>
+					<div>
 						{freeToReadField()}
 						{enterpriseField()}
-					</>
+					</div>
 				) : (
-					<>
+					<div>
 						{enterpriseField()}
 						{giftField()}
 						{nonGiftField()}
-					</>
+					</div>
 				)}
 			</div>
 		)


### PR DESCRIPTION
This PR removes a bug introduced [by `8.2.4`](https://github.com/Financial-Times/x-dash/compare/v8.2.3...v8.2.4). Fragments are unsupported by Preact, so this replaces the shorthand Fragment usage with a regular `div`. 
