### PR TITLE
ENTST-448: update social share buttons

### DIFF
--- a/components/x-gift-article/package.json
+++ b/components/x-gift-article/package.json
@@ -5,7 +5,7 @@
   "main": "dist/GiftArticle.cjs.js",
   "browser": "dist/GiftArticle.es5.js",
   "module": "dist/GiftArticle.esm.js",
-  "style": "src/v2/ShareArticleDialog.scss",
+  "style": "src/main.scss",
   "scripts": {
     "build": "node rollup.js",
     "start": "node rollup.js --watch",
@@ -49,6 +49,7 @@
     "@financial-times/o-loading": "^5.2.1",
     "@financial-times/o-message": "^5.2.1",
     "@financial-times/o-normalise": "^3.2.2",
+    "@financial-times/o-share": "^9.0.2",
     "@financial-times/o-typography": "^7.4.1"
   }
 }

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -10,6 +10,8 @@ import tracking from './lib/tracking'
 import * as updaters from './lib/updaters'
 import { ShareType } from './lib/constants'
 import ShareArticleDialog from './v2/ShareArticleDialog'
+import Form from './Form'
+import oShare from '@financial-times/o-share/main'
 
 const isCopySupported =
 	typeof document !== 'undefined' && document.queryCommandSupported && document.queryCommandSupported('copy')
@@ -234,6 +236,11 @@ const withGiftFormActions = withActions(
 						showHighlightsSuccessMessage: false
 					}
 				}
+			},
+			initOShare(selector) {
+				return () => {
+					return new oShare(document.querySelector(selector))
+				}
 			}
 		}
 	},
@@ -294,9 +301,15 @@ const withGiftFormActions = withActions(
 )
 
 const BaseGiftArticle = (props) => {
+	return props.isLoading ? <Loading /> : <Form {...props} />
+}
+
+const BaseShareArticleModal = (props) => {
 	return props.isLoading ? <Loading /> : <ShareArticleDialog {...props} />
 }
 
 const GiftArticle = withGiftFormActions(BaseGiftArticle)
 
-export { GiftArticle }
+const ShareArticleModal = withGiftFormActions(BaseShareArticleModal)
+
+export { GiftArticle, ShareArticleModal }

--- a/components/x-gift-article/src/main.scss
+++ b/components/x-gift-article/src/main.scss
@@ -1,0 +1,2 @@
+@import "GiftArticle.scss";
+@import "./v2/ShareArticleDialog.scss";

--- a/components/x-gift-article/src/v2/GiftLinkSection.jsx
+++ b/components/x-gift-article/src/v2/GiftLinkSection.jsx
@@ -19,6 +19,7 @@ export const GiftLinkSection = (props) => {
 				break
 			default:
 		}
+		actions.initOShare('#social-share-buttons')
 	}
 
 	// when the gift url is created or the non-gift url is shortened, show the url section

--- a/components/x-gift-article/src/v2/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/v2/ShareArticleDialog.scss
@@ -4,6 +4,8 @@
 @import '@financial-times/o-buttons/main';
 @import '@financial-times/o-forms/main';
 @import '@financial-times/o-message/main';
+@import '@financial-times/o-share/main';
+@import '@financial-times/o-icons/main';
 
 @include oNormalise();
 @include oTypography();
@@ -35,6 +37,14 @@
 @include oMessage($opts: (
 	'types': ('action', 'alert'),
 	'states': ('error', 'success')
+));
+
+@include oShare($opts: (
+	'icons': ('twitter', 'facebook', 'linkedin', 'mail', 'whatsapp')
+));
+
+@include oIcons($opts: (
+	'icons': ('mail')
 ));
 
 .share-article-dialog__wrapper {
@@ -93,7 +103,7 @@
 
 .share-article-dialog__footer {
 	:first-child {
-		margin-top: oSpacingByName('s6');
+		margin-top: oSpacingByName('s4');
 	}
 
 	:last-child {
@@ -124,4 +134,23 @@
 
 .share-article-dialog__include-highlights {
 	margin-bottom: oSpacingByName('s1');
+}
+
+.share-article-dialog__share-via-socials-title {
+	@include oTypographySans($scale: 0, $weight: 'semibold');
+	color: oColorsByName('ft-grey');
+	margin-bottom: oSpacingByName('s3');
+}
+
+.share-article-dialog__share-via-socials-wrapper {
+	display: flex;
+	gap: oSpacingByName('s3');
+}
+
+.share-article-dialog__icon--email:hover {
+	background-color: oColorsByName('slate');
+	border-color: oColorsByName('slate');
+	svg {
+		fill: oColorsByName('white');
+	}
 }

--- a/components/x-gift-article/src/v2/SocialShareButtons.jsx
+++ b/components/x-gift-article/src/v2/SocialShareButtons.jsx
@@ -1,0 +1,104 @@
+import { h } from '@financial-times/x-engine'
+import { ShareType } from '../lib/constants'
+
+export const SocialShareButtons = ({ actions, mailtoUrl, mobileShareLinks, shareType }) => {
+	const onClickHandler = (event) => {
+		switch (shareType) {
+			case ShareType.gift:
+				actions.emailGiftUrl(event)
+				break
+			case ShareType.enterprise:
+				actions.emailEnterpriseUrl(event)
+				break
+			case ShareType.nonGift:
+				actions.emailNonGiftUrl(event)
+				break
+			default:
+		}
+	}
+
+	return (
+		<div>
+			<h4 className="share-article-dialog__share-via-socials-title">Or share via</h4>
+			<div id="social-share-buttons" data-o-component="o-share" className="o-share">
+				<ul className="share-article-dialog__share-via-socials-wrapper">
+					<li className="o-share__action">
+						<a
+							className="o-share__icon o-share__icon--twitter"
+							href={mobileShareLinks.twitter}
+							rel="noopener noreferrer"
+							data-trackable="twitter"
+						>
+							<div className="o-share__icon__image">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+									<path d="M417 720c193.2 0 298.9-160.1 298.9-298.9 0-4.5 0-9.1-.3-13.6 20.6-14.9 38.3-33.3 52.4-54.4-19.2 8.5-39.5 14.1-60.3 16.5 21.9-13.1 38.3-33.8 46.2-58.1-20.6 12.2-43.2 20.9-66.7 25.5-39.8-42.3-106.3-44.3-148.6-4.6-27.3 25.7-38.9 63.9-30.4 100.4-84.5-4.2-163.2-44.1-216.5-109.8-27.9 48-13.6 109.4 32.5 140.2-16.7-.5-33.1-5-47.7-13.1v1.3c0 50 35.3 93.1 84.3 103-15.5 4.2-31.7 4.8-47.4 1.8 13.8 42.8 53.2 72.1 98.1 72.9-37.2 29.2-83.1 45.1-130.5 45.1-8.4 0-16.7-.5-25-1.5 48 31 103.9 47.3 161 47.3" />
+								</svg>
+							</div>
+							<span className="o-share__text">Share on Twitter</span>
+						</a>
+					</li>
+					<li className="o-share__action">
+						<a
+							className="o-share__icon o-share__icon--facebook"
+							href={mobileShareLinks.facebook}
+							rel="noopener noreferrer"
+							data-trackable="facebook"
+						>
+							<div className="o-share__icon__image">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+									<path d="M643.9 342h-48.2c-37.8 0-45.1 18-45.1 44.3v58.1h90.1l-11.7 91h-78.4V769h-94V535.5H378v-91h78.6v-67.1c0-77.9 47.6-120.3 117.1-120.3 33.3 0 61.9 2.5 70.2 3.6V342z" />
+								</svg>
+							</div>
+							<span className="o-share__text">Share on Facebook</span>
+						</a>
+					</li>
+					<li className="o-share__action">
+						<a
+							className="o-share__icon o-share__icon--linkedin"
+							href={mobileShareLinks.linkedin}
+							rel="noopener noreferrer"
+							data-trackable="linkedin"
+						>
+							<div className="o-share__icon__image">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+									<path d="M264.4 426.2h106.2v341.4H264.4V426.2zm53.2-169.7c-34.1 0-61.6 27.6-61.6 61.5 0 34 27.5 61.5 61.6 61.5 33.9 0 61.5-27.6 61.5-61.5-.1-34-27.6-61.5-61.5-61.5zm323.1 161.2c-51.6 0-86.2 28.3-100.4 55.1h-1.5v-46.7H437.2v341.4h106V598.7c0-44.5 8.4-87.7 63.6-87.7 54.5 0 55.1 50.9 55.1 90.5v166H768V580.3c0-91.9-19.9-162.6-127.3-162.6z" />
+								</svg>
+							</div>
+							<span className="o-share__text">Share on LinkedIn</span>
+						</a>
+					</li>
+					<li className="o-share__action">
+						<a
+							className="o-share__icon o-share__icon--whatsapp"
+							href={mobileShareLinks.whatsapp}
+							rel="noopener noreferrer"
+							data-trackable="whatsapp"
+						>
+							<div className="o-share__icon__image">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+									<path d="M756.7 436.8c-35.6-122-152.2-196.3-279.3-178.1-116 16.7-208.2 121.5-210.6 238.6-.9 45.5 9.5 87.9 30.4 128.2 2.6 4.9 3.1 12.2 1.6 17.6-4.1 15.4-9.8 30.5-14.9 45.7L257.6 768c44.5-14.2 86.2-27.4 127.8-41.1 7.3-2.4 13.1-1.8 19.9 1.5 48.9 23.9 100.3 31.5 154.2 22.4 145.1-24.5 238.3-172.8 197.2-314zM542.2 710.9c-47.6 5.4-91.8-3.7-132.7-28.3-5.4-3.2-9.9-3.8-15.8-1.8-20.2 6.8-40.7 13.2-61 19.7-2.4.8-4.9 1.2-9.5 2.4 5.3-16.1 8.6-31.2 15.1-44.8 9.4-20.1 6.5-35.8-4.3-55.9-57.4-106-12.8-237.4 99.5-287 124.7-55.1 269.7 24.4 288.6 159.4 17.9 129.1-77.2 224.6-179.9 236.3zm98.3-144.6c2.9 1.7 5.2 7.7 4.9 11.6-1.8 27.4-19.7 46.3-47.1 50.4-4.6.7-9.3.9-14 1.4l-.3 1c-8.8-1.9-17.7-3.3-26.2-5.9-57.5-17.8-101.9-53-134.8-103.2-13.6-20.8-27.2-41.4-30.4-66.8-3.1-24.2 4.6-44.7 21.1-62.3 10.4-11 23.3-10.4 36.3-7.7 2.9.6 6.1 4.2 7.4 7.2 6.9 16.7 13.7 33.4 19.4 50.5 1.5 4.7-.5 10.8-2 16-.8 3-3.6 5.5-5.7 8.1-14.9 18.3-14.7 18.2-1.7 37.8 17.8 26.9 41.5 46.8 70.2 61.2 9 4.5 15.7 3.7 21.9-4.2 5.2-6.5 11.1-12.5 16.5-18.9 4-4.8 8.6-6 14.2-3.1 16.8 8.9 33.9 17.4 50.3 26.9" />
+								</svg>
+							</div>
+							<span className="o-share__text">Share on Whatsapp</span>
+						</a>
+					</li>
+					<li className="o-share__action">
+						<a
+							className="o-share__icon share-article-dialog__icon--email"
+							href={mailtoUrl}
+							rel="noopener noreferrer"
+							onClick={onClickHandler}
+						>
+							<div className="o-share__icon__image">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+									<path d="M768 305.1H256V719h512V305.1zm-51.2 362.6H307.2V450.1L512 573l204.8-122.9v217.6zm0-277.3L512 513.3 307.2 390.4v-34.1h409.6v34.1z" />
+								</svg>
+							</div>
+							<span className="o-share__text">Share via Email</span>
+						</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+	)
+}

--- a/components/x-gift-article/src/v2/UrlSection.jsx
+++ b/components/x-gift-article/src/v2/UrlSection.jsx
@@ -1,6 +1,7 @@
 import { h } from '@financial-times/x-engine'
 import CopyConfirmation from '../CopyConfirmation'
 import { ShareType } from '../lib/constants'
+import { SocialShareButtons } from './SocialShareButtons'
 
 export const UrlSection = (props) => {
 	const {
@@ -29,27 +30,30 @@ export const UrlSection = (props) => {
 	}
 
 	return (
-		<div
-			className="o-forms-input o-forms-input--text o-forms-input--suffix js-gift-article__url-section"
-			data-section-id={shareType + 'Link'}
-			data-trackable={shareType + 'Link'}
-		>
-			<input id="share-link" type="text" name={urlType} value={url} readOnly />
-			<button
-				className={`o-buttons o-buttons--big o-buttons--primary ${
-					enterpriseEnabled ? 'o-buttons--professional' : ''
-				}`}
-				aria-label="Copy link of the gift article to your clipboard"
-				onClick={copyLinkHandler}
+		<div>
+			<div
+				className="o-forms-input o-forms-input--text o-forms-input--suffix js-gift-article__url-section"
+				data-section-id={shareType + 'Link'}
+				data-trackable={shareType + 'Link'}
 			>
-				Copy Link
-			</button>
-			{showCopyConfirmation && (
-				<CopyConfirmation
-					hideCopyConfirmation={actions.hideCopyConfirmation}
-					isArticleSharingUxUpdates={isArticleSharingUxUpdates}
-				/>
-			)}
+				<input id="share-link" type="text" name={urlType} value={url} readOnly />
+				<button
+					className={`o-buttons o-buttons--big o-buttons--primary ${
+						enterpriseEnabled ? 'o-buttons--professional' : ''
+					}`}
+					aria-label="Copy link of the gift article to your clipboard"
+					onClick={copyLinkHandler}
+				>
+					Copy Link
+				</button>
+				{showCopyConfirmation && (
+					<CopyConfirmation
+						hideCopyConfirmation={actions.hideCopyConfirmation}
+						isArticleSharingUxUpdates={isArticleSharingUxUpdates}
+					/>
+				)}
+			</div>
+			{props.showMobileShareLinks && <SocialShareButtons {...props} />}
 		</div>
 	)
 }

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -1,10 +1,9 @@
-import { GiftArticle } from '../src/GiftArticle'
+import { GiftArticle, ShareArticleModal } from '../src/GiftArticle'
 import fetchMock from 'fetch-mock'
 import React from 'react'
 import BuildService from '../../../.storybook/build-service'
 
-import '../src/GiftArticle.scss'
-import '../src/v2/ShareArticleDialog.scss'
+import '../src/main.scss'
 
 const dependencies = {
 	'o-fonts': '^5.3.0'
@@ -14,156 +13,20 @@ export default {
 	title: 'x-gift-article'
 }
 
-// export const WithGiftCredits = (args) => {
-// 	require('./with-gift-credits').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-// WithGiftCredits.storyName = 'With gift credits'
-// WithGiftCredits.args = require('./with-gift-credits').args
-//
-// export const WithoutGiftCredits = (args) => {
-// 	require('./without-gift-credits').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-//
-// WithoutGiftCredits.storyName = 'Without gift credits'
-// WithoutGiftCredits.args = require('./without-gift-credits').args
-//
-// export const WithGiftLink = (args) => {
-// 	require('./with-gift-link').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} />
-// 		</div>
-// 	)
-// }
-//
-// WithGiftLink.storyName = 'With gift link'
-// WithGiftLink.args = require('./with-gift-link').args
-//
-// export const FreeArticle = (args) => {
-// 	require('./free-article').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-// FreeArticle.storyName = 'Free article'
-// FreeArticle.args = require('./free-article').args
-//
-// export const FreeArticleWithEnterpriseSharing = (args) => {
-// 	require('./free-article-with-enterprise-sharing').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-// FreeArticleWithEnterpriseSharing.storyName = 'Free article with enterprise sharing'
-// FreeArticleWithEnterpriseSharing.args = require('./free-article-with-enterprise-sharing').args
-//
-// export const WithEnterpriseSharing = (args) => {
-// 	require('./with-enterprise').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-// WithEnterpriseSharing.storyName = 'With enterprise sharing'
-// WithEnterpriseSharing.args = require('./with-enterprise').args
-//
-// export const WithEnterpriseSharingWithoutCredits = (args) => {
-// 	require('./with-enterprise-no-credits').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-// WithEnterpriseSharingWithoutCredits.storyName = 'With enterprise sharing (no credits)'
-// WithEnterpriseSharingWithoutCredits.args = require('./with-enterprise-no-credits').args
-//
-// export const WithEnterpriseSharingFirstTimeUser = (args) => {
-// 	require('./with-enterprise-first-time-user').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-// WithEnterpriseSharingFirstTimeUser.storyName = 'With enterprise sharing (first time user)'
-// WithEnterpriseSharingFirstTimeUser.args = require('./with-enterprise-first-time-user').args
-//
-// export const WithEnterpriseSharingRequestAccess = (args) => {
-// 	require('./with-enterprise-request-access').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-// WithEnterpriseSharingRequestAccess.storyName = 'With enterprise sharing (request access)'
-// WithEnterpriseSharingRequestAccess.args = require('./with-enterprise-request-access').args
-//
-// export const WithEnterpriseSharingLink = (args) => {
-// 	require('./with-enterprise-sharing-link').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-// WithEnterpriseSharingLink.storyName = 'With enterprise sharing (link generated)'
-// WithEnterpriseSharingLink.args = require('./with-enterprise-sharing-link').args
-//
-// export const NativeShare = (args) => {
-// 	require('./native-share').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-//
-// NativeShare.storyName = 'Native share'
-// NativeShare.args = require('./native-share').args
-//
-// export const ErrorResponse = (args) => {
-// 	require('./error-response').fetchMock(fetchMock)
-// 	return (
-// 		<div className="story-container">
-// 			{dependencies && <BuildService dependencies={dependencies} />}
-// 			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
-// 		</div>
-// 	)
-// }
-//
-// ErrorResponse.storyName = 'Error response'
-// ErrorResponse.args = require('./error-response').args
+export const WithGiftCredits = (args) => {
+	require('./with-gift-credits').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithGiftCredits.storyName = 'With gift credits'
+WithGiftCredits.args = require('./with-gift-credits').args
 
-export const ShareArticleDialog = (args) => {
-	require('./share-article-dialog').fetchMock(fetchMock)
+export const WithoutGiftCredits = (args) => {
+	require('./without-gift-credits').fetchMock(fetchMock)
 	return (
 		<div className="story-container">
 			{dependencies && <BuildService dependencies={dependencies} />}
@@ -172,11 +35,108 @@ export const ShareArticleDialog = (args) => {
 	)
 }
 
-ShareArticleDialog.storyName = 'Share article dialog (B2B)'
-ShareArticleDialog.args = require('./share-article-dialog').args
+WithoutGiftCredits.storyName = 'Without gift credits'
+WithoutGiftCredits.args = require('./without-gift-credits').args
 
-export const ShareArticleDialogB2C = (args) => {
-	require('./share-article-dialog-b2c').fetchMock(fetchMock)
+export const WithGiftLink = (args) => {
+	require('./with-gift-link').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} />
+		</div>
+	)
+}
+
+WithGiftLink.storyName = 'With gift link'
+WithGiftLink.args = require('./with-gift-link').args
+
+export const FreeArticle = (args) => {
+	require('./free-article').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+FreeArticle.storyName = 'Free article'
+FreeArticle.args = require('./free-article').args
+
+export const FreeArticleWithEnterpriseSharing = (args) => {
+	require('./free-article-with-enterprise-sharing').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+FreeArticleWithEnterpriseSharing.storyName = 'Free article with enterprise sharing'
+FreeArticleWithEnterpriseSharing.args = require('./free-article-with-enterprise-sharing').args
+
+export const WithEnterpriseSharing = (args) => {
+	require('./with-enterprise').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharing.storyName = 'With enterprise sharing'
+WithEnterpriseSharing.args = require('./with-enterprise').args
+
+export const WithEnterpriseSharingWithoutCredits = (args) => {
+	require('./with-enterprise-no-credits').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharingWithoutCredits.storyName = 'With enterprise sharing (no credits)'
+WithEnterpriseSharingWithoutCredits.args = require('./with-enterprise-no-credits').args
+
+export const WithEnterpriseSharingFirstTimeUser = (args) => {
+	require('./with-enterprise-first-time-user').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharingFirstTimeUser.storyName = 'With enterprise sharing (first time user)'
+WithEnterpriseSharingFirstTimeUser.args = require('./with-enterprise-first-time-user').args
+
+export const WithEnterpriseSharingRequestAccess = (args) => {
+	require('./with-enterprise-request-access').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharingRequestAccess.storyName = 'With enterprise sharing (request access)'
+WithEnterpriseSharingRequestAccess.args = require('./with-enterprise-request-access').args
+
+export const WithEnterpriseSharingLink = (args) => {
+	require('./with-enterprise-sharing-link').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<GiftArticle {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+WithEnterpriseSharingLink.storyName = 'With enterprise sharing (link generated)'
+WithEnterpriseSharingLink.args = require('./with-enterprise-sharing-link').args
+
+export const NativeShare = (args) => {
+	require('./native-share').fetchMock(fetchMock)
 	return (
 		<div className="story-container">
 			{dependencies && <BuildService dependencies={dependencies} />}
@@ -185,11 +145,11 @@ export const ShareArticleDialogB2C = (args) => {
 	)
 }
 
-ShareArticleDialogB2C.storyName = 'Share article dialog (B2C)'
-ShareArticleDialogB2C.args = require('./share-article-dialog-b2c').args
+NativeShare.storyName = 'Native share'
+NativeShare.args = require('./native-share').args
 
-export const ShareArticleDialogWithAdvanceSharing = (args) => {
-	require('./share-article-dialog-with-advanced-sharing').fetchMock(fetchMock)
+export const ErrorResponse = (args) => {
+	require('./error-response').fetchMock(fetchMock)
 	return (
 		<div className="story-container">
 			{dependencies && <BuildService dependencies={dependencies} />}
@@ -198,5 +158,44 @@ export const ShareArticleDialogWithAdvanceSharing = (args) => {
 	)
 }
 
-ShareArticleDialogWithAdvanceSharing.storyName = 'Share article dialog (B2B with Advanced Sharing)'
-ShareArticleDialogWithAdvanceSharing.args = require('./share-article-dialog-with-advanced-sharing').args
+ErrorResponse.storyName = 'Error response'
+ErrorResponse.args = require('./error-response').args
+
+export const ShareArticleModalB2B = (args) => {
+	require('./share-article-modal').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalB2B.storyName = 'Share article modal (B2B)'
+ShareArticleModalB2B.args = require('./share-article-modal').args
+
+export const ShareArticleModalB2C = (args) => {
+	require('./share-article-modal-b2c').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalB2C.storyName = 'Share article modal (B2C)'
+ShareArticleModalB2C.args = require('./share-article-modal-b2c').args
+
+export const ShareArticleModalWithAdvanceSharing = (args) => {
+	require('./share-article-modal-with-advanced-sharing').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalWithAdvanceSharing.storyName = 'Share article modal (B2B with Advanced Sharing)'
+ShareArticleModalWithAdvanceSharing.args = require('./share-article-modal-with-advanced-sharing').args

--- a/components/x-gift-article/storybook/share-article-modal-b2c.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2c.jsx
@@ -15,7 +15,9 @@ exports.args = {
 	nativeShare: false,
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
 	hasHighlights: false,
-	isGiftUrlCreated: false
+	isGiftUrlCreated: false,
+	enterpriseEnabled: false,
+	showMobileShareLinks: true
 }
 
 exports.fetchMock = (fetchMock) => {
@@ -38,11 +40,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionLimit: 3,
 			remainingAllowance: 1
 		})
-		.get('path:/v1/users/me/allowance', {
-			limit: 120,
-			hasCredits: true,
-			firstTimeUser: false
-		})
+		.get('path:/v1/users/me/allowance', 404)
 		.post('path:/v1/shares', {
 			url: articleUrlRedeemed,
 			redeemLimit: 120

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
@@ -16,7 +16,7 @@ exports.args = {
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
 	hasHighlights: false,
 	isGiftUrlCreated: false,
-	enterpriseEnabled: false
+	showMobileShareLinks: true
 }
 
 exports.fetchMock = (fetchMock) => {
@@ -39,7 +39,11 @@ exports.fetchMock = (fetchMock) => {
 			redemptionLimit: 3,
 			remainingAllowance: 1
 		})
-		.get('path:/v1/users/me/allowance', 404)
+		.get('path:/v1/users/me/allowance', {
+			limit: 120,
+			hasCredits: true,
+			firstTimeUser: false
+		})
 		.post('path:/v1/shares', {
 			url: articleUrlRedeemed,
 			redeemLimit: 120

--- a/components/x-gift-article/storybook/share-article-modal.js
+++ b/components/x-gift-article/storybook/share-article-modal.js
@@ -15,7 +15,8 @@ exports.args = {
 	nativeShare: false,
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
 	hasHighlights: false,
-	isGiftUrlCreated: false
+	isGiftUrlCreated: false,
+	showMobileShareLinks: true
 }
 
 exports.fetchMock = (fetchMock) => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,8 @@ module.exports = {
 		'^.+\\.jsx?$': './packages/x-babel-config/jest'
 	},
 	moduleNameMapper: {
-		'^[./a-zA-Z0-9$_-]+\\.scss$': '<rootDir>/__mocks__/styleMock.js'
+		'^[./a-zA-Z0-9$_-]+\\.scss$': '<rootDir>/__mocks__/styleMock.js',
+		'@financial-times/o-share': '<rootDir>/node_modules/@financial-times/o-share/main.js'
 	},
 	modulePathIgnorePatterns: ['<rootDir>/e2e/']
 }


### PR DESCRIPTION
https://github.com/Financial-Times/x-dash/assets/10318770/1fc45534-a356-4abb-b30a-6b73e700fc0b

![Screenshot 2023-06-27 at 09 36 35](https://github.com/Financial-Times/x-dash/assets/10318770/6efbe00c-3859-4022-860a-4dab94e1ce43)
![Screenshot 2023-06-27 at 09 36 48](https://github.com/Financial-Times/x-dash/assets/10318770/06f3b30c-3cfa-4548-ba46-e3164ba89f04)
![Screenshot 2023-06-27 at 09 36 53](https://github.com/Financial-Times/x-dash/assets/10318770/626be1e1-39fa-4141-8250-b035e8451c8f)


If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
