### PR TITLE
ENTST-552: update no credits copy

### DIFF
--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -62,8 +62,8 @@ export const SharedLinkTypeSelector = (props) => {
 			</span>
 			{!canShareWithNonSubscribers && (
 				<NoCreditAlert>
-					You’ve run out of sharing credits, which you need to share articles with FT non-subscribers. Use
-					another option or{' '}
+					You’ve run out of sharing credits for non-subscribers. You can still share it with FT subscribers
+					via a link or{' '}
 					<a
 						href={`${enterpriseEnabled ? 'mailto:customer.success@ft.com' : 'mailto:help@ft.com'}`}
 						rel="noreferrer"


### PR DESCRIPTION
The alert text for when a user runs out of sharing credits has been updated as shown below

| before | after |
|---|---|
| ![Screenshot 2023-07-10 at 11 49 43](https://github.com/Financial-Times/x-dash/assets/10318770/a9ad7207-ad52-4196-bec3-44a3623bf346) | ![Screenshot 2023-07-10 at 11 47 56](https://github.com/Financial-Times/x-dash/assets/10318770/e62e40fe-fc1f-4da4-b150-b4d7bad2c0f1) |
| ![Screenshot 2023-07-10 at 11 49 45](https://github.com/Financial-Times/x-dash/assets/10318770/7df0a141-fda8-42d5-b51a-3439d91f1456) | ![Screenshot 2023-07-10 at 11 48 00](https://github.com/Financial-Times/x-dash/assets/10318770/be95bbb7-9899-4287-b5ed-806626a53f03) |


If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
