### PR TITLE
ENTST-553: mail icon hover state

### DIFF
--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -166,12 +166,10 @@
 	gap: oSpacingByName('s3');
 }
 
-.share-article-dialog__icon--email:hover {
+.o-share__icon.share-article-dialog__icon--email:hover {
 	background-color: oColorsByName('slate');
 	border-color: oColorsByName('slate');
-	svg {
-		fill: oColorsByName('white');
-	}
+	color: oColorsByName('white');
 }
 
 .share-article-dialog__alert {


### PR DESCRIPTION
This PR addresses the mail icon hover state issue affecting B2B users on `next-article`, see screenshots below for illustration.

| before | after |
| ---| --- |
| ![Screenshot 2023-07-10 at 16 24 37](https://github.com/Financial-Times/next-article/assets/10318770/ff0ec022-c598-4c92-bd00-c6cb5787d9f1) | ![Screenshot 2023-07-10 at 16 25 03](https://github.com/Financial-Times/next-article/assets/10318770/f00eaf82-7a21-45b0-9f9c-69ec063cddc8) |

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
