### PR TITLE
X-Gift article highlights sharing Release

### DIFF
--- a/components/x-gift-article/package.json
+++ b/components/x-gift-article/package.json
@@ -28,7 +28,7 @@
     "@financial-times/o-loading": "^5.2.1",
     "@financial-times/o-message": "^5.2.1",
     "@financial-times/o-normalise": "^3.2.2",
-    "@financial-times/o-typography": "^7.2.2",
+    "@financial-times/o-typography": "^7.4.1",
     "@financial-times/x-rollup": "file:../../packages/x-rollup",
     "check-engine": "^1.10.1",
     "sass": "^1.49.0"
@@ -41,12 +41,14 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
+    "@financial-times/o-banner": "^4.4.9",
     "@financial-times/o-buttons": "^7.2.2",
+    "@financial-times/o-colors": "^6.6.0",
     "@financial-times/o-forms": "^9.2.3",
     "@financial-times/o-labels": "^6.2.2",
     "@financial-times/o-loading": "^5.2.1",
     "@financial-times/o-message": "^5.2.1",
     "@financial-times/o-normalise": "^3.2.2",
-    "@financial-times/o-typography": "^7.2.2"
+    "@financial-times/o-typography": "^7.4.1"
   }
 }

--- a/components/x-gift-article/src/Buttons.jsx
+++ b/components/x-gift-article/src/Buttons.jsx
@@ -9,7 +9,8 @@ export default ({
 	nativeShare,
 	actions,
 	giftCredits,
-	isFreeArticle
+	isFreeArticle,
+	includeHighlights
 }) => {
 	if (isGiftUrlCreated || shareType === ShareType.nonGift) {
 		if (nativeShare) {
@@ -80,6 +81,7 @@ export default ({
 				disabled={!giftCredits}
 				type="button"
 				onClick={shareType === ShareType.enterprise ? actions.createEnterpriseUrl : actions.createGiftUrl}
+				data-trackable={shareType === ShareType.enterprise ? `includeHighlights:${includeHighlights}` : ''}
 			>
 				Create {shareType === ShareType.enterprise ? 'enterprise' : 'gift'} link
 			</button>

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -5,6 +5,7 @@ import UrlSection from './UrlSection'
 import MobileShareButtons from './MobileShareButtons'
 import CopyConfirmation from './CopyConfirmation'
 import { ShareType } from './lib/constants'
+import HighlightSection from './HighlightSection'
 
 export default (props) => (
 	<div className="x-gift-article">
@@ -25,7 +26,12 @@ export default (props) => (
 					enterpriseEnabled={props.enterpriseEnabled}
 					isFreeArticle={props.isFreeArticle}
 				/>
-
+				<HighlightSection
+					shareType={props.shareType}
+					hasHighlights={props.hasHighlights}
+					includeHighlights={props.includeHighlights}
+					isGiftUrlCreated={props.isGiftUrlCreated}
+				/>
 				<UrlSection {...props} />
 			</div>
 		</form>

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -34,8 +34,10 @@ export default (props) => (
 					isGiftUrlCreated={props.isGiftUrlCreated}
 					saveHighlightsHandler={props.actions.saveHighlightsHandler}
 					showHighlightsRecipientMessage={props.showHighlightsRecipientMessage}
+					showHighlightsSuccessMessage={props.showHighlightsSuccessMessage}
 					showHighlightsCheckbox={props.showHighlightsCheckbox}
 					closeHighlightsRecipientMessage={props.actions.closeHighlightsRecipientMessage}
+					closeHighlightsSuccessMessage={props.actions.closeHighlightsSuccessMessage}
 				/>
 				<UrlSection {...props} />
 			</div>

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -30,6 +30,7 @@ export default (props) => (
 					shareType={props.shareType}
 					hasHighlights={props.hasHighlights}
 					includeHighlights={props.includeHighlights}
+					includeHighlightsHandler={props.actions.includeHighlightsHandler}
 					isGiftUrlCreated={props.isGiftUrlCreated}
 				/>
 				<UrlSection {...props} />

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -32,6 +32,10 @@ export default (props) => (
 					includeHighlights={props.includeHighlights}
 					includeHighlightsHandler={props.actions.includeHighlightsHandler}
 					isGiftUrlCreated={props.isGiftUrlCreated}
+					saveHighlightsHandler={props.actions.saveHighlightsHandler}
+					showHighlightsRecipientMessage={props.showHighlightsRecipientMessage}
+					showHighlightsCheckbox={props.showHighlightsCheckbox}
+					closeHighlightsRecipientMessage={props.actions.closeHighlightsRecipientMessage}
 				/>
 				<UrlSection {...props} />
 			</div>

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -200,6 +200,22 @@ const withGiftFormActions = withActions(
 					state.includeHighlights = includeHighlights
 					return { includeHighlights }
 				}
+			},
+			saveHighlightsHandler() {
+				return () => {
+					return {
+						showHighlightsRecipientMessage: false,
+						showHighlightsSuccessMessage: true,
+						showHighlightsCheckbox: true
+					}
+				}
+			},
+			closeHighlightsSuccessMessage() {
+				return () => {
+					return {
+						showHighlightsSuccessMessage: false
+					}
+				}
 			}
 		}
 	},
@@ -216,6 +232,8 @@ const withGiftFormActions = withActions(
 			isArticleSharingUxUpdates: false,
 			includeHighlights: false,
 			hasHighlights: false,
+			showHighlightsRecipientMessage: new URL(location.href).searchParams.has('highlights'),
+			showHighlightsCheckbox: !new URL(location.href).searchParams.has('highlights'),
 			urls: {
 				dummy: 'https://on.ft.com/gift_link',
 				gift: undefined,

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -193,6 +193,13 @@ const withGiftFormActions = withActions(
 						}
 					}
 				}
+			},
+			includeHighlightsHandler() {
+				return (state) => {
+					const includeHighlights = !state.includeHighlights
+					state.includeHighlights = includeHighlights
+					return { includeHighlights }
+				}
 			}
 		}
 	},

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -210,6 +210,13 @@ const withGiftFormActions = withActions(
 					}
 				}
 			},
+			closeHighlightsRecipientMessage() {
+				return () => {
+					return {
+						showHighlightsRecipientMessage: false
+					}
+				}
+			},
 			closeHighlightsSuccessMessage() {
 				return () => {
 					return {
@@ -233,6 +240,7 @@ const withGiftFormActions = withActions(
 			includeHighlights: false,
 			hasHighlights: false,
 			showHighlightsRecipientMessage: new URL(location.href).searchParams.has('highlights'),
+			showHighlightsSuccessMessage: false,
 			showHighlightsCheckbox: !new URL(location.href).searchParams.has('highlights'),
 			urls: {
 				dummy: 'https://on.ft.com/gift_link',

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -64,13 +64,18 @@ const withGiftFormActions = withActions(
 			},
 
 			async createEnterpriseUrl() {
-				const { redemptionUrl, redemptionLimit } = await enterpriseApi.getESUrl(initialProps.article.id)
+				return async (state) => {
+					const { redemptionUrl, redemptionLimit } = await enterpriseApi.getESUrl(
+						initialProps.article.id,
+						state.includeHighlights
+					)
 
-				if (redemptionUrl) {
-					tracking.createESLink(redemptionUrl)
-					return updaters.setGiftUrl(redemptionUrl, redemptionLimit, false, true)
-				} else {
-					return updaters.setErrorState(true)
+					if (redemptionUrl) {
+						tracking.createESLink(redemptionUrl)
+						return updaters.setGiftUrl(redemptionUrl, redemptionLimit, false, true)(state)
+					} else {
+						return updaters.setErrorState(true)
+					}
 				}
 			},
 
@@ -202,6 +207,7 @@ const withGiftFormActions = withActions(
 			isGiftUrlShortened: false,
 			isNonGiftUrlShortened: false,
 			isArticleSharingUxUpdates: false,
+			includeHighlights: false,
 			urls: {
 				dummy: 'https://on.ft.com/gift_link',
 				gift: undefined,

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -201,6 +201,12 @@ const withGiftFormActions = withActions(
 					return { includeHighlights }
 				}
 			},
+			checkIfHasHighlights() {
+				return (state) => {
+					state.hasHighlights = !!document.getElementsByClassName(initialProps.highlightClassName).length
+					return { hasHighlights: state.hasHighlights }
+				}
+			},
 			saveHighlightsHandler() {
 				return () => {
 					return {
@@ -242,6 +248,7 @@ const withGiftFormActions = withActions(
 			showHighlightsRecipientMessage: new URL(location.href).searchParams.has('highlights'),
 			showHighlightsSuccessMessage: false,
 			showHighlightsCheckbox: !new URL(location.href).searchParams.has('highlights'),
+			highlightClassName: 'user-annotation',
 			urls: {
 				dummy: 'https://on.ft.com/gift_link',
 				gift: undefined,

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -208,6 +208,7 @@ const withGiftFormActions = withActions(
 			isNonGiftUrlShortened: false,
 			isArticleSharingUxUpdates: false,
 			includeHighlights: false,
+			hasHighlights: false,
 			urls: {
 				dummy: 'https://on.ft.com/gift_link',
 				gift: undefined,

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -11,6 +11,8 @@
 @import 'Loading.scss';
 @import 'Message.scss';
 @import 'MobileShareButtons.scss';
+@import 'HighlightSection.scss';
+@import 'HighlightRecipientMessage.scss';
 
 .x-gift-article {
 	@include oTypographySans;
@@ -28,7 +30,8 @@
 		$opts: (
 			'elements': (
 				'text',
-				'radio-round'
+				'radio-round',
+				'checkbox'
 			),
 			'features': (
 				'inline',

--- a/components/x-gift-article/src/GiftArticle.scss
+++ b/components/x-gift-article/src/GiftArticle.scss
@@ -13,6 +13,7 @@
 @import 'MobileShareButtons.scss';
 @import 'HighlightSection.scss';
 @import 'HighlightRecipientMessage.scss';
+@import 'HighlightSavedMessage.scss';
 
 .x-gift-article {
 	@include oTypographySans;

--- a/components/x-gift-article/src/HighlightCheckbox.jsx
+++ b/components/x-gift-article/src/HighlightCheckbox.jsx
@@ -1,0 +1,22 @@
+import { h } from '@financial-times/x-engine'
+
+export default ({ includeHighlightsHandler, includeHighlights, isGiftUrlCreated }) => {
+	return (
+		<div className="o-forms-input o-forms-input--checkbox o-forms-field x-gift-article__checkbox">
+			<label htmlFor="includeHighlights">
+				<input
+					type="checkbox"
+					id="includeHighlights"
+					name="includeHighlights"
+					value={includeHighlights}
+					checked={includeHighlights}
+					onChange={includeHighlightsHandler}
+					disabled={isGiftUrlCreated}
+				/>
+				<span className="o-forms-input__label x-gift-article__checkbox-span">
+					Make highlights visible to recipients
+				</span>
+			</label>
+		</div>
+	)
+}

--- a/components/x-gift-article/src/HighlightCheckbox.jsx
+++ b/components/x-gift-article/src/HighlightCheckbox.jsx
@@ -12,6 +12,7 @@ export default ({ includeHighlightsHandler, includeHighlights, isGiftUrlCreated 
 					checked={includeHighlights}
 					onChange={includeHighlightsHandler}
 					disabled={isGiftUrlCreated}
+					data-trackable="make-highlights-visible"
 				/>
 				<span className="o-forms-input__label x-gift-article__checkbox-span">
 					Make highlights visible to recipients

--- a/components/x-gift-article/src/HighlightRecipientMessage.jsx
+++ b/components/x-gift-article/src/HighlightRecipientMessage.jsx
@@ -1,0 +1,26 @@
+import { h } from '@financial-times/x-engine'
+
+export default ({ handleSaveAnnotations, handleCloseRecipientMessage }) => {
+	return (
+		<div className="x-gift-article__highlight-recipient-message">
+			<p className="x-gift-article__highlight-recipient-message__title">Share the highlighted article</p>
+			<div className="x-gift-article__highlight-recipient-message__divider"></div>
+			<p className="o-typography-professional o-typography-inverse x-gift-article__highlight-recipient-message__description">
+				If you wish to share the highlighted article,
+				<button
+					type="button"
+					className="o-typography-link x-gift-article__highlight-recipient-message__save-highlights-button"
+					onClick={handleSaveAnnotations}
+				>
+					save the highlights
+				</button>
+				as your own before creating the link.
+			</p>
+			<button
+				className="x-gift-article__highlight-recipient-message__close"
+				type="button"
+				onClick={handleCloseRecipientMessage}
+			></button>
+		</div>
+	)
+}

--- a/components/x-gift-article/src/HighlightRecipientMessage.jsx
+++ b/components/x-gift-article/src/HighlightRecipientMessage.jsx
@@ -19,6 +19,7 @@ export default ({ handleSaveAnnotations, handleCloseRecipientMessage }) => {
 			<button
 				className="x-gift-article__highlight-recipient-message__close"
 				type="button"
+				content="Close"
 				onClick={handleCloseRecipientMessage}
 			></button>
 		</div>

--- a/components/x-gift-article/src/HighlightRecipientMessage.jsx
+++ b/components/x-gift-article/src/HighlightRecipientMessage.jsx
@@ -6,14 +6,14 @@ export default ({ handleSaveAnnotations, handleCloseRecipientMessage }) => {
 			<p className="x-gift-article__highlight-recipient-message__title">Share the highlighted article</p>
 			<div className="x-gift-article__highlight-recipient-message__divider"></div>
 			<p className="o-typography-professional o-typography-inverse x-gift-article__highlight-recipient-message__description">
-				If you wish to share the highlighted article,
+				If you wish to share the highlighted article,{' '}
 				<button
 					type="button"
 					className="o-typography-link x-gift-article__highlight-recipient-message__save-highlights-button"
 					onClick={handleSaveAnnotations}
 				>
 					save the highlights
-				</button>
+				</button>{' '}
 				as your own before creating the link.
 			</p>
 			<button

--- a/components/x-gift-article/src/HighlightRecipientMessage.jsx
+++ b/components/x-gift-article/src/HighlightRecipientMessage.jsx
@@ -2,14 +2,14 @@ import { h } from '@financial-times/x-engine'
 
 export default ({ handleSaveAnnotations, handleCloseRecipientMessage }) => {
 	return (
-		<div className="x-gift-article__highlight-recipient-message">
-			<p className="x-gift-article__highlight-recipient-message__title">Share the highlighted article</p>
-			<div className="x-gift-article__highlight-recipient-message__divider"></div>
-			<p className="o-typography-professional o-typography-inverse x-gift-article__highlight-recipient-message__description">
+		<div className="x-gift-article-highlight-recipient-message">
+			<p className="x-gift-article-highlight-recipient-message__title">Share the highlighted article</p>
+			<div className="x-gift-article-highlight-recipient-message__divider"></div>
+			<p className="o-typography-professional o-typography-inverse x-gift-article-highlight-recipient-message__description">
 				If you wish to share the highlighted article,{' '}
 				<button
 					type="button"
-					className="o-typography-link x-gift-article__highlight-recipient-message__save-highlights-button"
+					className="o-typography-link x-gift-article-highlight-recipient-message__save-highlights-button"
 					onClick={handleSaveAnnotations}
 				>
 					save the highlights
@@ -17,11 +17,12 @@ export default ({ handleSaveAnnotations, handleCloseRecipientMessage }) => {
 				as your own before creating the link.
 			</p>
 			<button
-				className="x-gift-article__highlight-recipient-message__close"
+				className="x-gift-article-highlight-recipient-message__close"
 				type="button"
-				content="Close"
 				onClick={handleCloseRecipientMessage}
-			></button>
+			>
+				<span className="o-normalise-visually-hidden">Close</span>
+			</button>
 		</div>
 	)
 }

--- a/components/x-gift-article/src/HighlightRecipientMessage.scss
+++ b/components/x-gift-article/src/HighlightRecipientMessage.scss
@@ -53,6 +53,7 @@
     .x-gift-article__highlight-recipient-message__save-highlights-button {
       background: none;
       border: none;
+      padding: 0;
     }
 }
 

--- a/components/x-gift-article/src/HighlightRecipientMessage.scss
+++ b/components/x-gift-article/src/HighlightRecipientMessage.scss
@@ -1,0 +1,59 @@
+@import '@financial-times/o-colors/main';
+@import '@financial-times/o-spacing/main';
+@import '@financial-times/o-typography/main';
+
+@include oTypography();
+
+.x-gift-article__highlight-recipient-message {
+    position: relative;;
+    background-color: oColorsByName('slate');
+    color: oColorsMix('ft-grey', 'white', 20);
+    padding: oSpacingByName('s3');
+  
+    .x-gift-article__highlight-recipient-message__title {
+      @include oTypographySans($scale: 1, $weight: 'regular');
+      margin: 0;
+      color: oColorsByName('white');
+    }
+  
+    .x-gift-article__highlight-recipient-message__description {
+      @include oTypographySans($scale: 0);
+      margin: 0;
+    }
+    
+    .x-gift-article__highlight-recipient-message__divider{
+      padding-top: oSpacingByName('s2');
+      padding-bottom: oSpacingByName('s3');
+      &::after {
+        border-top: oSpacingByName('s1') solid oColorsByName('mint');
+        content: "";
+        position: absolute;
+        width: 40px;
+        content: "";
+        display: block;
+      }
+    }
+  
+    .x-gift-article__highlight-recipient-message__close {
+      background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1%3Across?source=editor&tint=%23FFFFFF&bgcolor=%23FFFFFF');
+      background-repeat: no-repeat;
+      background-size: contain;
+      background-position: 50%;
+      background-color: transparent;
+      width: oSpacingByName('s6');
+      height: oSpacingByName('s6');
+      border: none;
+      padding: 0;
+      content: "";
+      position: absolute;
+      right: oSpacingByName('s2');
+      top: oSpacingByName('s2');
+    }
+  
+    .x-gift-article__highlight-recipient-message__save-highlights-button {
+      background: none;
+      border: none;
+    }
+}
+
+

--- a/components/x-gift-article/src/HighlightRecipientMessage.scss
+++ b/components/x-gift-article/src/HighlightRecipientMessage.scss
@@ -4,24 +4,24 @@
 
 @include oTypography();
 
-.x-gift-article__highlight-recipient-message {
+.x-gift-article-highlight-recipient-message {
 	position: relative;
 	background-color: oColorsByName('slate');
 	color: oColorsMix('ft-grey', 'white', 20);
 	padding: oSpacingByName('s3');
 
-	.x-gift-article__highlight-recipient-message__title {
+	.x-gift-article-highlight-recipient-message__title {
 		@include oTypographySans($scale: 1, $weight: 'regular');
 		margin: 0;
 		color: oColorsByName('white');
 	}
 
-	.x-gift-article__highlight-recipient-message__description {
+	.x-gift-article-highlight-recipient-message__description {
 		@include oTypographySans($scale: 0);
 		margin: 0;
 	}
 
-	.x-gift-article__highlight-recipient-message__divider {
+	.x-gift-article-highlight-recipient-message__divider {
 		padding-top: oSpacingByName('s2');
 		padding-bottom: oSpacingByName('s3');
 		&::after {
@@ -33,7 +33,7 @@
 		}
 	}
 
-	.x-gift-article__highlight-recipient-message__close {
+	.x-gift-article-highlight-recipient-message__close {
 		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1%3Across?source=editor&tint=%23FFFFFF&bgcolor=%23FFFFFF');
 		background-repeat: no-repeat;
 		background-size: contain;
@@ -48,7 +48,7 @@
 		top: oSpacingByName('s2');
 	}
 
-	.x-gift-article__highlight-recipient-message__save-highlights-button {
+	.x-gift-article-highlight-recipient-message__save-highlights-button {
 		background: none;
 		border: none;
 		padding: 0;

--- a/components/x-gift-article/src/HighlightRecipientMessage.scss
+++ b/components/x-gift-article/src/HighlightRecipientMessage.scss
@@ -5,56 +5,52 @@
 @include oTypography();
 
 .x-gift-article__highlight-recipient-message {
-    position: relative;;
-    background-color: oColorsByName('slate');
-    color: oColorsMix('ft-grey', 'white', 20);
-    padding: oSpacingByName('s3');
-  
-    .x-gift-article__highlight-recipient-message__title {
-      @include oTypographySans($scale: 1, $weight: 'regular');
-      margin: 0;
-      color: oColorsByName('white');
-    }
-  
-    .x-gift-article__highlight-recipient-message__description {
-      @include oTypographySans($scale: 0);
-      margin: 0;
-    }
-    
-    .x-gift-article__highlight-recipient-message__divider{
-      padding-top: oSpacingByName('s2');
-      padding-bottom: oSpacingByName('s3');
-      &::after {
-        border-top: oSpacingByName('s1') solid oColorsByName('mint');
-        content: "";
-        position: absolute;
-        width: 40px;
-        content: "";
-        display: block;
-      }
-    }
-  
-    .x-gift-article__highlight-recipient-message__close {
-      background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1%3Across?source=editor&tint=%23FFFFFF&bgcolor=%23FFFFFF');
-      background-repeat: no-repeat;
-      background-size: contain;
-      background-position: 50%;
-      background-color: transparent;
-      width: oSpacingByName('s6');
-      height: oSpacingByName('s6');
-      border: none;
-      padding: 0;
-      content: "";
-      position: absolute;
-      right: oSpacingByName('s2');
-      top: oSpacingByName('s2');
-    }
-  
-    .x-gift-article__highlight-recipient-message__save-highlights-button {
-      background: none;
-      border: none;
-      padding: 0;
-    }
+	position: relative;
+	background-color: oColorsByName('slate');
+	color: oColorsMix('ft-grey', 'white', 20);
+	padding: oSpacingByName('s3');
+
+	.x-gift-article__highlight-recipient-message__title {
+		@include oTypographySans($scale: 1, $weight: 'regular');
+		margin: 0;
+		color: oColorsByName('white');
+	}
+
+	.x-gift-article__highlight-recipient-message__description {
+		@include oTypographySans($scale: 0);
+		margin: 0;
+	}
+
+	.x-gift-article__highlight-recipient-message__divider {
+		padding-top: oSpacingByName('s2');
+		padding-bottom: oSpacingByName('s3');
+		&::after {
+			border-top: oSpacingByName('s1') solid oColorsByName('mint');
+			content: '';
+			position: absolute;
+			width: 40px;
+			display: block;
+		}
+	}
+
+	.x-gift-article__highlight-recipient-message__close {
+		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1%3Across?source=editor&tint=%23FFFFFF&bgcolor=%23FFFFFF');
+		background-repeat: no-repeat;
+		background-size: contain;
+		background-position: 50%;
+		background-color: transparent;
+		width: oSpacingByName('s6');
+		height: oSpacingByName('s6');
+		border: none;
+		padding: 0;
+		position: absolute;
+		right: oSpacingByName('s2');
+		top: oSpacingByName('s2');
+	}
+
+	.x-gift-article__highlight-recipient-message__save-highlights-button {
+		background: none;
+		border: none;
+		padding: 0;
+	}
 }
-
-

--- a/components/x-gift-article/src/HighlightSavedMessage.jsx
+++ b/components/x-gift-article/src/HighlightSavedMessage.jsx
@@ -14,7 +14,7 @@ export default ({ handleCloseSuccessMessage }) => {
 					<button
 						type="button"
 						className="o-message__close"
-						aria-label="close"
+						content="close"
 						title="Close"
 						onClick={handleCloseSuccessMessage}
 					></button>

--- a/components/x-gift-article/src/HighlightSavedMessage.jsx
+++ b/components/x-gift-article/src/HighlightSavedMessage.jsx
@@ -1,0 +1,25 @@
+import { h } from '@financial-times/x-engine'
+
+export default ({ handleCloseSuccessMessage }) => {
+	return (
+		<div
+			className="o-message o-message--alert o-message--success x-gift-article__highlights-saved-message"
+			data-o-component="o-message"
+		>
+			<div className="o-message__container">
+				<div className="o-message__content">
+					<p className="o-message__content-main">
+						<span className="o-message__content-highlight">Highlights saved.</span>
+					</p>
+					<button
+						type="button"
+						className="o-message__close"
+						aria-label="close"
+						title="Close"
+						onClick={handleCloseSuccessMessage}
+					></button>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/components/x-gift-article/src/HighlightSavedMessage.jsx
+++ b/components/x-gift-article/src/HighlightSavedMessage.jsx
@@ -11,13 +11,9 @@ export default ({ handleCloseSuccessMessage }) => {
 					<p className="o-message__content-main">
 						<span className="o-message__content-highlight">Highlights saved.</span>
 					</p>
-					<button
-						type="button"
-						className="o-message__close"
-						content="close"
-						title="Close"
-						onClick={handleCloseSuccessMessage}
-					></button>
+					<button type="button" className="o-message__close" onClick={handleCloseSuccessMessage}>
+						<span className="o-normalise-visually-hidden">Close</span>
+					</button>
 				</div>
 			</div>
 		</div>

--- a/components/x-gift-article/src/HighlightSavedMessage.scss
+++ b/components/x-gift-article/src/HighlightSavedMessage.scss
@@ -1,0 +1,3 @@
+.x-gift-article__highlights-saved-message {
+  margin-bottom: oSpacingByName('s4');
+}

--- a/components/x-gift-article/src/HighlightSection.jsx
+++ b/components/x-gift-article/src/HighlightSection.jsx
@@ -1,6 +1,13 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from './lib/constants'
-export default ({ shareType, includeHighlights, isGiftUrlCreated, hasHighlights }) => {
+import HighlightCheckbox from './HighlightCheckbox'
+export default ({
+	shareType,
+	includeHighlights,
+	includeHighlightsHandler,
+	isGiftUrlCreated,
+	hasHighlights
+}) => {
 	if (shareType === ShareType.enterprise && hasHighlights) {
 		if (isGiftUrlCreated && includeHighlights) {
 			return (
@@ -9,6 +16,15 @@ export default ({ shareType, includeHighlights, isGiftUrlCreated, hasHighlights 
 				</div>
 			)
 		}
+		return (
+			<div className="x-gift-article__highlight-section">
+				<HighlightCheckbox
+					includeHighlights={includeHighlights}
+					includeHighlightsHandler={includeHighlightsHandler}
+					isGiftUrlCreated={isGiftUrlCreated}
+				/>
+			</div>
+		)
 	}
 	return null
 }

--- a/components/x-gift-article/src/HighlightSection.jsx
+++ b/components/x-gift-article/src/HighlightSection.jsx
@@ -1,13 +1,32 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from './lib/constants'
+import HighlightRecipientMessage from './HighlightRecipientMessage'
 import HighlightCheckbox from './HighlightCheckbox'
+import HighlightsApiClient from './lib/highlightsApi'
+
+const USER_ANNOTATIONS_API = `https://enterprise-user-annotations-api.ft.com/v1`
+
 export default ({
 	shareType,
 	includeHighlights,
 	includeHighlightsHandler,
 	isGiftUrlCreated,
-	hasHighlights
+	hasHighlights,
+	saveHighlightsHandler,
+	showHighlightsRecipientMessage,
+	showHighlightsCheckbox,
+	closeHighlightsRecipientMessage
 }) => {
+	const handleSaveAnnotations = async () => {
+		const highlightsToken = new URL(location.href).searchParams.get('highlights')
+		const highlightsAPIClient = new HighlightsApiClient(USER_ANNOTATIONS_API)
+		const response = await highlightsAPIClient.copySharedHighlights(highlightsToken)
+
+		if (response) {
+			saveHighlightsHandler()
+		}
+	}
+
 	if (shareType === ShareType.enterprise && hasHighlights) {
 		if (isGiftUrlCreated && includeHighlights) {
 			return (
@@ -18,11 +37,19 @@ export default ({
 		}
 		return (
 			<div className="x-gift-article__highlight-section">
-				<HighlightCheckbox
-					includeHighlights={includeHighlights}
-					includeHighlightsHandler={includeHighlightsHandler}
-					isGiftUrlCreated={isGiftUrlCreated}
-				/>
+				{showHighlightsRecipientMessage ? (
+					<HighlightRecipientMessage
+						handleSaveAnnotations={handleSaveAnnotations}
+						handleCloseRecipientMessage={closeHighlightsRecipientMessage}
+					/>
+				) : null}
+				{showHighlightsCheckbox ? (
+					<HighlightCheckbox
+						includeHighlights={includeHighlights}
+						includeHighlightsHandler={includeHighlightsHandler}
+						isGiftUrlCreated={isGiftUrlCreated}
+					/>
+				) : null}
 			</div>
 		)
 	}

--- a/components/x-gift-article/src/HighlightSection.jsx
+++ b/components/x-gift-article/src/HighlightSection.jsx
@@ -21,12 +21,18 @@ export default ({
 	closeHighlightsRecipientMessage
 }) => {
 	const handleSaveAnnotations = async () => {
-		const highlightsToken = new URL(location.href).searchParams.get('highlights')
+		const url = new URL(location.href)
+		const params = new URLSearchParams(url.search)
+		const highlightsToken = params.get('highlights')
 		const highlightsAPIClient = new HighlightsApiClient(USER_ANNOTATIONS_API)
 		const response = await highlightsAPIClient.copySharedHighlights(highlightsToken)
 
 		if (response) {
 			saveHighlightsHandler()
+			params.delete('highlights')
+			url.search = params.toString()
+			localStorage.setItem('showSuccessSavedMessage', 'true')
+			location.href = url.toString()
 		}
 	}
 

--- a/components/x-gift-article/src/HighlightSection.jsx
+++ b/components/x-gift-article/src/HighlightSection.jsx
@@ -1,0 +1,14 @@
+import { h } from '@financial-times/x-engine'
+import { ShareType } from './lib/constants'
+export default ({ shareType, includeHighlights, isGiftUrlCreated, hasHighlights }) => {
+	if (shareType === ShareType.enterprise && hasHighlights) {
+		if (isGiftUrlCreated && includeHighlights) {
+			return (
+				<div className="x-gift-article__highlight-section">
+					<div className="x-gift-article__highlight-shared">highlights visible to recipients</div>
+				</div>
+			)
+		}
+	}
+	return null
+}

--- a/components/x-gift-article/src/HighlightSection.jsx
+++ b/components/x-gift-article/src/HighlightSection.jsx
@@ -1,6 +1,7 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from './lib/constants'
 import HighlightRecipientMessage from './HighlightRecipientMessage'
+import HighlightSavedMessage from './HighlightSavedMessage'
 import HighlightCheckbox from './HighlightCheckbox'
 import HighlightsApiClient from './lib/highlightsApi'
 
@@ -14,7 +15,9 @@ export default ({
 	hasHighlights,
 	saveHighlightsHandler,
 	showHighlightsRecipientMessage,
+	showHighlightsSuccessMessage,
 	showHighlightsCheckbox,
+	closeHighlightsSuccessMessage,
 	closeHighlightsRecipientMessage
 }) => {
 	const handleSaveAnnotations = async () => {
@@ -42,6 +45,9 @@ export default ({
 						handleSaveAnnotations={handleSaveAnnotations}
 						handleCloseRecipientMessage={closeHighlightsRecipientMessage}
 					/>
+				) : null}
+				{showHighlightsSuccessMessage ? (
+					<HighlightSavedMessage handleCloseSuccessMessage={closeHighlightsSuccessMessage} />
 				) : null}
 				{showHighlightsCheckbox ? (
 					<HighlightCheckbox

--- a/components/x-gift-article/src/HighlightSection.scss
+++ b/components/x-gift-article/src/HighlightSection.scss
@@ -1,0 +1,14 @@
+@import '@financial-times/o-colors/main';
+@import '@financial-times/o-spacing/main';
+
+.x-gift-article__highlight-section {
+	border-top: 1px solid oColorsMix(black, paper, 20);
+	padding-top: oSpacingByName('s4');
+	@include oLabels(
+		$opts: (
+			'states': (
+				'content-premium'
+			)
+		)
+	);
+}

--- a/components/x-gift-article/src/HighlightSection.scss
+++ b/components/x-gift-article/src/HighlightSection.scss
@@ -22,10 +22,10 @@
 
 .x-gift-article__form .o-forms-field.x-gift-article__checkbox {
 	margin: 0;
-}
 
-.x-gift-article__checkbox-span::before {
-	background-color: inherit !important;
+	.o-forms-input__label.x-gift-article__checkbox-span::before {
+		background-color: inherit;
+	}
 }
 
 .x-gift-article__highlight-shared {

--- a/components/x-gift-article/src/HighlightSection.scss
+++ b/components/x-gift-article/src/HighlightSection.scss
@@ -4,7 +4,13 @@
 
 .x-gift-article__highlight-section {
 	border-top: 1px solid oColorsMix(black, paper, 20);
-	padding-top: oSpacingByName('s4');
+	padding-top: oSpacingByName('s6');
+	padding-bottom: oSpacingByName('s6');
+
+	@include oGridRespondTo($from: S) {
+		padding-bottom: oSpacingByName('s3');
+	}
+
 	@include oLabels(
 		$opts: (
 			'states': (
@@ -15,7 +21,7 @@
 }
 
 .x-gift-article__form .o-forms-field.x-gift-article__checkbox {
-	margin-bottom: oSpacingByName('s1');
+	margin: 0;
 }
 
 .x-gift-article__checkbox-span::before {

--- a/components/x-gift-article/src/HighlightSection.scss
+++ b/components/x-gift-article/src/HighlightSection.scss
@@ -12,3 +12,12 @@
 		)
 	);
 }
+
+.x-gift-article__form .o-forms-field.x-gift-article__checkbox {
+	margin-bottom: oSpacingByName('s1');
+}
+
+.x-gift-article__checkbox-span::before {
+	background-color: inherit !important;
+}
+

--- a/components/x-gift-article/src/HighlightSection.scss
+++ b/components/x-gift-article/src/HighlightSection.scss
@@ -1,3 +1,4 @@
+@import '@financial-times/o-typography/main';
 @import '@financial-times/o-colors/main';
 @import '@financial-times/o-spacing/main';
 
@@ -21,3 +22,11 @@
 	background-color: inherit !important;
 }
 
+.x-gift-article__highlight-shared {
+	@include oTypographySans($scale: -1);
+	background-color: oColorsMix(black, paper, 5);
+	width: fit-content;
+	padding: oSpacingByName('s1') oSpacingByName('s2');
+	text-transform: uppercase;
+	color: oColorsMix(ft-grey, paper, 100);
+}

--- a/components/x-gift-article/src/HighlightSection.scss
+++ b/components/x-gift-article/src/HighlightSection.scss
@@ -22,10 +22,6 @@
 
 .x-gift-article__form .o-forms-field.x-gift-article__checkbox {
 	margin: 0;
-
-	.o-forms-input__label.x-gift-article__checkbox-span::before {
-		background-color: inherit;
-	}
 }
 
 .x-gift-article__highlight-shared {

--- a/components/x-gift-article/src/Message.jsx
+++ b/components/x-gift-article/src/Message.jsx
@@ -112,11 +112,7 @@ export default ({
 					</div>
 				)
 			}
-			return (
-				<div className="x-gift-article-message">
-					Your organisation has <strong>Enterprise Sharing credits</strong> available for you to use
-				</div>
-			)
+			return null
 		} else {
 			if (enterpriseRequestAccess) {
 				//Activation Message

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -23,7 +23,8 @@ export default ({
 	enterpriseLimit,
 	enterpriseHasCredits,
 	enterpriseRequestAccess,
-	enterpriseFirstTimeUser
+	enterpriseFirstTimeUser,
+	includeHighlights
 }) => {
 	const hideUrlShareElements =
 		(giftCredits === 0 && shareType === ShareType.gift) ||
@@ -75,7 +76,8 @@ export default ({
 						nativeShare,
 						actions,
 						giftCredits,
-						isFreeArticle
+						isFreeArticle,
+						includeHighlights
 					}}
 				/>
 			)}

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -84,11 +84,15 @@ export default class EnterpriseApiClient {
 	/**
 	 * Generates an enterprise sharing redeem link for the contentId
 	 * @param {string} contentId Article ID
+	 * @param {boolean} [includeHighlights] should include the user highlights in the share link
 	 * @returns {Promise<{ redeemLimit: number, redemptionUrl: string }>} object with enterprise sharing redeem link URL and limit
 	 */
-	async getESUrl(contentId) {
+	async getESUrl(contentId, includeHighlights = false) {
 		try {
-			const json = await this.fetchJson('/v1/shares', { method: 'POST', body: JSON.stringify({ contentId }) })
+			const json = await this.fetchJson('/v1/shares', {
+				method: 'POST',
+				body: JSON.stringify({ contentId, includeHighlights })
+			})
 
 			return {
 				redemptionUrl: json.url,

--- a/components/x-gift-article/src/lib/highlightsApi.js
+++ b/components/x-gift-article/src/lib/highlightsApi.js
@@ -49,7 +49,7 @@ export default class HighlightsApiClient {
 			return {
 				annotationsCopyResult: json.annotationsCopyResult
 			}
-		} catch (e) {
+		} catch (error) {
 			return { annotationsCopyResult: undefined }
 		}
 	}

--- a/components/x-gift-article/src/lib/highlightsApi.js
+++ b/components/x-gift-article/src/lib/highlightsApi.js
@@ -1,0 +1,56 @@
+export default class HighlightsApiClient {
+	constructor(baseUrl) {
+		this.baseUrl = baseUrl
+	}
+
+	/**
+	 * Concatenates protocol, domain and path URLs.
+	 * @param {string} path URL Path
+	 * @returns {string} Fetch URL
+	 * @throws {Error} if baseURL is empty
+	 */
+	getFetchUrl(path) {
+		if (!this.baseUrl) {
+			throw new Error('User Annotations API base url missing')
+		}
+
+		return `${this.baseUrl}${path}`
+	}
+
+	/**
+	 * Makes a fetch request to the path with additional options
+	 * @param {string} path URL path
+	 * @param {RequestInit} additionalOptions fetch additional options
+	 * @returns {Promise<object>} A promise that resolves to the requested URL response parsed from json
+	 */
+	async fetchJson(path, additionalOptions) {
+		const url = this.getFetchUrl(path)
+		const options = Object.assign(
+			{
+				credentials: 'include',
+				headers: {
+					'Content-Type': 'application/json'
+				}
+			},
+			additionalOptions
+		)
+
+		const response = await fetch(url, options)
+		return await response.json()
+	}
+
+	async copySharedHighlights(highlightsToken) {
+		try {
+			const json = await this.fetchJson('/copy-annotations', {
+				method: 'POST',
+				body: JSON.stringify({ highlightsToken })
+			})
+
+			return {
+				annotationsCopyResult: json.annotationsCopyResult
+			}
+		} catch (e) {
+			return { annotationsCopyResult: undefined }
+		}
+	}
+}

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -13,7 +13,8 @@ exports.args = {
 	},
 	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: true
 }
 
 // This reference is only required for hot module loading in development


### PR DESCRIPTION
## Description
This PR introduces two features
- Highlights checkbox that creates a share with highlights included
- A new message is introduced to B2B recipients in the x-gift-article prompting the users to save their highlights in order to re-share the article with the received highlights.

Changes:

- Updated the entrepriseApi
- Created a separate highlightsApi client to be used only for requests to the user-annotations-api
- Created HighlightsSection component to be a wrapper of the highlights checkbox, the recipient message for saving highlights and the success message afterwards.
- Created a HighlightCheckbox component, which will appear after the user has saved the shared highlights or when the user has created highlights on their own.
- Created a new message HighlightRecipientMessage which will be shown to B2B users only if they open a shared article with highlights( highlights query parameter should be in the url)
- Created a new success message HighlightSuccessMessage which will appear after the user clicks save the highlights.
- add an action to check if user have highlights ,this action will be used by the next-article project to update the hasHighlights status when user creates highlights after the x-gift-article component initializes 
- remove organization share credit message
- update storybook to show share highlights options

## Jira Tickets 

Highlights checkbox ticket
https://financialtimes.atlassian.net/browse/ENTST-352

Recipient message ticket
https://financialtimes.atlassian.net/browse/ENTST-397

## Visuals

### Sharing article with existing highlights
https://github.com/Financial-Times/x-dash/assets/22678655/b17b8ca1-494c-4ab1-b18a-b7fb4353cbcc

### Sharing article with no highlights
<img width="1006" alt="Screenshot 2023-05-04 at 15 28 14" src="https://user-images.githubusercontent.com/10318770/236238328-4467868f-50c4-4db8-bf1e-b3c1071c753f.png">

### Sharing article with received highlights

https://github.com/Financial-Times/x-dash/assets/22678655/539e4301-7fb2-4487-9a01-50d71b142882
