### PR TITLE
Removed ES credits message

### DIFF
--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -112,11 +112,7 @@ export default ({
 					</div>
 				)
 			}
-			return (
-				<div className="x-gift-article-message">
-					Your organisation has <strong>Enterprise Sharing credits</strong> available for you to use
-				</div>
-			)
+			return null
 		} else {
 			if (enterpriseRequestAccess) {
 				//Activation Message


### PR DESCRIPTION
## Description
Removed the message `Your organisation has Enterprise Sharing credits available for you to use` because it is no longer needed. 

## Jira ticket
https://financialtimes.atlassian.net/browse/ENTST-392

## Screenshot
| Before  | After |
| ------------- | ------------- |
| <img width="1177" alt="Screenshot 2023-05-03 at 11 11 26" src="https://user-images.githubusercontent.com/22678655/235863512-5f8cf5c1-de9b-46c2-979c-d0291da2cc2b.png"> | <img width="1186" alt="Screenshot 2023-05-03 at 11 09 01" src="https://user-images.githubusercontent.com/22678655/235863095-a019c89b-38a6-452a-9aaa-db8b081225a0.png"> |


