### PR TITLE
Bugfix: Gift Article Radio Buttons

### DIFF
--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -119,5 +119,6 @@ export default ({
 	}
 
 	// If the article is free but Enterprise Sharing is NOT enabled, do not display the radio buttons.
+	// They're not required because there's only one available sharing option in this case.
 	return null
 }

--- a/components/x-gift-article/src/RadioButtonsSection.jsx
+++ b/components/x-gift-article/src/RadioButtonsSection.jsx
@@ -73,7 +73,8 @@ export default ({
 		</label>
 	)
 
-	if (!isFreeArticle || enterpriseEnabled) {
+	// If the article is free and Enterprise Sharing is enabled, display the radio buttons.
+	if (isFreeArticle && enterpriseEnabled) {
 		return (
 			<div
 				className="o-forms-input o-forms-input--radio-round o-forms-field x-gift-article__radio_buttons"
@@ -83,14 +84,32 @@ export default ({
 				<span className="x-gift-article--visually-hidden" id="article-share-options">
 					Article share options
 				</span>
-				{isFreeArticle ? (
+				{freeToReadField()}
+				{enterpriseField()}
+			</div>
+		)
+	}
+
+	// If the article is not free, display the radio buttons with conditional options depending
+	// on whether or not Enterprise Sharing is enabled.
+	if (!isFreeArticle) {
+		return (
+			<div
+				className="o-forms-input o-forms-input--radio-round o-forms-field x-gift-article__radio_buttons"
+				role="group"
+				aria-labelledby="article-share-options"
+			>
+				<span className="x-gift-article--visually-hidden" id="article-share-options">
+					Article share options
+				</span>
+				{enterpriseEnabled ? (
 					<div>
-						{freeToReadField()}
 						{enterpriseField()}
+						{giftField()}
+						{nonGiftField()}
 					</div>
 				) : (
 					<div>
-						{enterpriseField()}
 						{giftField()}
 						{nonGiftField()}
 					</div>
@@ -99,5 +118,6 @@ export default ({
 		)
 	}
 
+	// If the article is free but Enterprise Sharing is NOT enabled, do not display the radio buttons.
 	return null
 }


### PR DESCRIPTION
This PR fixes a bug whereby B2C users were erroneously seeing the 'Enterprise Sharing' option in the Gift Article radio buttons. This was happening because the specific logic controlling which radio buttons to display was quite confusing.

I've now separated out that logic. There's some minor repetition of code which I think is justified by making the logic clearer and easier to understand. I've also added a few code comment to explain it.
