### PR TITLE
fix: highlights checkbox displaying when highlights are not selected

### DIFF
--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -19,7 +19,8 @@ const baseArgs = {
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
 	id: 'base-gift-article-static-id',
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: true
 }
 
 describe('x-gift-article', () => {

--- a/components/x-gift-article/src/v2/AdvancedSharingOptions.jsx
+++ b/components/x-gift-article/src/v2/AdvancedSharingOptions.jsx
@@ -11,7 +11,8 @@ export const AdvancedSharingOptions = (props) => {
 		includeHighlights,
 		enterpriseHasCredits,
 		giftCredits,
-		showHighlightsRecipientMessage
+		showHighlightsRecipientMessage,
+		hasHighlights
 	} = props
 	const onValueChange = (event) => {
 		if (event.target.value === ShareType.enterprise) {
@@ -69,7 +70,7 @@ export const AdvancedSharingOptions = (props) => {
 				</NoCreditAlert>
 			)}
 			{showHighlightsRecipientMessage && <ReceivedHighlightsAlert {...props} />}
-			{showHighlightsCheckbox && (
+			{showHighlightsCheckbox && hasHighlights && (
 				<div className="o-forms-input o-forms-input--checkbox o-forms-field share-article-dialog__include-highlights">
 					<label htmlFor="includeHighlights">
 						<input

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-free-article.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-free-article.jsx
@@ -12,7 +12,8 @@ exports.args = {
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
 	id: 'base-gift-article-static-id',
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: true
 }
 
 exports.fetchMock = (fetchMock) => {

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-enterprise-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-enterprise-credits.jsx
@@ -12,7 +12,8 @@ exports.args = {
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
 	id: 'base-gift-article-static-id',
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: true
 }
 
 exports.fetchMock = (fetchMock) => {

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-gift-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-gift-credits.jsx
@@ -12,7 +12,8 @@ exports.args = {
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
 	id: 'base-gift-article-static-id',
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: true
 }
 
 exports.fetchMock = (fetchMock) => {

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-save-highlights-message.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-save-highlights-message.jsx
@@ -13,6 +13,7 @@ exports.args = {
 	},
 	id: 'base-gift-article-static-id',
 	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: false,
 	showHighlightsCheckbox: false,
 	showHighlightsRecipientMessage: true
 }

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
@@ -12,7 +12,8 @@ exports.args = {
 		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
 	},
 	id: 'base-gift-article-static-id',
-	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: true
 }
 
 exports.fetchMock = (fetchMock) => {


### PR DESCRIPTION
Fix to issue found in testing which enabled users to select 'share highlights' even when there are no highlights on the article

https://github.com/Financial-Times/x-dash/assets/10318770/013e1534-3770-4e77-a80e-38b816ca4831


ENTST-547

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
