### PR TITLE
ENTST-451: update share messaging when highlights are received

### DIFF
--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -18,7 +18,6 @@ const baseArgs = {
 		url: articleUrl,
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }
@@ -55,6 +54,9 @@ describe('x-gift-article', () => {
 			.post('path:/v1/shares', {
 				url: articleUrlRedeemed,
 				redeemLimit: 120
+			})
+			.post('path:/v1/copy-annotations', {
+				annotationsCopyResult: []
 			})
 	})
 
@@ -161,7 +163,7 @@ describe('x-gift-article', () => {
 		expect(subject.find('#no-credit-alert')).toExist()
 	})
 
-	it('displays the social share buttons when showMobileShareLinks is true', async () => {
+	it('displays the social share buttons', async () => {
 		const subject = mount(<ShareArticleModal {...baseArgs} actionsRef={(a) => Object.assign(actions, a)} />)
 
 		await actions.activate()
@@ -171,21 +173,5 @@ describe('x-gift-article', () => {
 		subject.update()
 
 		expect(subject.find('#social-share-buttons')).toExist()
-	})
-
-	it('does not display the social share buttons when showMobileShareLinks is false', async () => {
-		const args = {
-			...baseArgs,
-			showMobileShareLinks: false
-		}
-		const subject = mount(<ShareArticleModal {...args} actionsRef={(a) => Object.assign(actions, a)} />)
-
-		await actions.activate()
-
-		await actions.shortenNonGiftUrl()
-
-		subject.update()
-
-		expect(subject.find('#social-share-buttons')).not.toExist()
 	})
 })

--- a/components/x-gift-article/package.json
+++ b/components/x-gift-article/package.json
@@ -26,7 +26,7 @@
     "@financial-times/o-forms": "^9.11.0",
     "@financial-times/o-labels": "^6.2.2",
     "@financial-times/o-loading": "^5.2.1",
-    "@financial-times/o-message": "^5.2.1",
+    "@financial-times/o-message": "5.4.2",
     "@financial-times/o-normalise": "^3.2.2",
     "@financial-times/o-typography": "^7.4.1",
     "@financial-times/x-rollup": "file:../../packages/x-rollup",
@@ -47,7 +47,7 @@
     "@financial-times/o-forms": "^9.11.0",
     "@financial-times/o-labels": "^6.2.2",
     "@financial-times/o-loading": "^5.2.1",
-    "@financial-times/o-message": "^5.2.1",
+    "@financial-times/o-message": "^5.4.2",
     "@financial-times/o-normalise": "^3.2.2",
     "@financial-times/o-share": "^9.0.2",
     "@financial-times/o-typography": "^7.4.1"

--- a/components/x-gift-article/readme.md
+++ b/components/x-gift-article/readme.md
@@ -75,7 +75,6 @@ Property                  | Type    | Required | Note
 --------------------------|---------|----------|----
 `isFreeArticle`           | Boolean | yes      | Only non gift form is displayed when this value is `true`.
 `article`                 | Object  | yes      | Must contain `id`, `title` and `url` properties
-`showMobileShareLinks`    | Boolean | no       | For ft.com on mobile sharing.
 `nativeShare`             | Boolean | no       | This is a property for App to display Native Sharing.
 `apiProtocol`             | String  | no       | The protocol to use when making requests to the gift article and URL shortening services. Ignored if `apiDomain` is not set.
 `apiDomain`               | String  | no       | The domain to use when making requests to the gift article and URL shortening services.

--- a/components/x-gift-article/src/Form.jsx
+++ b/components/x-gift-article/src/Form.jsx
@@ -60,6 +60,6 @@ export default (props) => (
 			</div>
 		)}
 
-		{props.showMobileShareLinks && <MobileShareButtons mobileShareLinks={props.mobileShareLinks} />}
+		<MobileShareButtons mobileShareLinks={props.mobileShareLinks} />
 	</div>
 )

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -273,22 +273,20 @@ const withGiftFormActions = withActions(
 				nonGift: createMailtoUrl(props.article.title, `${props.article.url}?shareType=nongift`)
 			},
 
-			mobileShareLinks: props.showMobileShareLinks
-				? {
-						facebook: `http://www.facebook.com/sharer.php?u=${encodeURIComponent(
-							props.article.url
-						)}&t=${encodeURIComponent(props.article.title)}`,
-						twitter: `https://twitter.com/intent/tweet?url=${encodeURIComponent(
-							props.article.url
-						)}&text=${encodeURIComponent(props.article.title)}&via=financialtimes`,
-						linkedin: `http://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(
-							props.article.url
-						)}&title=${encodeURIComponent(props.article.title)}&source=Financial+Times`,
-						whatsapp: `whatsapp://send?text=${encodeURIComponent(
-							props.article.title
-						)}%20-%20${encodeURIComponent(props.article.url)}`
-				  }
-				: undefined
+			mobileShareLinks: {
+				facebook: `http://www.facebook.com/sharer.php?u=${encodeURIComponent(
+					props.article.url
+				)}&t=${encodeURIComponent(props.article.title)}`,
+				twitter: `https://twitter.com/intent/tweet?url=${encodeURIComponent(
+					props.article.url
+				)}&text=${encodeURIComponent(props.article.title)}&via=financialtimes`,
+				linkedin: `http://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(
+					props.article.url
+				)}&title=${encodeURIComponent(props.article.title)}&source=Financial+Times`,
+				whatsapp: `whatsapp://send?text=${encodeURIComponent(props.article.title)}%20-%20${encodeURIComponent(
+					props.article.url
+				)}`
+			}
 		}
 
 		const expandedProps = Object.assign({}, props, initialState)
@@ -305,7 +303,7 @@ const BaseGiftArticle = (props) => {
 }
 
 const BaseShareArticleModal = (props) => {
-	return props.isLoading ? <Loading /> : <ShareArticleDialog {...props} />
+	return <ShareArticleDialog {...props} />
 }
 
 const GiftArticle = withGiftFormActions(BaseGiftArticle)

--- a/components/x-gift-article/src/v2/AdvancedSharingOptions.jsx
+++ b/components/x-gift-article/src/v2/AdvancedSharingOptions.jsx
@@ -1,15 +1,18 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from '../lib/constants'
 import { NoCreditAlert } from './NoCreditAlert'
+import { ReceivedHighlightsAlert } from './ReceivedHighlightsAlert'
 
-export const AdvancedSharingOptions = ({
-	shareType,
-	actions,
-	showHighlightsCheckbox,
-	includeHighlights,
-	enterpriseHasCredits,
-	giftCredits
-}) => {
+export const AdvancedSharingOptions = (props) => {
+	const {
+		shareType,
+		actions,
+		showHighlightsCheckbox,
+		includeHighlights,
+		enterpriseHasCredits,
+		giftCredits,
+		showHighlightsRecipientMessage
+	} = props
 	const onValueChange = (event) => {
 		if (event.target.value === ShareType.enterprise) {
 			actions.showEnterpriseUrlSection(event)
@@ -65,6 +68,7 @@ export const AdvancedSharingOptions = ({
 					other option.
 				</NoCreditAlert>
 			)}
+			{showHighlightsRecipientMessage && <ReceivedHighlightsAlert {...props} />}
 			{showHighlightsCheckbox && (
 				<div className="o-forms-input o-forms-input--checkbox o-forms-field share-article-dialog__include-highlights">
 					<label htmlFor="includeHighlights">

--- a/components/x-gift-article/src/v2/NoCreditAlert.jsx
+++ b/components/x-gift-article/src/v2/NoCreditAlert.jsx
@@ -4,7 +4,7 @@ export const NoCreditAlert = ({ children }) => {
 	return (
 		<div
 			id="no-credit-alert"
-			className="o-message o-message--alert o-message--neutral share-article-dialog__alert-no-credit"
+			className="o-message o-message--alert o-message--neutral share-article-dialog__alert"
 			data-o-component="o-message"
 		>
 			<div className="o-message__container">

--- a/components/x-gift-article/src/v2/ReceivedHighlightsAlert.jsx
+++ b/components/x-gift-article/src/v2/ReceivedHighlightsAlert.jsx
@@ -1,0 +1,44 @@
+import { h } from '@financial-times/x-engine'
+import HighlightsApiClient from '../lib/highlightsApi'
+
+export const ReceivedHighlightsAlert = ({ actions }) => {
+	const handleSaveAnnotations = async (event) => {
+		event.preventDefault()
+		const url = new URL(location.href)
+		const params = new URLSearchParams(url.search)
+		const highlightsToken = params.get('highlights')
+		const highlightsAPIClient = new HighlightsApiClient('https://enterprise-user-annotations-api.ft.com/v1')
+		const { annotationsCopyResult } = await highlightsAPIClient.copySharedHighlights(highlightsToken)
+
+		if (annotationsCopyResult) {
+			actions.saveHighlightsHandler()
+		}
+	}
+
+	return (
+		<div
+			id="received-highlights-alert"
+			className="o-message o-message--alert o-message--received-highlights share-article-dialog__alert"
+			data-o-component="o-message"
+		>
+			<div className="o-message__container">
+				<div className="o-message__content">
+					<p className="o-message__content-main">
+						If you wish to share the article with the highlights, you need to{' '}
+						{/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+						<a
+							className="o-typography-professional o-typography-link"
+							href=""
+							rel="noreferrer"
+							onClick={handleSaveAnnotations}
+						>
+							save the highlights
+						</a>{' '}
+						first.
+					</p>
+				</div>
+				<button className="o-message__close" onClick={actions.closeHighlightsRecipientMessage} />
+			</div>
+		</div>
+	)
+}

--- a/components/x-gift-article/src/v2/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/v2/ShareArticleDialog.jsx
@@ -6,7 +6,8 @@ import { AdvancedSharingBanner } from './AdvancedSharingBanner'
 
 export default (props) => {
 	return (
-		<div className="o-typography-wrapper share-article-dialog__wrapper">
+		<div className="o-typography-wrapper share-article-dialog__wrapper" hidden={props.isLoading}>
+			<div className="o-overlay__close" />
 			<AdvancedSharingBanner {...props} />
 			<main className="share-article-dialog__main">
 				<Header {...props} />

--- a/components/x-gift-article/src/v2/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/v2/ShareArticleDialog.scss
@@ -40,6 +40,14 @@
 	'layouts': ('inner')
 ));
 
+@include oMessageAddState(
+	$name: 'received-highlights',
+	$opts: (
+		'foreground-color': 'slate',
+		'background-color': whitesmoke,
+		'icon': 'info',
+	), $types: ('action', 'alert'));
+
 @include oShare($opts: (
 	'icons': ('twitter', 'facebook', 'linkedin', 'mail', 'whatsapp')
 ));
@@ -54,8 +62,8 @@
 	background: oColorsByName('white');
 	box-shadow: 2px 2px 8px rgba(15, 10, 46, 0.09);
 	width: oSpacingByName('s8') * 11; // 32 * 11 = 352px
+	margin: 0;
 }
-
 
 .share-article-dialog__banner-strip {
 	background: oColorsByName('slate');
@@ -68,8 +76,11 @@
 	@include oTypographySans($scale: 0, $weight: 'medium');
 	color: oColorsMix($color: 'black', $percentage: 70);
 	text-transform: uppercase;
-	padding: oSpacingByName('s4') oSpacingByName('s4') 0;
-	margin: 0;
+	padding-left: oSpacingByName('s4');
+	padding-right: oSpacingByName('s4');
+	margin: oSpacingByName('s2') 0 0;
+	line-height: 24px;
+	letter-spacing: 1px;
 }
 
 .share-article-dialog__main {
@@ -95,7 +106,13 @@
 }
 
 .share-article-dialog__header-share-link-title {
-	@include oTypographySans($scale: 0, $weight: 'medium');
+	@include oTypographySans($scale: 0, $weight: 'semibold');
+}
+
+.share-article-dialog__non-subscriber-checkbox {
+	:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .share-article-dialog__create-link-button {
@@ -104,7 +121,7 @@
 
 .share-article-dialog__footer {
 	:first-child {
-		margin-top: oSpacingByName('s4');
+		margin-top: oSpacingByName('s6');
 	}
 
 	:last-child {
@@ -141,6 +158,7 @@
 	@include oTypographySans($scale: 0, $weight: 'semibold');
 	color: oColorsByName('ft-grey');
 	margin-bottom: oSpacingByName('s3');
+	margin-top: oSpacingByName('s3');
 }
 
 .share-article-dialog__share-via-socials-wrapper {
@@ -156,6 +174,6 @@
 	}
 }
 
-.share-article-dialog__alert-no-credit {
+.share-article-dialog__alert {
 	margin-top: oSpacingByName('s4');
 }

--- a/components/x-gift-article/src/v2/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/v2/SharedLinkTypeSelector.jsx
@@ -39,7 +39,7 @@ export const SharedLinkTypeSelector = (props) => {
 
 	return (
 		<div
-			className={`o-forms-field o-forms-field--optional ${
+			className={`o-forms-field o-forms-field--optional share-article-dialog__non-subscriber-checkbox ${
 				enterpriseEnabled ? 'o-forms-field--professional' : ''
 			}`}
 			role="group"
@@ -64,7 +64,7 @@ export const SharedLinkTypeSelector = (props) => {
 					You’ve run out of sharing credits, which you need to share articles with FT non-subscribers. Use
 					another option or{' '}
 					<a
-						href="mailto:customer.success@ft.com"
+						href={`${enterpriseEnabled ? 'mailto:customer.success@ft.com' : 'mailto:help@ft.com'}`}
 						rel="noreferrer"
 						target="_blank"
 						data-trackable="enterprise-out-of-credits"

--- a/components/x-gift-article/src/v2/SocialShareButtons.jsx
+++ b/components/x-gift-article/src/v2/SocialShareButtons.jsx
@@ -1,7 +1,13 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from '../lib/constants'
 
-export const SocialShareButtons = ({ actions, mailtoUrl, mobileShareLinks, shareType }) => {
+export const SocialShareButtons = ({
+	actions,
+	mailtoUrl,
+	mobileShareLinks,
+	shareType,
+	enterpriseEnabled
+}) => {
 	const onClickHandler = (event) => {
 		switch (shareType) {
 			case ShareType.gift:
@@ -84,7 +90,9 @@ export const SocialShareButtons = ({ actions, mailtoUrl, mobileShareLinks, share
 					</li>
 					<li className="o-share__action">
 						<a
-							className="o-share__icon share-article-dialog__icon--email"
+							className={`o-share__icon ${
+								enterpriseEnabled ? 'share-article-dialog__icon--email' : 'o-share__icon--mail'
+							}`}
 							href={mailtoUrl}
 							rel="noopener noreferrer"
 							onClick={onClickHandler}

--- a/components/x-gift-article/src/v2/UrlSection.jsx
+++ b/components/x-gift-article/src/v2/UrlSection.jsx
@@ -53,7 +53,7 @@ export const UrlSection = (props) => {
 					/>
 				)}
 			</div>
-			{props.showMobileShareLinks && <SocialShareButtons {...props} />}
+			<SocialShareButtons {...props} />
 		</div>
 	)
 }

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -254,3 +254,18 @@ ShareArticleModalWithAdvancedSharingNoEnterpriseCredits.storyName =
 	'Share article modal (AS no enterprise credits)'
 ShareArticleModalWithAdvancedSharingNoEnterpriseCredits.args =
 	require('./share-article-modal-with-advanced-sharing-no-enterprise-credits').args
+
+export const ShareArticleModalWithAdvancedSharingSaveHighlightsMessage = (args) => {
+	require('./share-article-modal-with-advanced-sharing-save-highlights-message').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalWithAdvancedSharingSaveHighlightsMessage.storyName =
+	'Share article modal (AS save highlights message)'
+ShareArticleModalWithAdvancedSharingSaveHighlightsMessage.args =
+	require('./share-article-modal-with-advanced-sharing-save-highlights-message').args

--- a/components/x-gift-article/storybook/share-article-modal-b2c-no-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2c-no-credits.jsx
@@ -11,7 +11,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }

--- a/components/x-gift-article/storybook/share-article-modal-b2c.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2c.jsx
@@ -12,12 +12,7 @@ exports.args = {
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
 	id: 'base-gift-article-static-id',
-	nativeShare: false,
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
-	hasHighlights: false,
-	isGiftUrlCreated: false,
-	enterpriseEnabled: false,
-	showMobileShareLinks: true
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }
 
 exports.fetchMock = (fetchMock) => {

--- a/components/x-gift-article/storybook/share-article-modal-no-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-no-credits.jsx
@@ -11,7 +11,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-gift-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-gift-credits.jsx
@@ -11,7 +11,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-save-highlights-message.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-save-highlights-message.jsx
@@ -12,7 +12,9 @@ exports.args = {
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
 	id: 'base-gift-article-static-id',
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	showHighlightsCheckbox: false,
+	showHighlightsRecipientMessage: true
 }
 
 exports.fetchMock = (fetchMock) => {
@@ -37,11 +39,14 @@ exports.fetchMock = (fetchMock) => {
 		})
 		.get('path:/v1/users/me/allowance', {
 			limit: 120,
-			hasCredits: false,
+			hasCredits: true,
 			firstTimeUser: false
 		})
 		.post('path:/v1/shares', {
 			url: articleUrlRedeemed,
 			redeemLimit: 120
+		})
+		.post('path:/v1/copy-annotations', {
+			annotationsCopyResult: []
 		})
 }

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
@@ -12,11 +12,7 @@ exports.args = {
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
 	id: 'base-gift-article-static-id',
-	nativeShare: false,
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
-	hasHighlights: false,
-	isGiftUrlCreated: false,
-	showMobileShareLinks: true
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }
 
 exports.fetchMock = (fetchMock) => {

--- a/components/x-gift-article/storybook/share-article-modal.js
+++ b/components/x-gift-article/storybook/share-article-modal.js
@@ -12,11 +12,7 @@ exports.args = {
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
 	id: 'base-gift-article-static-id',
-	nativeShare: false,
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
-	hasHighlights: false,
-	isGiftUrlCreated: false,
-	showMobileShareLinks: true
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }
 
 exports.fetchMock = (fetchMock) => {

--- a/components/x-gift-article/storybook/with-enterprise-first-time-user.js
+++ b/components/x-gift-article/storybook/with-enterprise-first-time-user.js
@@ -11,7 +11,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Title Title Title Title'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }

--- a/components/x-gift-article/storybook/with-enterprise-no-credits.js
+++ b/components/x-gift-article/storybook/with-enterprise-no-credits.js
@@ -11,7 +11,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Title Title Title Title'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }

--- a/components/x-gift-article/storybook/with-enterprise-request-access.js
+++ b/components/x-gift-article/storybook/with-enterprise-request-access.js
@@ -11,7 +11,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Title Title Title Title'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }

--- a/components/x-gift-article/storybook/with-enterprise-sharing-link.js
+++ b/components/x-gift-article/storybook/with-enterprise-sharing-link.js
@@ -12,7 +12,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Title Title Title Title'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
 	shareType: 'enterprise'

--- a/components/x-gift-article/storybook/with-enterprise.js
+++ b/components/x-gift-article/storybook/with-enterprise.js
@@ -11,7 +11,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Title Title Title Title'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
 	hasHighlights: true

--- a/components/x-gift-article/storybook/with-gift-credits.js
+++ b/components/x-gift-article/storybook/with-gift-credits.js
@@ -11,7 +11,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Title Title Title Title'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
 }

--- a/components/x-gift-article/storybook/with-gift-link.js
+++ b/components/x-gift-article/storybook/with-gift-link.js
@@ -12,7 +12,6 @@ exports.args = {
 		url: articleUrl,
 		title: 'Title Title Title Title'
 	},
-	showMobileShareLinks: true,
 	id: 'base-gift-article-static-id'
 }
 


### PR DESCRIPTION
https://github.com/Financial-Times/x-dash/assets/10318770/d5c8dc20-a454-4236-bfe4-41812351c01d 

![Screenshot 2023-07-03 at 12 21 02](https://github.com/Financial-Times/x-dash/assets/10318770/181d152f-a5b7-4c97-9f05-a799f3ad3117)

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
