### PR TITLE
Make backToTop a Wrapper level prop for live blogs

### DIFF
--- a/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/LiveBlogPost.test.jsx
@@ -97,7 +97,8 @@ const regularPostContentPipeline = {
 	publishedDate: new Date().toISOString(),
 	articleUrl: 'Https://www.ft.com',
 	showShareButtons: true,
-	renderRichText: RichText
+	renderRichText: RichText,
+	backToTop: 'Back to top'
 }
 
 const backToTopPostSpark = {
@@ -260,6 +261,12 @@ describe('x-live-blog-post', () => {
 			const liveBlogPost = mount(<LiveBlogPost {...postWithoutByline} />)
 			expect(liveBlogPost.html()).toContain('class="x-live-blog-post__body')
 			expect(liveBlogPost.html()).toContain('<p>structured live blog body</p>')
+		})
+
+		it('renders back to top link', () => {
+			const liveBlogPost = mount(<LiveBlogPost {...regularPostContentPipeline} />)
+			expect(liveBlogPost.html()).toContain('Back to top')
+			expect(liveBlogPost.html()).toContain('</a>')
 		})
 	})
 

--- a/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
+++ b/components/x-live-blog-wrapper/src/LiveBlogWrapper.jsx
@@ -40,6 +40,7 @@ class BaseLiveBlogWrapper extends Component {
 	 * @param {string} props.id - The id of the liveblog package
 	 * @param {*} props.liveBlogWrapperElementRef
 	 * @param {PostTrackerConfig} props.postTrackerConfig - Optional config for tracking post
+	 * @param {string | Function} props.backToTop
 	 */
 	constructor(props) {
 		super(props)
@@ -146,6 +147,7 @@ class BaseLiveBlogWrapper extends Component {
 				showShareButtons={showShareButtons}
 				ad={ads[index]}
 				renderRichText={this.props.renderRichText}
+				backToTop={this.props.backToTop}
 			/>
 		))
 


### PR DESCRIPTION
Summary: Adds a `backToTop` prop to x-live-blog-wrapper

`backToTop` is currently an x-live-blog-post level argument but we don't really have a use case for this being post-level rather than live-blog level. I'm adding it in now so that I can use it in the new Content Pipeline UI that currently being developed - [relevant PR](https://github.com/Financial-Times/cp-content-pipeline/pull/383)

The prop can be either a string or a function to support the different implementations currently in place for dotcom and the App

Change is additive and non-breaking 🤞 