### PR TITLE
ENTST-455: User journey flow update - B2B non advanced-sharing / B2C

### DIFF
--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -27,28 +27,28 @@ describe('x-gift-article', () => {
 		actions = {}
 
 		fetchMock
-			.get('/article/gift-credits', {
+			.get('path:/article/gift-credits', {
 				allowance: 20,
 				consumedCredits: 5,
 				remainingCredits: 15,
 				renewalDate: '2018-08-01T00:00:00Z'
 			})
-			.get(`/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
 				shortenedUrl: 'https://shortened-gift-url'
 			})
-			.get(`/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			.get(`path:/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
 				shortenedUrl: 'https://shortened-non-gift-url'
 			})
-			.get(`/article/gift-link/${encodeURIComponent(articleId)}`, {
+			.get(`path:/article/gift-link/${encodeURIComponent(articleId)}`, {
 				redemptionUrl: articleUrlRedeemed,
 				remainingAllowance: 1
 			})
-			.get('https://enterprise-sharing-api.ft.com/v1/users/me/allowance', {
+			.get('path:/v1/users/me/allowance', {
 				limit: 120,
 				hasCredits: true,
 				firstTimeUser: true
 			})
-			.post('https://enterprise-sharing-api.ft.com/v1/shares', {
+			.post('path:/v1/shares', {
 				url: articleUrlRedeemed,
 				redeemLimit: 120
 			})
@@ -58,35 +58,16 @@ describe('x-gift-article', () => {
 		fetchMock.reset()
 	})
 
-	it('displays the correct title', async () => {
+	it('displays the article title', async () => {
 		const args = {
-			...baseArgs,
-			title: 'A given test title'
+			...baseArgs
 		}
+
+		args.article.title = 'A given test article title'
 
 		const subject = mount(<GiftArticle {...args} />)
 
-		expect(subject.find('h2').text()).toEqual('A given test title')
-	})
-
-	it('displays the mobile share links when showMobileShareLinks is true', async () => {
-		const args = {
-			...baseArgs,
-			showMobileShareLinks: true
-		}
-		const subject = mount(<GiftArticle {...args} />)
-
-		expect(subject.find('div.x-gift-article-mobile-share-buttons').length).toEqual(1)
-	})
-
-	it('does not display the mobile share links when showMobileShareLinks is false', async () => {
-		const args = {
-			...baseArgs,
-			showMobileShareLinks: false
-		}
-		const subject = mount(<GiftArticle {...args} />)
-
-		expect(subject.find('div.x-gift-article-mobile-share-buttons').length).toEqual(0)
+		expect(subject.find('h2').text()).toEqual('A given test article title')
 	})
 
 	it('should call correct endpoints on activate', async () => {
@@ -100,53 +81,19 @@ describe('x-gift-article', () => {
 		expect(fetchMock.called('/article/gift-credits')).toBe(true)
 	})
 
-	it('should call showGiftUrlSection and show correct html element', async () => {
+	it('should call shortenNonGiftUrl and display correct url', async () => {
 		const subject = mount(<GiftArticle {...baseArgs} actionsRef={(a) => Object.assign(actions, a)} />)
-
-		await actions.activate()
-
-		expect(actions.showGiftUrlSection).toBeDefined()
-		await actions.showGiftUrlSection()
-		subject.update()
-
-		expect(subject.find('div[data-section-id="giftLink"]')).toHaveLength(1)
-	})
-
-	it('should call showEnterpriseUrlSection and show correct html element', async () => {
-		const subject = mount(<GiftArticle {...baseArgs} actionsRef={(a) => Object.assign(actions, a)} />)
-
-		await actions.activate()
-
-		expect(actions.showEnterpriseUrlSection).toBeDefined()
-		await actions.showEnterpriseUrlSection()
-		subject.update()
-
-		expect(subject.find('div[data-section-id="enterpriseLink"]')).toHaveLength(1)
-	})
-
-	it('enterpriseLink radio button is not shown for non-enterprise users', async () => {
-		const args = {
-			...baseArgs,
-			enterpriseApiBaseUrl: undefined
-		}
-
-		const subject = mount(<GiftArticle {...args} actionsRef={(a) => Object.assign(actions, a)} />)
-
-		expect(subject.find('input#enterpriseLink')).toHaveLength(0)
-		expect(subject.find('input#giftLink')).toHaveLength(1)
-		expect(subject.find('input#nonGiftLink')).toHaveLength(1)
-	})
-
-	it('should call showNonGiftUrlSection and show correct html element', async () => {
-		const subject = mount(<GiftArticle {...baseArgs} actionsRef={(a) => Object.assign(actions, a)} />)
-		await actions.activate()
 
 		expect(actions.showNonGiftUrlSection).toBeDefined()
 		await actions.showNonGiftUrlSection()
 
+		expect(actions.shortenNonGiftUrl).toBeDefined()
+		await actions.shortenNonGiftUrl()
+
 		subject.update()
 
-		expect(subject.find('div[data-section-id="nonGiftLink"]')).toHaveLength(1)
+		const input = subject.find('input#share-link')
+		expect(input.prop('value')).toEqual('https://shortened-non-gift-url')
 	})
 
 	it('should call createGiftUrl and display correct url', async () => {
@@ -171,55 +118,11 @@ describe('x-gift-article', () => {
 		expect(input.prop('value')).toEqual('https://gift-url-redeemed')
 	})
 
-	it('when no gift-credits are available, a message is shown', async () => {
-		fetchMock.get(
-			'/article/gift-credits',
-			{
-				allowance: 20,
-				consumedCredits: 20,
-				remainingCredits: 0,
-				renewalDate: '2018-08-01T00:00:00Z'
-			},
-			{ overwriteRoutes: true }
-		)
+	it.todo('when no gift-credits are available, a message is shown')
 
-		const subject = mount(<GiftArticle {...baseArgs} actionsRef={(a) => Object.assign(actions, a)} />)
-		await actions.activate()
+	it.todo('when no enterprise credits are available, a message is shown')
 
-		expect(actions.showGiftUrlSection).toBeDefined()
-		await actions.showGiftUrlSection()
-		subject.update()
+	it.todo('displays the mobile share links when showMobileShareLinks is true')
 
-		expect(subject.find('input#share-link')).toHaveLength(0)
-		expect(
-			subject.find('div.x-gift-article-message').text().includes('You’ve used all your gift article credits')
-		).toBe(true)
-	})
-
-	it('when no enterprise credits are available, a message is shown', async () => {
-		fetchMock.get(
-			`https://enterprise-sharing-api.ft.com/v1/users/me/allowance`,
-			{
-				limit: 120,
-				hasCredits: false,
-				firstTimeUser: false
-			},
-			{ overwriteRoutes: true }
-		)
-
-		const subject = mount(<GiftArticle {...baseArgs} actionsRef={(a) => Object.assign(actions, a)} />)
-		await actions.activate()
-
-		expect(actions.showEnterpriseUrlSection).toBeDefined()
-		await actions.showEnterpriseUrlSection()
-		subject.update()
-
-		expect(subject.find('input#share-link')).toHaveLength(0)
-		expect(
-			subject
-				.find('div.x-gift-article-message')
-				.text()
-				.includes('Your organisation has run out of share credits')
-		).toBe(true)
-	})
+	it.todo('does not display the mobile share links when showMobileShareLinks is false')
 })

--- a/components/x-gift-article/package.json
+++ b/components/x-gift-article/package.json
@@ -5,7 +5,7 @@
   "main": "dist/GiftArticle.cjs.js",
   "browser": "dist/GiftArticle.es5.js",
   "module": "dist/GiftArticle.esm.js",
-  "style": "src/GiftArticle.scss",
+  "style": "src/v2/ShareArticleDialog.scss",
   "scripts": {
     "build": "node rollup.js",
     "start": "node rollup.js --watch",
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@financial-times/o-buttons": "^7.2.2",
-    "@financial-times/o-forms": "^9.2.3",
+    "@financial-times/o-forms": "^9.11.0",
     "@financial-times/o-labels": "^6.2.2",
     "@financial-times/o-loading": "^5.2.1",
     "@financial-times/o-message": "^5.2.1",
@@ -44,7 +44,7 @@
     "@financial-times/o-banner": "^4.4.9",
     "@financial-times/o-buttons": "^7.2.2",
     "@financial-times/o-colors": "^6.6.0",
-    "@financial-times/o-forms": "^9.2.3",
+    "@financial-times/o-forms": "^9.11.0",
     "@financial-times/o-labels": "^6.2.2",
     "@financial-times/o-loading": "^5.2.1",
     "@financial-times/o-message": "^5.2.1",

--- a/components/x-gift-article/src/CopyConfirmation.jsx
+++ b/components/x-gift-article/src/CopyConfirmation.jsx
@@ -1,14 +1,18 @@
 import { h } from '@financial-times/x-engine'
 
-export default ({ hideCopyConfirmation }) => (
+export default ({ hideCopyConfirmation, isArticleSharingUxUpdates }) => (
 	<div
-		className="o-message o-message--alert o-message--success x-gift-article__copy-confirmation"
+		className="o-message o-message--alert o-message--success share-article-dialog__copy-confirmation-alert"
 		role="alert"
 	>
 		<div className="o-message__container">
 			<div className="o-message__content">
 				<p className="o-message__content-main">
-					<span className="o-message__content-highlight">The link has been copied to your clipboard</span>
+					{isArticleSharingUxUpdates ? (
+						<span>Link copied to clipboard.</span>
+					) : (
+						<span className="o-message__content-highlight">Link copied to clipboard.</span>
+					)}
 				</p>
 			</div>
 

--- a/components/x-gift-article/src/lib/tracking.js
+++ b/components/x-gift-article/src/lib/tracking.js
@@ -25,6 +25,15 @@ module.exports = {
 			link
 		}),
 
+	createNonGiftLink: (link, longUrl) =>
+		dispatchEvent({
+			category: 'gift-link',
+			action: 'create',
+			linkType: 'nonGiftLink',
+			link,
+			longUrl
+		}),
+
 	initEnterpriseSharing: (status) =>
 		dispatchEvent({
 			category: 'gift-link',

--- a/components/x-gift-article/src/v2/Footer.jsx
+++ b/components/x-gift-article/src/v2/Footer.jsx
@@ -1,0 +1,10 @@
+import { h } from '@financial-times/x-engine'
+import { FooterMessage } from './FooterMessage'
+
+export const Footer = (props) => {
+	return (
+		<footer className="share-article-dialog__footer">
+			<FooterMessage {...props} />
+		</footer>
+	)
+}

--- a/components/x-gift-article/src/v2/FooterMessage.jsx
+++ b/components/x-gift-article/src/v2/FooterMessage.jsx
@@ -1,0 +1,51 @@
+import { h } from '@financial-times/x-engine'
+import { ShareType } from '../lib/constants'
+
+export const FooterMessage = ({
+	shareType,
+	isGiftUrlCreated,
+	redemptionLimit,
+	giftCredits,
+	isNonGiftUrlShortened,
+	enterpriseEnabled
+}) => {
+	if (!isGiftUrlCreated && !isNonGiftUrlShortened) {
+		return enterpriseEnabled ? (
+			<p className="share-article-dialog__footer-message">
+				Send to multiple people with{' '}
+				<a
+					className="o-typography-professional o-typography-link"
+					href="https://enterprise.ft.com/ft-enterprise-sharing-trial"
+					target="_blank"
+					rel="noreferrer"
+				>
+					Advanced Sharing
+				</a>
+			</p>
+		) : null
+	}
+
+	if (shareType === ShareType.gift) {
+		const redemptionLimitUnit = redemptionLimit === 1 ? 'time' : 'times'
+		const creditUnit = giftCredits === 1 ? 'credit' : 'credits'
+		const redemptionLimitMessage = `Link can be viewed ${redemptionLimit} ${redemptionLimitUnit} and is valid for 90 days.`
+		const creditsMessage = `You still have ${giftCredits} ${creditUnit} left this month.`
+
+		return (
+			<div className="share-article-dialog__footer-message-shared-link">
+				<p>{redemptionLimitMessage}</p>
+				<p>{creditsMessage}</p>
+			</div>
+		)
+	}
+
+	if (shareType === ShareType.nonGift) {
+		return (
+			<p className="share-article-dialog__footer-message-shared-link">
+				Only FT subscribers will be able to see the full article using this link.
+			</p>
+		)
+	}
+
+	return null
+}

--- a/components/x-gift-article/src/v2/GiftLinkSection.jsx
+++ b/components/x-gift-article/src/v2/GiftLinkSection.jsx
@@ -1,0 +1,84 @@
+import { h } from '@financial-times/x-engine'
+import { SharedLinkTypeSelector } from './SharedLinkTypeSelector'
+import { ShareType } from '../lib/constants'
+import CopyConfirmation from '../CopyConfirmation'
+
+export const GiftLinkSection = (props) => {
+	const {
+		isGiftUrlCreated,
+		urlType,
+		url,
+		actions,
+		isArticleSharingUxUpdates,
+		shareType,
+		showCopyConfirmation,
+		isNonGiftUrlShortened,
+		enterpriseEnabled
+	} = props
+
+	const createLinkHandler = async () => {
+		switch (shareType) {
+			case ShareType.gift:
+				await actions.createGiftUrl()
+				break
+			case ShareType.nonGift:
+				await actions.shortenNonGiftUrl()
+				break
+			default:
+		}
+	}
+
+	const copyLinkHandler = (event) => {
+		switch (shareType) {
+			case ShareType.gift:
+				actions.copyGiftUrl(event)
+				break
+			case ShareType.nonGift:
+				actions.copyNonGiftUrl(event)
+				break
+			default:
+		}
+	}
+
+	if (isGiftUrlCreated || (shareType === ShareType.nonGift && isNonGiftUrlShortened)) {
+		return (
+			<div
+				className="o-forms-input o-forms-input--text o-forms-input--suffix js-gift-article__url-section"
+				data-section-id={shareType + 'Link'}
+				data-trackable={shareType + 'Link'}
+			>
+				<input id="share-link" type="text" name={urlType} value={url} readOnly />
+				<button
+					className={`o-buttons o-buttons--big o-buttons--primary ${
+						enterpriseEnabled ? 'o-buttons--professional' : ''
+					}`}
+					aria-label="Copy link of the gift article to your clipboard"
+					onClick={copyLinkHandler}
+				>
+					Copy Link
+				</button>
+				{showCopyConfirmation && (
+					<CopyConfirmation
+						hideCopyConfirmation={actions.hideCopyConfirmation}
+						isArticleSharingUxUpdates={isArticleSharingUxUpdates}
+					/>
+				)}
+			</div>
+		)
+	}
+
+	return (
+		<div>
+			<SharedLinkTypeSelector {...props} />
+			<button
+				id="create-link-button"
+				className={`o-buttons o-buttons--big o-buttons--primary share-article-dialog__create-link-button ${
+					enterpriseEnabled ? 'o-buttons--professional' : ''
+				}`}
+				onClick={createLinkHandler}
+			>
+				Create link
+			</button>
+		</div>
+	)
+}

--- a/components/x-gift-article/src/v2/Header.jsx
+++ b/components/x-gift-article/src/v2/Header.jsx
@@ -1,0 +1,21 @@
+import { h } from '@financial-times/x-engine'
+import { ShareType } from '../lib/constants'
+
+export const Header = ({ title, article, isGiftUrlCreated, shareType, isNonGiftUrlShortened }) => {
+	// when a gift link is created or shortened, the title is "Sharing link"
+	if (isGiftUrlCreated || (shareType === ShareType.nonGift && isNonGiftUrlShortened)) {
+		return (
+			<header>
+				<div className="share-article-dialog__header-share-link-title">Sharing link</div>
+			</header>
+		)
+	}
+
+	// when a gift link is not created, the title should be "Share this article:"
+	return (
+		<header>
+			<h5 className="share-article-dialog__header-share-article-title">{title}</h5>
+			<h2 className="share-article-dialog__header-article-title">{article.title}</h2>
+		</header>
+	)
+}

--- a/components/x-gift-article/src/v2/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/v2/ShareArticleDialog.jsx
@@ -1,0 +1,15 @@
+import { h } from '@financial-times/x-engine'
+import { Header } from './Header'
+import { GiftLinkSection } from './GiftLinkSection'
+import { Footer } from './Footer'
+
+export default (props) => {
+	return (
+		<div className="o-typography-wrapper share-article-dialog__wrapper">
+			{/*todo use the enterpriseEnabled field to add the Advanced Sharing top banner*/}
+			<Header {...props} />
+			<GiftLinkSection {...props} />
+			<Footer {...props} />
+		</div>
+	)
+}

--- a/components/x-gift-article/src/v2/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/v2/ShareArticleDialog.scss
@@ -1,0 +1,98 @@
+@import '../lib/variables';
+@import '@financial-times/o-normalise/main';
+@import '@financial-times/o-typography/main';
+@import '@financial-times/o-buttons/main';
+@import '@financial-times/o-forms/main';
+@import '@financial-times/o-message/main';
+
+@include oNormalise();
+@include oTypography();
+
+@include oButtons($opts: (
+	'sizes': ('big'),
+	'types': ('primary'),
+	'themes': ('professional', 'b2c'),
+));
+
+@include oForms(
+	$opts: (
+		'elements': (
+			'text',
+			'radio-round',
+			'checkbox'
+		),
+		'features': (
+			'inline',
+			'disabled',
+			'suffix'
+		),
+		'themes': (
+			'professional'
+		)
+	)
+);
+
+@include oMessage($opts: (
+	'types': ('action', 'alert'),
+	'states': ('error', 'success')
+));
+
+.share-article-dialog__wrapper {
+	@include oNormaliseBoxSizing();
+	padding: oSpacingByName('s4');
+	border-radius: oSpacingByName('s1');
+	background: oColorsByName('white');
+	box-shadow: 2px 2px 8px rgba(15, 10, 46, 0.09);
+	width: 353px;
+}
+
+.share-article-dialog__header-share-article-title {
+	@include oTypographySans($scale: -1, $weight: 'medium');
+	color: oColorsByName('black');
+	margin-top: oSpacingByName('s1');
+	margin-bottom: oSpacingByName('s1');
+}
+
+.share-article-dialog__header-article-title {
+	@include oTypographyDisplay($scale: 3, $weight: 'medium');
+	color: oColorsByName('black');
+	margin-top: oSpacingByName('s2');
+	margin-bottom: oSpacingByName('s2');
+	margin-right: oSpacingByName('s1');
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.share-article-dialog__header-share-link-title {
+	@include oTypographySans($scale: 0, $weight: 'medium');
+}
+
+.share-article-dialog__create-link-button {
+	width: 100%;
+}
+
+.share-article-dialog__footer {
+	:first-child {
+		margin-top: oSpacingByName('s6');
+	}
+	:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.share-article-dialog__footer-message {
+	@include oTypographySans($scale: 0, $weight: 'regular');
+	color: oColorsByName('ft-grey');
+	margin-bottom: 0;
+}
+
+.share-article-dialog__footer-message-shared-link {
+	@include oTypographySans($scale: -1, $weight: 'regular');
+	color: oColorsMix($color: 'black', $percentage: 60);
+}
+
+.share-article-dialog__copy-confirmation-alert {
+	margin-top: oSpacingByName('s2');
+	width: 100%;
+}

--- a/components/x-gift-article/src/v2/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/v2/SharedLinkTypeSelector.jsx
@@ -1,0 +1,38 @@
+import { h } from '@financial-times/x-engine'
+import { ShareType } from '../lib/constants'
+
+export const SharedLinkTypeSelector = ({ shareType, actions, enterpriseEnabled }) => {
+	const handleChange = (event) => {
+		if (event.target.checked) {
+			// if the checkbox is checked, the user wants to share the article with non-subscribers
+			actions.showGiftUrlSection(event)
+		} else {
+			// if the checkbox is unchecked, the user wants to share the article with subscribers only
+			actions.showNonGiftUrlSection(event)
+		}
+	}
+
+	return (
+		<div
+			className={`o-forms-field o-forms-field--optional ${
+				enterpriseEnabled ? 'o-forms-field--professional' : ''
+			}`}
+			role="group"
+			aria-labelledby="share-with-non-subscribers-checkbox"
+		>
+			<span className="o-forms-input o-forms-input--checkbox">
+				<label htmlFor="share-with-non-subscribers-checkbox">
+					<input
+						className="o-forms-field--professional"
+						id="share-with-non-subscribers-checkbox"
+						name="share-with-non-subscribers-checkbox"
+						type="checkbox"
+						checked={shareType === ShareType.gift}
+						onChange={handleChange}
+					/>
+					<span className="o-forms-input__label">Give access to non-subscribers</span>
+				</label>
+			</span>
+		</div>
+	)
+}

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import BuildService from '../../../.storybook/build-service'
 
 import '../src/GiftArticle.scss'
+import '../src/v2/ShareArticleDialog.scss'
 
 const dependencies = {
 	'o-fonts': '^5.3.0'
@@ -160,3 +161,29 @@ export const ErrorResponse = (args) => {
 
 ErrorResponse.storyName = 'Error response'
 ErrorResponse.args = require('./error-response').args
+
+export const ShareArticleDialog = (args) => {
+	require('./share-article-dialog').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleDialog.storyName = 'Share article dialog'
+ShareArticleDialog.args = require('./share-article-dialog').args
+
+export const ShareArticleDialogB2C = (args) => {
+	require('./share-article-dialog-b2c').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleDialogB2C.storyName = 'Share article dialog (B2C)'
+ShareArticleDialogB2C.args = require('./share-article-dialog-b2c').args

--- a/components/x-gift-article/storybook/share-article-dialog-b2c.jsx
+++ b/components/x-gift-article/storybook/share-article-dialog-b2c.jsx
@@ -1,0 +1,47 @@
+const articleId = 'e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrl = 'https://www.ft.com/content/e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article:',
+	isFreeArticle: false,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
+	},
+	id: 'base-gift-article-static-id',
+	nativeShare: false,
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: false,
+	isGiftUrlCreated: false,
+	enterpriseEnabled: false
+}
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('path:/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`path:/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			redemptionLimit: 3,
+			remainingAllowance: 1
+		})
+		.get('path:/v1/users/me/allowance', 404)
+		.post('path:/v1/shares', {
+			url: articleUrlRedeemed,
+			redeemLimit: 120
+		})
+}

--- a/components/x-gift-article/storybook/share-article-dialog.js
+++ b/components/x-gift-article/storybook/share-article-dialog.js
@@ -1,0 +1,50 @@
+const articleId = 'e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrl = 'https://www.ft.com/content/e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article:',
+	isFreeArticle: false,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
+	},
+	id: 'base-gift-article-static-id',
+	nativeShare: false,
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: false,
+	isGiftUrlCreated: false
+}
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('path:/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`path:/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			redemptionLimit: 3,
+			remainingAllowance: 1
+		})
+		.get('path:/v1/users/me/allowance', {
+			limit: 120,
+			hasCredits: true,
+			firstTimeUser: false
+		})
+		.post('path:/v1/shares', {
+			url: articleUrlRedeemed,
+			redeemLimit: 120
+		})
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,7 @@
       },
       "devDependencies": {
         "@financial-times/o-buttons": "^7.2.2",
-        "@financial-times/o-forms": "^9.2.3",
+        "@financial-times/o-forms": "^9.11.0",
         "@financial-times/o-labels": "^6.2.2",
         "@financial-times/o-loading": "^5.2.1",
         "@financial-times/o-message": "^5.2.1",
@@ -137,7 +137,7 @@
         "@financial-times/o-banner": "^4.4.9",
         "@financial-times/o-buttons": "^7.2.2",
         "@financial-times/o-colors": "^6.6.0",
-        "@financial-times/o-forms": "^9.2.3",
+        "@financial-times/o-forms": "^9.11.0",
         "@financial-times/o-labels": "^6.2.2",
         "@financial-times/o-loading": "^5.2.1",
         "@financial-times/o-message": "^5.2.1",
@@ -2644,9 +2644,10 @@
       }
     },
     "node_modules/@financial-times/o-forms": {
-      "version": "9.6.0",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.11.0.tgz",
+      "integrity": "sha512-YIwLCRY5t9GIhysto4ztxSc6THnVPSxmfVEQtTTST4bdQ5ksxhWq/XNh+IaK/imfDUcb6edlYtuTEisY1acwyg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/lodash.uniqueid": "^4.0.7",
         "lodash.uniqueid": "^4.0.1"
@@ -2658,13 +2659,14 @@
         "@financial-times/math": "^1.0.0",
         "@financial-times/o-brand": "^4.1.0",
         "@financial-times/o-buttons": "^7.2.0",
-        "@financial-times/o-colors": "^6.4.1",
+        "@financial-times/o-colors": "^6.5.0",
         "@financial-times/o-grid": "^6.0.0",
         "@financial-times/o-icons": "^7.0.0",
         "@financial-times/o-loading": "^5.0.0",
         "@financial-times/o-normalise": "^3.3.0",
         "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-typography": "^7.0.1"
+        "@financial-times/o-typography": "^7.0.1",
+        "@financial-times/o-utils": "^2.2.0"
       }
     },
     "node_modules/@financial-times/o-grid": {
@@ -2887,9 +2889,9 @@
       }
     },
     "node_modules/@financial-times/o-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.1.1.tgz",
-      "integrity": "sha512-kZQfGjVI0A8axO3aPs8AIGStxG+jGX0FKZgjBTQAx+4Dud6vloVGJpSix+/Q7ym5rewjhDLsFVECM18Lvswbhw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.2.0.tgz",
+      "integrity": "sha512-fCm8428H6GOpNhpwNXDKCe5Gx9GPyrwgFg26UsAfVCVmyjOMFCp2TxJECP6Y+NaXJqx6ZYU4lhARxSiL2HO+5A==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -28639,7 +28641,9 @@
       "requires": {}
     },
     "@financial-times/o-forms": {
-      "version": "9.6.0",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.11.0.tgz",
+      "integrity": "sha512-YIwLCRY5t9GIhysto4ztxSc6THnVPSxmfVEQtTTST4bdQ5ksxhWq/XNh+IaK/imfDUcb6edlYtuTEisY1acwyg==",
       "dev": true,
       "requires": {
         "@types/lodash.uniqueid": "^4.0.7",
@@ -28734,9 +28738,9 @@
       }
     },
     "@financial-times/o-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.1.1.tgz",
-      "integrity": "sha512-kZQfGjVI0A8axO3aPs8AIGStxG+jGX0FKZgjBTQAx+4Dud6vloVGJpSix+/Q7ym5rewjhDLsFVECM18Lvswbhw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.2.0.tgz",
+      "integrity": "sha512-fCm8428H6GOpNhpwNXDKCe5Gx9GPyrwgFg26UsAfVCVmyjOMFCp2TxJECP6Y+NaXJqx6ZYU4lhARxSiL2HO+5A==",
       "dev": true,
       "peer": true
     },
@@ -28809,7 +28813,7 @@
       "version": "file:components/x-gift-article",
       "requires": {
         "@financial-times/o-buttons": "^7.2.2",
-        "@financial-times/o-forms": "^9.2.3",
+        "@financial-times/o-forms": "^9.11.0",
         "@financial-times/o-labels": "^6.2.2",
         "@financial-times/o-loading": "^5.2.1",
         "@financial-times/o-message": "^5.2.1",


### PR DESCRIPTION
# B2C
![Screenshot 2023-06-20 at 16 35 03](https://github.com/Financial-Times/x-dash/assets/10318770/0e37e456-8bce-4ec7-9de7-3e91f6e98beb)
![Screenshot 2023-06-20 at 16 35 07](https://github.com/Financial-Times/x-dash/assets/10318770/a6709f0f-dca6-4275-81e1-713c28c8836a)
![Screenshot 2023-06-20 at 16 35 14](https://github.com/Financial-Times/x-dash/assets/10318770/ca92cfaf-c41a-4216-8eea-d620ef5873ff)
![Screenshot 2023-06-20 at 16 35 17](https://github.com/Financial-Times/x-dash/assets/10318770/1beef88a-940b-49b8-9d4e-29b5ef8dc05f)
<img width="612" alt="Screenshot 2023-06-21 at 09 48 46" src="https://github.com/Financial-Times/x-dash/assets/10318770/e21d98a8-02e3-482a-8560-d672d7b1e447">


# B2B
![Screenshot 2023-06-20 at 16 35 46](https://github.com/Financial-Times/x-dash/assets/10318770/f20923cb-a226-40f1-9205-310c4f26b81e)
![Screenshot 2023-06-20 at 16 35 49](https://github.com/Financial-Times/x-dash/assets/10318770/c9237c8e-12ec-4889-8084-73210467b099)
![Screenshot 2023-06-20 at 16 35 54](https://github.com/Financial-Times/x-dash/assets/10318770/56e0cf45-bcc7-48f2-a4df-446511ed8694)
![Screenshot 2023-06-20 at 16 36 02](https://github.com/Financial-Times/x-dash/assets/10318770/fa14c94d-65c9-4602-95dd-9f29a21a109e)
![Screenshot 2023-06-20 at 17 06 24](https://github.com/Financial-Times/x-dash/assets/10318770/2eb93b85-bf3d-4f39-87d6-067598ab3046)



If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
