### PR TITLE
ENTST-557: fix "Copy link" cta text casing

### DIFF
--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -44,7 +44,7 @@ export const UrlSection = (props) => {
 					aria-label="Copy link of the gift article to your clipboard"
 					onClick={copyLinkHandler}
 				>
-					Copy Link
+					Copy link
 				</button>
 				{showCopyConfirmation && (
 					<CopyConfirmation


### PR DESCRIPTION
| before | after|
| --- | --- |
| ![Screenshot 2023-07-11 at 10 52 29](https://github.com/Financial-Times/x-dash/assets/10318770/13a2683e-989b-4feb-8e2c-0a3ec47f69b3) | ![Screenshot 2023-07-11 at 10 52 36](https://github.com/Financial-Times/x-dash/assets/10318770/c29df766-7cf1-4c92-aaf6-43ca4da23f3d) |

If this is your first `x-dash` pull request please familiarise yourself with the [contribution guide](https://github.com/Financial-Times/x-dash/blob/HEAD/contribution.md) before submitting.

## If you're creating a component:

- Add the `Component` label to this Pull Request
- If this will be a long-lived PR, consider using smaller PRs targeting this branch for individual features, so your team can review them without involving x-dash maintainers
  - If you're using this workflow, create a Label and a Project for your component and ensure all small PRs are attached to them. Add the Project to the [Components board](https://github.com/Financial-Times/x-dash/projects/4)
    - put a link to this Pull Request in the Project description
    - set the Project to `Automated kanban with reviews`, but remove the `To Do` column
  - If you're not using this workflow, add this Pull Request to the [Components board](https://github.com/Financial-Times/x-dash/projects/4).

## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
