### PR TITLE
Get highlightsClassName from state

### DIFF
--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -203,7 +203,7 @@ const withGiftFormActions = withActions(
 			},
 			checkIfHasHighlights() {
 				return (state) => {
-					state.hasHighlights = !!document.getElementsByClassName(initialProps.highlightClassName).length
+					state.hasHighlights = !!document.getElementsByClassName(state.highlightClassName).length
 					return { hasHighlights: state.hasHighlights }
 				}
 			},


### PR DESCRIPTION
## Description 
The highlights checkbox is visible even when the article has no highlights. Switched to get the `highlightsClassName` property from the `state` instead of `initialProps`.