### PR TITLE
CPP-1103 Change x-teaser's props to match content-pipeline's Content

### DIFF
--- a/components/x-teaser-list/storybook/content-items.json
+++ b/components/x-teaser-list/storybook/content-items.json
@@ -4,33 +4,6 @@
     "url": "https://www.ft.com/content/65867e26-d203-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/65867e26-d203-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Brexit Briefing",
-      "type": "BRAND",
-      "url": "https://www.ft.com/brexit-briefing",
-      "relativeUrl": "/brexit-briefing"
-    },
-    "metaAltLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
     "title": "Is December looming as the new Brexit deadline?",
     "standfirst": "As Theresa May prepares to meet EU leaders, the prospect looks increasingly likely",
     "altStandfirst": null,
@@ -42,33 +15,42 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
+        "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+        "prefLabel": "Brexit Briefing",
+        "type": "BRAND",
+        "url": "https://www.ft.com/brexit-briefing",
+        "relativeUrl": "/brexit-briefing"
+      },
+      "metaAltLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      }
+    }
   },
   {
     "id": "93614586-d1f1-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/93614586-d1f1-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/93614586-d1f1-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "May seeks to overcome deadlock after Brexit setback",
     "standfirst": "UK and EU consider extending transition deal to defuse dispute over Irish border backstop",
     "altStandfirst": null,
@@ -80,33 +62,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "d4e80114-d1ee-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Midsized UK businesses turn sour on Brexit",
     "standfirst": "Quarterly survey shows more companies now believe Brexit will damage their business than help them",
     "altStandfirst": null,
@@ -118,33 +102,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "6582b8ce-d175-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Barnier open to extending Brexit transition by a year",
     "standfirst": "In return, Theresa May must accept ‘two-tier’ backstop to avoid a hard Irish border",
     "altStandfirst": null,
@@ -156,46 +142,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "7ab52d68-d11a-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": true,
-      "isOpinion": true,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": "Inside Business",
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "3f97b34f-8fa3-43fd-8326-d8b0fde2a1f3",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "Sarah Gordon",
-      "type": "PERSON",
-      "attributes": [
-        {
-          "key": "headshot",
-          "value": "fthead-v1:sarah-gordon"
-        }
-      ],
-      "url": "https://www.ft.com/sarah-gordon",
-      "relativeUrl": "/sarah-gordon"
-    },
-    "metaAltLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
     "title": "UK lets down business with lack of Brexit advice",
     "standfirst": "Governments should be more concerned about SMEs: if supply chains falter, so will economic growth",
     "altStandfirst": null,
@@ -207,33 +182,48 @@
       "height": 1152
     },
     "headshot": "fthead-v1:sarah-gordon",
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": true,
+        "isOpinion": true,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": "Inside Business",
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "3f97b34f-8fa3-43fd-8326-d8b0fde2a1f3",
+        "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+        "prefLabel": "Sarah Gordon",
+        "type": "PERSON",
+        "attributes": [
+          {
+            "key": "headshot",
+            "value": "fthead-v1:sarah-gordon"
+          }
+        ],
+        "url": "https://www.ft.com/sarah-gordon",
+        "relativeUrl": "/sarah-gordon"
+      },
+      "metaAltLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      }
+    }
   },
   {
     "id": "868cedae-d18a-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/868cedae-d18a-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/868cedae-d18a-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "243243d9-de4b-4869-909b-fab711125624",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Global trade",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/global-trade",
-      "relativeUrl": "/global-trade",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Trump looks to start formal US-UK trade talks",
     "standfirst": "White House makes London a priority ‘as soon as it is ready’ after Brexit",
     "altStandfirst": null,
@@ -245,33 +235,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "243243d9-de4b-4869-909b-fab711125624",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Global trade",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/global-trade",
+        "relativeUrl": "/global-trade",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "c276c8a2-d159-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "House of Commons UK",
-      "type": "ORGANISATION",
-      "url": "https://www.ft.com/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "relativeUrl": "/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Bercow faces mounting calls to resign",
     "standfirst": "Maria Miller says Speaker needs to step down immediately to ‘drive culture change’",
     "altStandfirst": null,
@@ -283,40 +275,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "House of Commons UK",
+        "type": "ORGANISATION",
+        "url": "https://www.ft.com/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "relativeUrl": "/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "a1566658-d12e-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/a1566658-d12e-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/a1566658-d12e-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": true,
-      "isOpinion": true,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": "The FT View",
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "741cc381-76a8-382b-a621-fc8eca53d69f",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "The editorial board",
-      "type": "PERSON",
-      "url": "https://www.ft.com/ft-view",
-      "relativeUrl": "/ft-view"
-    },
-    "metaAltLink": {
-      "id": "fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "House of Commons UK",
-      "type": "ORGANISATION",
-      "url": "https://www.ft.com/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "relativeUrl": "/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "isDisplayTag": true
-    },
     "title": "A culture shift to clear Westminster’s toxic air",
     "standfirst": "Speaker John Bercow should take responsibility — and go now",
     "altStandfirst": null,
@@ -327,33 +314,42 @@
       "width": 2048,
       "height": 1152
     },
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": true,
+        "isOpinion": true,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": "The FT View",
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "741cc381-76a8-382b-a621-fc8eca53d69f",
+        "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+        "prefLabel": "The editorial board",
+        "type": "PERSON",
+        "url": "https://www.ft.com/ft-view",
+        "relativeUrl": "/ft-view"
+      },
+      "metaAltLink": {
+        "id": "fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "House of Commons UK",
+        "type": "ORGANISATION",
+        "url": "https://www.ft.com/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "relativeUrl": "/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "isDisplayTag": true
+      }
+    }
   },
   {
     "id": "f9f69a2c-d141-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "EU demands UK break Brexit impasse",
     "standfirst": "May tells Eurosceptics acceptable deal is in sight as Barnier says ‘Brits need more time’",
     "altStandfirst": null,
@@ -365,40 +361,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "eb6062c2-d13c-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Brexit Briefing",
-      "type": "BRAND",
-      "url": "https://www.ft.com/brexit-briefing",
-      "relativeUrl": "/brexit-briefing"
-    },
-    "metaAltLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
     "title": "Brexit, Scotland and the threat to constitutional unity",
     "standfirst": "Scottish Tories fear that possible arrangements for Northern Ireland threaten the union itself",
     "altStandfirst": null,
@@ -410,33 +401,42 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
+        "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+        "prefLabel": "Brexit Briefing",
+        "type": "BRAND",
+        "url": "https://www.ft.com/brexit-briefing",
+        "relativeUrl": "/brexit-briefing"
+      },
+      "metaAltLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      }
+    }
   },
   {
     "id": "d7472b20-d148-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/d7472b20-d148-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/d7472b20-d148-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "EU’s Tusk to ask UK for ‘concrete proposals’ to end Brexit impasse",
     "altStandfirst": null,
     "publishedDate": "2018-10-16T13:49:36.000Z",
@@ -447,34 +447,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "10ee3a20-d13b-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "FIGI": "BBG000BWQFY7",
-      "id": "1120e446-6695-4e49-91e6-fd1f7698388e",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Wells Fargo",
-      "type": "ORGANISATION",
-      "url": "https://www.ft.com/stream/1120e446-6695-4e49-91e6-fd1f7698388e",
-      "relativeUrl": "/stream/1120e446-6695-4e49-91e6-fd1f7698388e",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Wells Fargo applies for licence in France as part of Brexit strategy",
     "altStandfirst": null,
     "publishedDate": "2018-10-16T12:16:17.000Z",
@@ -485,33 +486,36 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "FIGI": "BBG000BWQFY7",
+        "id": "1120e446-6695-4e49-91e6-fd1f7698388e",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Wells Fargo",
+        "type": "ORGANISATION",
+        "url": "https://www.ft.com/stream/1120e446-6695-4e49-91e6-fd1f7698388e",
+        "relativeUrl": "/stream/1120e446-6695-4e49-91e6-fd1f7698388e",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "6bd7f80e-d11d-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "c4c9204f-8335-42c3-9415-c2c8cd971125",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "UK welfare reform",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/stream/c4c9204f-8335-42c3-9415-c2c8cd971125",
-      "relativeUrl": "/stream/c4c9204f-8335-42c3-9415-c2c8cd971125",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Rollout of controversial UK welfare reform faces fresh delay",
     "standfirst": "Universal credit system not expected to be fully operational until December 2023",
     "altStandfirst": null,
@@ -523,33 +527,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "c4c9204f-8335-42c3-9415-c2c8cd971125",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "UK welfare reform",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/stream/c4c9204f-8335-42c3-9415-c2c8cd971125",
+        "relativeUrl": "/stream/c4c9204f-8335-42c3-9415-c2c8cd971125",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "1969887a-d11e-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/1969887a-d11e-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/1969887a-d11e-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "466a4700-307f-47cc-83f1-c5f97a172232",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Pound Sterling",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
-      "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Pound rallies after upbeat wage growth reading",
     "standfirst": "Analysts remain cautious despite optimistic data",
     "altStandfirst": null,
@@ -557,33 +563,35 @@
     "firstPublishedDate": "2018-10-16T09:18:12.000Z",
     "image": {},
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Pound Sterling",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+        "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "dab8bfd2-ce3f-11e8-9fe5-24ad351828ab",
     "url": "https://www.ft.com/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab",
     "relativeUrl": "/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "9c0f3107-a34f-4319-a6a6-3101ac88b50d",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "UK politics & policy",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/world/uk/politics",
-      "relativeUrl": "/world/uk/politics",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Problem gambling shake-up set to be brought forward",
     "standfirst": "Blow for bookmakers as ministers seek to speed up start of fixed-odds betting terminals limits",
     "altStandfirst": null,
@@ -595,32 +603,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "9c0f3107-a34f-4319-a6a6-3101ac88b50d",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "UK politics & policy",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/world/uk/politics",
+        "relativeUrl": "/world/uk/politics",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "6b32f2c1-da43-4e19-80b9-8aef4ab640d7",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Technology sector",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/companies/technology",
-      "relativeUrl": "/companies/technology"
-    },
-    "metaAltLink": null,
     "title": "Crypto exchange Coinbase sets up Brexit contingency",
     "standfirst": "US digital start-up to scale up EU operations with new Dublin branch",
     "altStandfirst": null,
@@ -632,32 +643,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "6b32f2c1-da43-4e19-80b9-8aef4ab640d7",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Technology sector",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/companies/technology",
+        "relativeUrl": "/companies/technology"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "2e407a74-d06a-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "82645c31-4426-4ef5-99c9-9df6e0940c00",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "World",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/world",
-      "relativeUrl": "/world"
-    },
-    "metaAltLink": null,
     "title": "EU gives UK 24 hour Brexit breathing space",
     "standfirst": "Theresa May says deal achievable but Britain cannot be kept in backstop indefinitely",
     "altStandfirst": null,
@@ -669,64 +682,68 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "82645c31-4426-4ef5-99c9-9df6e0940c00",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "World",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/world",
+        "relativeUrl": "/world"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "434dc8e2-d09f-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/434dc8e2-d09f-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/434dc8e2-d09f-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit"
-    },
-    "metaAltLink": null,
     "title": "EC’s Tusk warns no-deal Brexit ‘is more likely than ever before’",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T17:30:48.000Z",
     "firstPublishedDate": "2018-10-15T17:30:48.000Z",
     "image": {},
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "fadfb212-d091-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/fadfb212-d091-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/fadfb212-d091-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit"
-    },
-    "metaAltLink": null,
     "title": "Barnier plan no solution to Irish border, says Foster",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T16:06:36.000Z",
@@ -737,32 +754,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "79939f94-c320-11e8-8d55-54197280d3f7",
     "url": "https://www.ft.com/content/79939f94-c320-11e8-8d55-54197280d3f7",
     "relativeUrl": "/content/79939f94-c320-11e8-8d55-54197280d3f7",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": "Explainer",
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "466a4700-307f-47cc-83f1-c5f97a172232",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Pound Sterling",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
-      "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232"
-    },
-    "metaAltLink": null,
     "title": "Pound timeline: from the 1970s to Brexit crunch",
     "standfirst": "Sterling has experienced several periods of volatility in the past 48 years",
     "altStandfirst": null,
@@ -774,32 +793,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": "Explainer",
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Pound Sterling",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+        "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "bfffa642-d079-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/bfffa642-d079-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/bfffa642-d079-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit"
-    },
-    "metaAltLink": null,
     "title": "Brexit talks could drag into December warns Ireland’s Varadkar",
     "standfirst": "Taoiseach says he always believed a deal this month was unlikely",
     "altStandfirst": null,
@@ -811,39 +832,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "82ae2756-d073-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/82ae2756-d073-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/82ae2756-d073-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Brexit Briefing",
-      "type": "BRAND",
-      "url": "https://www.ft.com/brexit-briefing",
-      "relativeUrl": "/brexit-briefing"
-    },
-    "metaAltLink": {
-      "id": "d7253b94-b248-4022-af1e-e99c15d0c1b6",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "UK trade",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/uk-trade",
-      "relativeUrl": "/uk-trade"
-    },
     "title": "Crisis or choreography over Brexit?",
     "standfirst": "While ministers haggle, company bosses press the button on expensive no-deal planning",
     "altStandfirst": null,
@@ -855,32 +871,41 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
+        "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+        "prefLabel": "Brexit Briefing",
+        "type": "BRAND",
+        "url": "https://www.ft.com/brexit-briefing",
+        "relativeUrl": "/brexit-briefing"
+      },
+      "metaAltLink": {
+        "id": "d7253b94-b248-4022-af1e-e99c15d0c1b6",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "UK trade",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/uk-trade",
+        "relativeUrl": "/uk-trade"
+      }
+    }
   },
   {
     "id": "a8181102-ce1e-11e8-9fe5-24ad351828ab",
     "url": "https://www.ft.com/content/a8181102-ce1e-11e8-9fe5-24ad351828ab",
     "relativeUrl": "/content/a8181102-ce1e-11e8-9fe5-24ad351828ab",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "d1252624-8645-438b-b521-9244aebdc99e",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Industrials",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/companies/industrials",
-      "relativeUrl": "/companies/industrials"
-    },
-    "metaAltLink": null,
     "title": "UK shipyards to submit bids to build 5 warships",
     "standfirst": "MoD restarts competition despite industry’s concerns over budget and timing",
     "altStandfirst": null,
@@ -892,32 +917,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "d1252624-8645-438b-b521-9244aebdc99e",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Industrials",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/companies/industrials",
+        "relativeUrl": "/companies/industrials"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "9b3b6d2e-d064-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit"
-    },
-    "metaAltLink": null,
     "title": "May to address UK parliament on state of Brexit talks",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T10:41:21.000Z",
@@ -928,32 +955,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "ed665ed8-cdfd-11e8-9fe5-24ad351828ab",
     "url": "https://www.ft.com/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab",
     "relativeUrl": "/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "6cc4c4ed-ef61-4c71-a5bb-f454fb5010a8",
-      "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
-      "prefLabel": "UK business & economy",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/uk-business-economy",
-      "relativeUrl": "/uk-business-economy"
-    },
-    "metaAltLink": null,
     "title": "Bradford hospital launches AI powered command centre",
     "standfirst": "Collaboration with GE Healthcare to create hub monitoring patients to make better use of resources",
     "altStandfirst": null,
@@ -965,76 +994,101 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "6cc4c4ed-ef61-4c71-a5bb-f454fb5010a8",
+        "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+        "prefLabel": "UK business & economy",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/uk-business-economy",
+        "relativeUrl": "/uk-business-economy"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "7c6b9fbb-ad93-34c5-b19b-ea79ffc5f426",
     "url": "http://ftalphaville.ft.com/marketslive/2018-10-15/",
     "relativeUrl": "http://ftalphaville.ft.com/marketslive/2018-10-15/",
     "type": "article",
-    "indicators": {
-      "isColumn": true,
-      "isOpinion": true,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "registered"
-    },
-    "metaPrefixText": "FT Alphaville",
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "602c702b-31fe-4116-a203-747c7c737eb7",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "Bryce Elder",
-      "type": "PERSON",
-      "url": "https://www.ft.com/markets/bryce-elder",
-      "relativeUrl": "/markets/bryce-elder"
-    },
-    "metaAltLink": {
-      "id": "c91b1fad-1097-468b-be82-9a8ff717d54c",
-      "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
-      "prefLabel": "Markets",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/markets",
-      "relativeUrl": "/markets"
-    },
     "title": "Markets Live: Monday, 15th October 2018",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T10:01:26.000Z",
     "firstPublishedDate": "2018-10-15T10:01:26.000Z",
     "image": {},
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": true,
+        "isOpinion": true,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "registered"
+      },
+      "metaPrefixText": "FT Alphaville",
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "602c702b-31fe-4116-a203-747c7c737eb7",
+        "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+        "prefLabel": "Bryce Elder",
+        "type": "PERSON",
+        "url": "https://www.ft.com/markets/bryce-elder",
+        "relativeUrl": "/markets/bryce-elder"
+      },
+      "metaAltLink": {
+        "id": "c91b1fad-1097-468b-be82-9a8ff717d54c",
+        "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+        "prefLabel": "Markets",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/markets",
+        "relativeUrl": "/markets"
+      }
+    }
   },
   {
     "id": "aa9b9bda-d056-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/aa9b9bda-d056-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/aa9b9bda-d056-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "d7253b94-b248-4022-af1e-e99c15d0c1b6",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "UK trade",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/uk-trade",
-      "relativeUrl": "/uk-trade"
-    },
-    "metaAltLink": null,
     "title": "Irish deputy PM voices ‘frustration’ at Brexit impasse",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T08:50:32.000Z",
     "firstPublishedDate": "2018-10-15T08:50:32.000Z",
     "image": {},
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "d7253b94-b248-4022-af1e-e99c15d0c1b6",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "UK trade",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/uk-trade",
+        "relativeUrl": "/uk-trade"
+      },
+      "metaAltLink": null
+    }
   }
 ]

--- a/components/x-teaser-timeline/storybook/content-items.json
+++ b/components/x-teaser-timeline/storybook/content-items.json
@@ -36,7 +36,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-17T13:00:26.000Z",
     "firstPublishedDate": "2018-10-17T13:00:26.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/c8a8d52e-d20a-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -74,7 +74,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-17T12:35:36.000Z",
     "firstPublishedDate": "2018-10-17T12:35:36.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/8ba50178-d216-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -113,7 +113,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-17T12:00:33.000Z",
     "firstPublishedDate": "2018-10-17T12:00:33.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/a3695666-d201-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -151,7 +151,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-17T09:06:19.000Z",
     "firstPublishedDate": "2018-10-16T19:45:43.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/9be47d9e-d17a-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -202,7 +202,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-17T04:01:53.000Z",
     "firstPublishedDate": "2018-10-17T04:01:53.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/23529cb0-d140-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -240,7 +240,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T23:31:16.000Z",
     "firstPublishedDate": "2018-10-16T23:31:16.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/f08f8340-d1a0-11e8-a9f2-7574db66bcd5",
       "width": 2048,
       "height": 1152
@@ -278,7 +278,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T18:13:59.000Z",
     "firstPublishedDate": "2018-10-16T17:12:31.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/ece474ca-d151-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -323,7 +323,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T17:36:20.000Z",
     "firstPublishedDate": "2018-10-16T17:36:20.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/5319de7e-d12f-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -360,7 +360,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T17:23:30.000Z",
     "firstPublishedDate": "2018-10-16T13:07:03.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/62fd9e46-d14f-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -405,7 +405,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T13:54:09.000Z",
     "firstPublishedDate": "2018-10-16T13:54:09.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/cb11f55e-d140-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -442,7 +442,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T13:49:36.000Z",
     "firstPublishedDate": "2018-10-16T13:49:36.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/383a4ea2-d14a-11e8-a9f2-7574db66bcd5",
       "width": 2048,
       "height": 1152
@@ -480,7 +480,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T12:16:17.000Z",
     "firstPublishedDate": "2018-10-16T12:16:17.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/31d2be9e-d13d-11e8-a9f2-7574db66bcd5",
       "width": 2048,
       "height": 1152
@@ -518,7 +518,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T12:03:13.000Z",
     "firstPublishedDate": "2018-10-16T12:03:13.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/d7517de4-d131-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -556,7 +556,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T10:46:19.000Z",
     "firstPublishedDate": "2018-10-16T09:18:12.000Z",
-    "image": {},
+    "mainImage": {},
     "headshot": null,
     "parentTheme": null
   },
@@ -590,7 +590,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-16T03:00:59.000Z",
     "firstPublishedDate": "2018-10-16T03:00:59.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/a6afae18-d069-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -627,7 +627,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T23:01:36.000Z",
     "firstPublishedDate": "2018-10-15T23:01:36.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/9a6adda6-d07a-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -664,7 +664,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T18:13:59.000Z",
     "firstPublishedDate": "2018-10-15T12:08:01.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/ac0fd098-d075-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -700,7 +700,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T17:30:48.000Z",
     "firstPublishedDate": "2018-10-15T17:30:48.000Z",
-    "image": {},
+    "mainImage": {},
     "headshot": null,
     "parentTheme": null
   },
@@ -732,7 +732,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T16:06:36.000Z",
     "firstPublishedDate": "2018-10-15T16:06:36.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/d0cbda02-cbb7-11e8-8d0b-a6539b949662",
       "width": 2048,
       "height": 1152
@@ -769,7 +769,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T13:44:20.000Z",
     "firstPublishedDate": "2018-10-15T13:44:20.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/aea311c6-c32d-11e8-95b1-d36dfef1b89a",
       "width": 2048,
       "height": 1152
@@ -806,7 +806,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T13:05:06.000Z",
     "firstPublishedDate": "2018-10-15T13:05:06.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/f87f782a-d089-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -850,7 +850,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T13:04:49.000Z",
     "firstPublishedDate": "2018-10-15T13:04:49.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/31c1c612-d079-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -887,7 +887,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T11:02:36.000Z",
     "firstPublishedDate": "2018-10-15T11:02:36.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/f1191270-ce41-11e8-8d0b-a6539b949662",
       "width": 2048,
       "height": 1152
@@ -923,7 +923,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T10:41:21.000Z",
     "firstPublishedDate": "2018-10-15T10:41:21.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/c77408fa-d065-11e8-a9f2-7574db66bcd5",
       "width": 2048,
       "height": 1152
@@ -960,7 +960,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T10:01:47.000Z",
     "firstPublishedDate": "2018-10-15T10:01:47.000Z",
-    "image": {
+    "mainImage": {
       "url": "http://prod-upp-image-read.ft.com/66d87a12-d06f-11e8-9a3c-5d5eac8f1ab4",
       "width": 2048,
       "height": 1152
@@ -1003,7 +1003,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T10:01:26.000Z",
     "firstPublishedDate": "2018-10-15T10:01:26.000Z",
-    "image": {},
+    "mainImage": {},
     "parentTheme": null
   },
   {
@@ -1034,7 +1034,7 @@
     "altStandfirst": null,
     "publishedDate": "2018-10-15T08:50:32.000Z",
     "firstPublishedDate": "2018-10-15T08:50:32.000Z",
-    "image": {},
+    "mainImage": {},
     "headshot": null,
     "parentTheme": null
   }

--- a/components/x-teaser-timeline/storybook/content-items.json
+++ b/components/x-teaser-timeline/storybook/content-items.json
@@ -4,33 +4,6 @@
     "url": "https://www.ft.com/content/65867e26-d203-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/65867e26-d203-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Brexit Briefing",
-      "type": "BRAND",
-      "url": "https://www.ft.com/brexit-briefing",
-      "relativeUrl": "/brexit-briefing"
-    },
-    "metaAltLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
     "title": "Is December looming as the new Brexit deadline?",
     "standfirst": "As Theresa May prepares to meet EU leaders, the prospect looks increasingly likely",
     "altStandfirst": null,
@@ -42,33 +15,42 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
+        "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+        "prefLabel": "Brexit Briefing",
+        "type": "BRAND",
+        "url": "https://www.ft.com/brexit-briefing",
+        "relativeUrl": "/brexit-briefing"
+      },
+      "metaAltLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      }
+    }
   },
   {
     "id": "93614586-d1f1-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/93614586-d1f1-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/93614586-d1f1-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "May seeks to overcome deadlock after Brexit setback",
     "standfirst": "UK and EU consider extending transition deal to defuse dispute over Irish border backstop",
     "altStandfirst": null,
@@ -81,33 +63,35 @@
     },
     "headshot": null,
     "parentTheme": null,
-    "saved": true
+    "saved": true,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "d4e80114-d1ee-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/d4e80114-d1ee-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Midsized UK businesses turn sour on Brexit",
     "standfirst": "Quarterly survey shows more companies now believe Brexit will damage their business than help them",
     "altStandfirst": null,
@@ -119,33 +103,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "6582b8ce-d175-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/6582b8ce-d175-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Barnier open to extending Brexit transition by a year",
     "standfirst": "In return, Theresa May must accept ‘two-tier’ backstop to avoid a hard Irish border",
     "altStandfirst": null,
@@ -157,46 +143,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "7ab52d68-d11a-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/7ab52d68-d11a-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": true,
-      "isOpinion": true,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": "Inside Business",
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "3f97b34f-8fa3-43fd-8326-d8b0fde2a1f3",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "Sarah Gordon",
-      "type": "PERSON",
-      "attributes": [
-        {
-          "key": "headshot",
-          "value": "fthead-v1:sarah-gordon"
-        }
-      ],
-      "url": "https://www.ft.com/sarah-gordon",
-      "relativeUrl": "/sarah-gordon"
-    },
-    "metaAltLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
     "title": "UK lets down business with lack of Brexit advice",
     "standfirst": "Governments should be more concerned about SMEs: if supply chains falter, so will economic growth",
     "altStandfirst": null,
@@ -208,33 +183,48 @@
       "height": 1152
     },
     "headshot": "fthead-v1:sarah-gordon",
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": true,
+        "isOpinion": true,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": "Inside Business",
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "3f97b34f-8fa3-43fd-8326-d8b0fde2a1f3",
+        "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+        "prefLabel": "Sarah Gordon",
+        "type": "PERSON",
+        "attributes": [
+          {
+            "key": "headshot",
+            "value": "fthead-v1:sarah-gordon"
+          }
+        ],
+        "url": "https://www.ft.com/sarah-gordon",
+        "relativeUrl": "/sarah-gordon"
+      },
+      "metaAltLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      }
+    }
   },
   {
     "id": "868cedae-d18a-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/868cedae-d18a-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/868cedae-d18a-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "243243d9-de4b-4869-909b-fab711125624",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Global trade",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/global-trade",
-      "relativeUrl": "/global-trade",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Trump looks to start formal US-UK trade talks",
     "standfirst": "White House makes London a priority ‘as soon as it is ready’ after Brexit",
     "altStandfirst": null,
@@ -246,33 +236,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "243243d9-de4b-4869-909b-fab711125624",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Global trade",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/global-trade",
+        "relativeUrl": "/global-trade",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "c276c8a2-d159-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/c276c8a2-d159-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "House of Commons UK",
-      "type": "ORGANISATION",
-      "url": "https://www.ft.com/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "relativeUrl": "/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Bercow faces mounting calls to resign",
     "standfirst": "Maria Miller says Speaker needs to step down immediately to ‘drive culture change’",
     "altStandfirst": null,
@@ -284,40 +276,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "House of Commons UK",
+        "type": "ORGANISATION",
+        "url": "https://www.ft.com/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "relativeUrl": "/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "a1566658-d12e-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/a1566658-d12e-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/a1566658-d12e-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": true,
-      "isOpinion": true,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": "The FT View",
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "741cc381-76a8-382b-a621-fc8eca53d69f",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "The editorial board",
-      "type": "PERSON",
-      "url": "https://www.ft.com/ft-view",
-      "relativeUrl": "/ft-view"
-    },
-    "metaAltLink": {
-      "id": "fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "House of Commons UK",
-      "type": "ORGANISATION",
-      "url": "https://www.ft.com/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "relativeUrl": "/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
-      "isDisplayTag": true
-    },
     "title": "A culture shift to clear Westminster’s toxic air",
     "standfirst": "Speaker John Bercow should take responsibility — and go now",
     "altStandfirst": null,
@@ -328,33 +315,42 @@
       "width": 2048,
       "height": 1152
     },
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": true,
+        "isOpinion": true,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": "The FT View",
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "741cc381-76a8-382b-a621-fc8eca53d69f",
+        "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+        "prefLabel": "The editorial board",
+        "type": "PERSON",
+        "url": "https://www.ft.com/ft-view",
+        "relativeUrl": "/ft-view"
+      },
+      "metaAltLink": {
+        "id": "fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "House of Commons UK",
+        "type": "ORGANISATION",
+        "url": "https://www.ft.com/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "relativeUrl": "/stream/fa354fe2-b2e0-483a-9267-cffe6ef9083b",
+        "isDisplayTag": true
+      }
+    }
   },
   {
     "id": "f9f69a2c-d141-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/f9f69a2c-d141-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "EU demands UK break Brexit impasse",
     "standfirst": "May tells Eurosceptics acceptable deal is in sight as Barnier says ‘Brits need more time’",
     "altStandfirst": null,
@@ -366,40 +362,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "eb6062c2-d13c-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/eb6062c2-d13c-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Brexit Briefing",
-      "type": "BRAND",
-      "url": "https://www.ft.com/brexit-briefing",
-      "relativeUrl": "/brexit-briefing"
-    },
-    "metaAltLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
     "title": "Brexit, Scotland and the threat to constitutional unity",
     "standfirst": "Scottish Tories fear that possible arrangements for Northern Ireland threaten the union itself",
     "altStandfirst": null,
@@ -411,33 +402,42 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
+        "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+        "prefLabel": "Brexit Briefing",
+        "type": "BRAND",
+        "url": "https://www.ft.com/brexit-briefing",
+        "relativeUrl": "/brexit-briefing"
+      },
+      "metaAltLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      }
+    }
   },
   {
     "id": "d7472b20-d148-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/d7472b20-d148-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/d7472b20-d148-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "EU’s Tusk to ask UK for ‘concrete proposals’ to end Brexit impasse",
     "altStandfirst": null,
     "publishedDate": "2018-10-16T13:49:36.000Z",
@@ -448,34 +448,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "10ee3a20-d13b-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/10ee3a20-d13b-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "FIGI": "BBG000BWQFY7",
-      "id": "1120e446-6695-4e49-91e6-fd1f7698388e",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Wells Fargo",
-      "type": "ORGANISATION",
-      "url": "https://www.ft.com/stream/1120e446-6695-4e49-91e6-fd1f7698388e",
-      "relativeUrl": "/stream/1120e446-6695-4e49-91e6-fd1f7698388e",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Wells Fargo applies for licence in France as part of Brexit strategy",
     "altStandfirst": null,
     "publishedDate": "2018-10-16T12:16:17.000Z",
@@ -486,33 +487,36 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "FIGI": "BBG000BWQFY7",
+        "id": "1120e446-6695-4e49-91e6-fd1f7698388e",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Wells Fargo",
+        "type": "ORGANISATION",
+        "url": "https://www.ft.com/stream/1120e446-6695-4e49-91e6-fd1f7698388e",
+        "relativeUrl": "/stream/1120e446-6695-4e49-91e6-fd1f7698388e",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "6bd7f80e-d11d-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/6bd7f80e-d11d-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "c4c9204f-8335-42c3-9415-c2c8cd971125",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "UK welfare reform",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/stream/c4c9204f-8335-42c3-9415-c2c8cd971125",
-      "relativeUrl": "/stream/c4c9204f-8335-42c3-9415-c2c8cd971125",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Rollout of controversial UK welfare reform faces fresh delay",
     "standfirst": "Universal credit system not expected to be fully operational until December 2023",
     "altStandfirst": null,
@@ -524,33 +528,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "c4c9204f-8335-42c3-9415-c2c8cd971125",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "UK welfare reform",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/stream/c4c9204f-8335-42c3-9415-c2c8cd971125",
+        "relativeUrl": "/stream/c4c9204f-8335-42c3-9415-c2c8cd971125",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "1969887a-d11e-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/1969887a-d11e-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/1969887a-d11e-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "466a4700-307f-47cc-83f1-c5f97a172232",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "Pound Sterling",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
-      "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Pound rallies after upbeat wage growth reading",
     "standfirst": "Analysts remain cautious despite optimistic data",
     "altStandfirst": null,
@@ -558,33 +564,35 @@
     "firstPublishedDate": "2018-10-16T09:18:12.000Z",
     "mainImage": {},
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "Pound Sterling",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+        "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "dab8bfd2-ce3f-11e8-9fe5-24ad351828ab",
     "url": "https://www.ft.com/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab",
     "relativeUrl": "/content/dab8bfd2-ce3f-11e8-9fe5-24ad351828ab",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "9c0f3107-a34f-4319-a6a6-3101ac88b50d",
-      "predicate": "http://www.ft.com/ontology/hasDisplayTag",
-      "prefLabel": "UK politics & policy",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/world/uk/politics",
-      "relativeUrl": "/world/uk/politics",
-      "isDisplayTag": true
-    },
-    "metaAltLink": null,
     "title": "Problem gambling shake-up set to be brought forward",
     "standfirst": "Blow for bookmakers as ministers seek to speed up start of fixed-odds betting terminals limits",
     "altStandfirst": null,
@@ -596,32 +604,35 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "9c0f3107-a34f-4319-a6a6-3101ac88b50d",
+        "predicate": "http://www.ft.com/ontology/hasDisplayTag",
+        "prefLabel": "UK politics & policy",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/world/uk/politics",
+        "relativeUrl": "/world/uk/politics",
+        "isDisplayTag": true
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/d5ebbb7e-d07b-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "6b32f2c1-da43-4e19-80b9-8aef4ab640d7",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Technology sector",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/companies/technology",
-      "relativeUrl": "/companies/technology"
-    },
-    "metaAltLink": null,
     "title": "Crypto exchange Coinbase sets up Brexit contingency",
     "standfirst": "US digital start-up to scale up EU operations with new Dublin branch",
     "altStandfirst": null,
@@ -633,32 +644,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "6b32f2c1-da43-4e19-80b9-8aef4ab640d7",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Technology sector",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/companies/technology",
+        "relativeUrl": "/companies/technology"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "2e407a74-d06a-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/2e407a74-d06a-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "82645c31-4426-4ef5-99c9-9df6e0940c00",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "World",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/world",
-      "relativeUrl": "/world"
-    },
-    "metaAltLink": null,
     "title": "EU gives UK 24 hour Brexit breathing space",
     "standfirst": "Theresa May says deal achievable but Britain cannot be kept in backstop indefinitely",
     "altStandfirst": null,
@@ -670,64 +683,68 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "82645c31-4426-4ef5-99c9-9df6e0940c00",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "World",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/world",
+        "relativeUrl": "/world"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "434dc8e2-d09f-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/434dc8e2-d09f-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/434dc8e2-d09f-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit"
-    },
-    "metaAltLink": null,
     "title": "EC’s Tusk warns no-deal Brexit ‘is more likely than ever before’",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T17:30:48.000Z",
     "firstPublishedDate": "2018-10-15T17:30:48.000Z",
     "mainImage": {},
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "fadfb212-d091-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/fadfb212-d091-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/fadfb212-d091-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit"
-    },
-    "metaAltLink": null,
     "title": "Barnier plan no solution to Irish border, says Foster",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T16:06:36.000Z",
@@ -738,32 +755,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "79939f94-c320-11e8-8d55-54197280d3f7",
     "url": "https://www.ft.com/content/79939f94-c320-11e8-8d55-54197280d3f7",
     "relativeUrl": "/content/79939f94-c320-11e8-8d55-54197280d3f7",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": "Explainer",
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "466a4700-307f-47cc-83f1-c5f97a172232",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Pound Sterling",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
-      "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232"
-    },
-    "metaAltLink": null,
     "title": "Pound timeline: from the 1970s to Brexit crunch",
     "standfirst": "Sterling has experienced several periods of volatility in the past 48 years",
     "altStandfirst": null,
@@ -775,32 +794,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": "Explainer",
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "466a4700-307f-47cc-83f1-c5f97a172232",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Pound Sterling",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/stream/466a4700-307f-47cc-83f1-c5f97a172232",
+        "relativeUrl": "/stream/466a4700-307f-47cc-83f1-c5f97a172232"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "bfffa642-d079-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/bfffa642-d079-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/bfffa642-d079-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit"
-    },
-    "metaAltLink": null,
     "title": "Brexit talks could drag into December warns Ireland’s Varadkar",
     "standfirst": "Taoiseach says he always believed a deal this month was unlikely",
     "altStandfirst": null,
@@ -812,39 +833,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "82ae2756-d073-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/82ae2756-d073-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/82ae2756-d073-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
-      "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-      "prefLabel": "Brexit Briefing",
-      "type": "BRAND",
-      "url": "https://www.ft.com/brexit-briefing",
-      "relativeUrl": "/brexit-briefing"
-    },
-    "metaAltLink": {
-      "id": "d7253b94-b248-4022-af1e-e99c15d0c1b6",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "UK trade",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/uk-trade",
-      "relativeUrl": "/uk-trade"
-    },
     "title": "Crisis or choreography over Brexit?",
     "standfirst": "While ministers haggle, company bosses press the button on expensive no-deal planning",
     "altStandfirst": null,
@@ -856,32 +872,41 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "464cc2f2-395e-4c36-bb29-01727fc95558",
+        "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+        "prefLabel": "Brexit Briefing",
+        "type": "BRAND",
+        "url": "https://www.ft.com/brexit-briefing",
+        "relativeUrl": "/brexit-briefing"
+      },
+      "metaAltLink": {
+        "id": "d7253b94-b248-4022-af1e-e99c15d0c1b6",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "UK trade",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/uk-trade",
+        "relativeUrl": "/uk-trade"
+      }
+    }
   },
   {
     "id": "a8181102-ce1e-11e8-9fe5-24ad351828ab",
     "url": "https://www.ft.com/content/a8181102-ce1e-11e8-9fe5-24ad351828ab",
     "relativeUrl": "/content/a8181102-ce1e-11e8-9fe5-24ad351828ab",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "d1252624-8645-438b-b521-9244aebdc99e",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Industrials",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/companies/industrials",
-      "relativeUrl": "/companies/industrials"
-    },
-    "metaAltLink": null,
     "title": "UK shipyards to submit bids to build 5 warships",
     "standfirst": "MoD restarts competition despite industry’s concerns over budget and timing",
     "altStandfirst": null,
@@ -893,32 +918,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "d1252624-8645-438b-b521-9244aebdc99e",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Industrials",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/companies/industrials",
+        "relativeUrl": "/companies/industrials"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "9b3b6d2e-d064-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/9b3b6d2e-d064-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "19b95057-4614-45fb-9306-4d54049354db",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "Brexit",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/brexit",
-      "relativeUrl": "/brexit"
-    },
-    "metaAltLink": null,
     "title": "May to address UK parliament on state of Brexit talks",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T10:41:21.000Z",
@@ -929,32 +956,34 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "19b95057-4614-45fb-9306-4d54049354db",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "Brexit",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/brexit",
+        "relativeUrl": "/brexit"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "ed665ed8-cdfd-11e8-9fe5-24ad351828ab",
     "url": "https://www.ft.com/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab",
     "relativeUrl": "/content/ed665ed8-cdfd-11e8-9fe5-24ad351828ab",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "6cc4c4ed-ef61-4c71-a5bb-f454fb5010a8",
-      "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
-      "prefLabel": "UK business & economy",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/uk-business-economy",
-      "relativeUrl": "/uk-business-economy"
-    },
-    "metaAltLink": null,
     "title": "Bradford hospital launches AI powered command centre",
     "standfirst": "Collaboration with GE Healthcare to create hub monitoring patients to make better use of resources",
     "altStandfirst": null,
@@ -966,76 +995,101 @@
       "height": 1152
     },
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "6cc4c4ed-ef61-4c71-a5bb-f454fb5010a8",
+        "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+        "prefLabel": "UK business & economy",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/uk-business-economy",
+        "relativeUrl": "/uk-business-economy"
+      },
+      "metaAltLink": null
+    }
   },
   {
     "id": "7c6b9fbb-ad93-34c5-b19b-ea79ffc5f426",
     "url": "http://ftalphaville.ft.com/marketslive/2018-10-15/",
     "relativeUrl": "http://ftalphaville.ft.com/marketslive/2018-10-15/",
     "type": "article",
-    "indicators": {
-      "isColumn": true,
-      "isOpinion": true,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "registered"
-    },
-    "metaPrefixText": "FT Alphaville",
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "602c702b-31fe-4116-a203-747c7c737eb7",
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "prefLabel": "Bryce Elder",
-      "type": "PERSON",
-      "url": "https://www.ft.com/markets/bryce-elder",
-      "relativeUrl": "/markets/bryce-elder"
-    },
-    "metaAltLink": {
-      "id": "c91b1fad-1097-468b-be82-9a8ff717d54c",
-      "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
-      "prefLabel": "Markets",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/markets",
-      "relativeUrl": "/markets"
-    },
     "title": "Markets Live: Monday, 15th October 2018",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T10:01:26.000Z",
     "firstPublishedDate": "2018-10-15T10:01:26.000Z",
     "mainImage": {},
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": true,
+        "isOpinion": true,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "registered"
+      },
+      "metaPrefixText": "FT Alphaville",
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "602c702b-31fe-4116-a203-747c7c737eb7",
+        "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+        "prefLabel": "Bryce Elder",
+        "type": "PERSON",
+        "url": "https://www.ft.com/markets/bryce-elder",
+        "relativeUrl": "/markets/bryce-elder"
+      },
+      "metaAltLink": {
+        "id": "c91b1fad-1097-468b-be82-9a8ff717d54c",
+        "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
+        "prefLabel": "Markets",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/markets",
+        "relativeUrl": "/markets"
+      }
+    }
   },
   {
     "id": "aa9b9bda-d056-11e8-a9f2-7574db66bcd5",
     "url": "https://www.ft.com/content/aa9b9bda-d056-11e8-a9f2-7574db66bcd5",
     "relativeUrl": "/content/aa9b9bda-d056-11e8-a9f2-7574db66bcd5",
     "type": "article",
-    "indicators": {
-      "isColumn": false,
-      "isOpinion": false,
-      "isScoop": false,
-      "isExclusive": false,
-      "isEditorsChoice": false,
-      "accessLevel": "subscribed"
-    },
-    "metaPrefixText": null,
-    "metaSuffixText": null,
-    "metaLink": {
-      "id": "d7253b94-b248-4022-af1e-e99c15d0c1b6",
-      "predicate": "http://www.ft.com/ontology/annotation/about",
-      "prefLabel": "UK trade",
-      "type": "TOPIC",
-      "url": "https://www.ft.com/uk-trade",
-      "relativeUrl": "/uk-trade"
-    },
-    "metaAltLink": null,
     "title": "Irish deputy PM voices ‘frustration’ at Brexit impasse",
     "altStandfirst": null,
     "publishedDate": "2018-10-15T08:50:32.000Z",
     "firstPublishedDate": "2018-10-15T08:50:32.000Z",
     "mainImage": {},
     "headshot": null,
-    "parentTheme": null
+    "parentTheme": null,
+    "teaserMetadata": {
+      "indicators": {
+        "isColumn": false,
+        "isOpinion": false,
+        "isScoop": false,
+        "isExclusive": false,
+        "isEditorsChoice": false,
+        "accessLevel": "subscribed"
+      },
+      "metaPrefixText": null,
+      "metaSuffixText": null,
+      "metaLink": {
+        "id": "d7253b94-b248-4022-af1e-e99c15d0c1b6",
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "prefLabel": "UK trade",
+        "type": "TOPIC",
+        "url": "https://www.ft.com/uk-trade",
+        "relativeUrl": "/uk-trade"
+      },
+      "metaAltLink": null
+    }
   }
 ]

--- a/components/x-teaser/Props.d.ts
+++ b/components/x-teaser/Props.d.ts
@@ -44,19 +44,21 @@ export interface General {
   /** Preferred to url if available */
   relativeUrl?: string
   type: ContentType
-  indicators: Indicators
 }
 
 export interface Meta {
-  /** Usually a brand, or a genre, or content type */
-  metaPrefixText?: string
-  metaSuffixText?: string
-  metaLink?: MetaLink
-  /** Fallback used if the parentId is the same as the display concept */
-  metaAltLink?: MetaLink
-  /** Promoted content type */
-  promotedPrefixText?: string
-  promotedSuffixText?: string
+  teaserMetadata: {
+    /** Usually a brand, or a genre, or content type */
+    metaPrefixText?: string
+    metaSuffixText?: string
+    metaLink?: MetaLink
+    /** Fallback used if the parentId is the same as the display concept */
+    metaAltLink?: MetaLink
+    /** Promoted content type */
+    promotedPrefixText?: string
+    promotedSuffixText?: string
+    indicators: Indicators
+  }
 }
 
 export interface Title {

--- a/components/x-teaser/Props.d.ts
+++ b/components/x-teaser/Props.d.ts
@@ -127,7 +127,7 @@ export interface Variants {
 export interface MetaLink {
   url: string
   /** Preferred if available */
-  relativeUrl?
+  relativeUrl?: string
   prefLabel: string
 }
 
@@ -136,7 +136,7 @@ export interface Link {
   type: ContentType
   url: string
   /** Preferred to url if available */
-  relativeUrl?
+  relativeUrl?: string
   title: string
 }
 

--- a/components/x-teaser/Props.d.ts
+++ b/components/x-teaser/Props.d.ts
@@ -82,7 +82,7 @@ export interface Status {
 
 export interface Image {
   /** Images must be accessible to the Origami Image Service */
-  image?: Media
+  mainImage?: Media
   imageSize?: ImageSize
   imageLazyLoad?: Boolean | String
 }

--- a/components/x-teaser/__fixtures__/article-with-data-image.json
+++ b/components/x-teaser/__fixtures__/article-with-data-image.json
@@ -18,7 +18,7 @@
     "url": "#",
     "prefLabel": "FT Investigations"
   },
-  "image": {
+  "mainImage": {
     "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==",
     "width": 2048,
     "height": 1152,

--- a/components/x-teaser/__fixtures__/article-with-data-image.json
+++ b/components/x-teaser/__fixtures__/article-with-data-image.json
@@ -8,23 +8,25 @@
   "altStandfirst": "Groping and sexual harassment at black-tie dinner charity event",
   "publishedDate": "2018-01-23T15:07:00.000Z",
   "firstPublishedDate": "2018-01-23T13:53:00.000Z",
-  "metaPrefixText": "",
-  "metaSuffixText": "",
-  "metaLink": {
-    "url": "#",
-    "prefLabel": "Sexual misconduct allegations"
-  },
-  "metaAltLink": {
-    "url": "#",
-    "prefLabel": "FT Investigations"
+  "teaserMetadata": {
+    "metaPrefixText": "",
+    "metaSuffixText": "",
+    "metaLink": {
+      "url": "#",
+      "prefLabel": "Sexual misconduct allegations"
+    },
+    "metaAltLink": {
+      "url": "#",
+      "prefLabel": "FT Investigations"
+    },
+    "indicators": {
+      "isEditorsChoice": true
+    }
   },
   "mainImage": {
     "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==",
     "width": 2048,
     "height": 1152,
     "imageLazyLoad": "js-image-lazy-load"
-  },
-  "indicators": {
-    "isEditorsChoice": true
   }
 }

--- a/components/x-teaser/__fixtures__/article-with-missing-image-url.json
+++ b/components/x-teaser/__fixtures__/article-with-missing-image-url.json
@@ -18,7 +18,7 @@
     "url": "#",
     "prefLabel": "FT Investigations"
   },
-  "image": {
+  "mainImage": {
     "width": 2048,
     "height": 1152
   },

--- a/components/x-teaser/__fixtures__/article-with-missing-image-url.json
+++ b/components/x-teaser/__fixtures__/article-with-missing-image-url.json
@@ -8,26 +8,28 @@
   "altStandfirst": "Groping and sexual harassment at black-tie dinner charity event",
   "publishedDate": "2018-01-23T15:07:00.000Z",
   "firstPublishedDate": "2018-01-23T13:53:00.000Z",
-  "metaPrefixText": "",
-  "metaSuffixText": "",
-  "metaLink": {
-    "url": "#",
-    "prefLabel": "Sexual misconduct allegations"
-  },
-  "metaAltLink": {
-    "url": "#",
-    "prefLabel": "FT Investigations"
+  "teaserMetadata": {
+    "metaPrefixText": "",
+    "metaSuffixText": "",
+    "metaLink": {
+      "url": "#",
+      "prefLabel": "Sexual misconduct allegations"
+    },
+    "metaAltLink": {
+      "url": "#",
+      "prefLabel": "FT Investigations"
+    },
+    "indicators": {
+      "accessLevel": "free",
+      "isEditorsChoice": true
+    }
   },
   "mainImage": {
     "width": 2048,
     "height": 1152
   },
-  "indicators": {
-    "isEditorsChoice": true
-  },
   "status": "",
   "headshotTint": "",
-  "accessLevel": "free",
   "theme": "",
   "parentTheme": "",
   "modifiers": ""

--- a/components/x-teaser/__fixtures__/article.json
+++ b/components/x-teaser/__fixtures__/article.json
@@ -18,7 +18,7 @@
     "url": "#",
     "prefLabel": "FT Investigations"
   },
-  "image": {
+  "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/a25832ea-0053-11e8-9650-9c0ad2d7c5b5",
     "width": 2048,
     "height": 1152

--- a/components/x-teaser/__fixtures__/article.json
+++ b/components/x-teaser/__fixtures__/article.json
@@ -8,27 +8,29 @@
   "altStandfirst": "Groping and sexual harassment at black-tie dinner charity event",
   "publishedDate": "2018-01-23T15:07:00.000Z",
   "firstPublishedDate": "2018-01-23T13:53:00.000Z",
-  "metaPrefixText": "",
-  "metaSuffixText": "",
-  "metaLink": {
-    "url": "#",
-    "prefLabel": "Sexual misconduct allegations"
-  },
-  "metaAltLink": {
-    "url": "#",
-    "prefLabel": "FT Investigations"
+  "teaserMetadata": {
+    "metaPrefixText": "",
+    "metaSuffixText": "",
+    "metaLink": {
+      "url": "#",
+      "prefLabel": "Sexual misconduct allegations"
+    },
+    "metaAltLink": {
+      "url": "#",
+      "prefLabel": "FT Investigations"
+    },
+    "indicators": {
+      "accessLevel": "free",
+      "isEditorsChoice": true
+    }
   },
   "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/a25832ea-0053-11e8-9650-9c0ad2d7c5b5",
     "width": 2048,
     "height": 1152
   },
-  "indicators": {
-    "isEditorsChoice": true
-  },
   "status": "",
   "headshotTint": "",
-  "accessLevel": "free",
   "theme": "",
   "parentTheme": "",
   "modifiers": ""

--- a/components/x-teaser/__fixtures__/content-package.json
+++ b/components/x-teaser/__fixtures__/content-package.json
@@ -18,7 +18,7 @@
     "url": "#",
     "prefLabel": "FT Series"
   },
-  "image": {
+  "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/7e97f5b6-578d-11e8-b8b2-d6ceb45fa9d0",
     "width": 2048,
     "height": 1152

--- a/components/x-teaser/__fixtures__/content-package.json
+++ b/components/x-teaser/__fixtures__/content-package.json
@@ -8,15 +8,20 @@
   "altStandfirst": "",
   "publishedDate": "2018-05-14T16:38:49.000Z",
   "firstPublishedDate": "2018-05-14T16:38:49.000Z",
-  "metaPrefixText": "",
-  "metaSuffixText": "",
-  "metaLink": {
-    "url": "#",
-    "prefLabel": "FT Magazine"
-  },
-  "metaAltLink": {
-    "url": "#",
-    "prefLabel": "FT Series"
+  "teaserMetadata": {
+    "metaPrefixText": "",
+    "metaSuffixText": "",
+    "metaLink": {
+      "url": "#",
+      "prefLabel": "FT Magazine"
+    },
+    "metaAltLink": {
+      "url": "#",
+      "prefLabel": "FT Series"
+    },
+    "indicators": {
+      "accessLevel": "free"
+    }
   },
   "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/7e97f5b6-578d-11e8-b8b2-d6ceb45fa9d0",
@@ -25,7 +30,6 @@
   },
   "status": "",
   "headshotTint": "",
-  "accessLevel": "free",
   "theme": "",
   "parentTheme": "",
   "modifiers": "centre"

--- a/components/x-teaser/__fixtures__/opinion.json
+++ b/components/x-teaser/__fixtures__/opinion.json
@@ -18,7 +18,7 @@
     "url": "#",
     "prefLabel": "Anti-Semitism"
   },
-  "image": {
+  "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/1005ca96-364b-11e8-8b98-2f31af407cc8",
     "width": 2048,
     "height": 1152

--- a/components/x-teaser/__fixtures__/opinion.json
+++ b/components/x-teaser/__fixtures__/opinion.json
@@ -8,15 +8,22 @@
   "altStandfirst": "Anti-Semitism and identity politics",
   "publishedDate": "2018-04-02T12:22:01.000Z",
   "firstPublishedDate": "2018-04-02T12:22:01.000Z",
-  "metaPrefixText": "",
-  "metaSuffixText": "",
-  "metaLink": {
-    "url": "#",
-    "prefLabel": "Gideon Rachman"
-  },
-  "metaAltLink": {
-    "url": "#",
-    "prefLabel": "Anti-Semitism"
+  "teaserMetadata": {
+    "metaPrefixText": "",
+    "metaSuffixText": "",
+    "metaLink": {
+      "url": "#",
+      "prefLabel": "Gideon Rachman"
+    },
+    "metaAltLink": {
+      "url": "#",
+      "prefLabel": "Anti-Semitism"
+    },
+    "indicators": {
+      "accessLevel": "free",
+      "isOpinion": true,
+      "isColumn": true
+    }
   },
   "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/1005ca96-364b-11e8-8b98-2f31af407cc8",
@@ -24,14 +31,9 @@
     "height": 1152
   },
   "headshot": "fthead-v1:gideon-rachman",
-  "indicators": {
-    "isOpinion": true,
-    "isColumn": true
-  },
   "showHeadshot": true,
   "status": "",
   "headshotTint": "",
-  "accessLevel": "free",
   "theme": "",
   "parentTheme": "",
   "modifiers": ""

--- a/components/x-teaser/__fixtures__/package-item.json
+++ b/components/x-teaser/__fixtures__/package-item.json
@@ -12,7 +12,7 @@
     "url": "#",
     "prefLabel": "Financial crisis: Are we safer now? "
   },
-  "image": {
+  "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/a25832ea-0053-11e8-9650-9c0ad2d7c5b5",
     "width": 2048,
     "height": 1152

--- a/components/x-teaser/__fixtures__/package-item.json
+++ b/components/x-teaser/__fixtures__/package-item.json
@@ -6,23 +6,25 @@
   "standfirst": "Martin Wolf on the power of vested interests in today’s rent-extracting economy",
   "publishedDate": "2018-09-02T15:07:00.000Z",
   "firstPublishedDate": "2018-09-02T13:53:00.000Z",
-  "metaPrefixText": "FT Series",
-  "metaSuffixText": "",
-  "metaLink": {
-    "url": "#",
-    "prefLabel": "Financial crisis: Are we safer now? "
+  "teaserMetadata": {
+    "metaPrefixText": "FT Series",
+    "metaSuffixText": "",
+    "metaLink": {
+      "url": "#",
+      "prefLabel": "Financial crisis: Are we safer now? "
+    },
+    "indicators": {
+      "accessLevel": "free",
+      "isOpinion": true
+    }
   },
   "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/a25832ea-0053-11e8-9650-9c0ad2d7c5b5",
     "width": 2048,
     "height": 1152
   },
-  "indicators": {
-    "isOpinion": true
-  },
   "status": "",
   "headshotTint": "",
-  "accessLevel": "free",
   "theme": "",
   "parentTheme": "extra-article",
 	"modifiers": "centre"

--- a/components/x-teaser/__fixtures__/podcast.json
+++ b/components/x-teaser/__fixtures__/podcast.json
@@ -7,23 +7,25 @@
   "altStandfirst": "",
   "publishedDate": "2018-10-24T04:00:00.000Z",
   "firstPublishedDate": "2018-10-24T04:00:00.000Z",
-  "metaSuffixText": "12 mins",
-  "metaLink": {
-    "url": "#",
-    "prefLabel": "Tech Tonic podcast"
+  "teaserMetadata": {
+    "metaSuffixText": "12 mins",
+    "metaLink": {
+      "url": "#",
+      "prefLabel": "Tech Tonic podcast"
+    },
+    "metaAltLink": "",
+    "indicators": {
+      "accessLevel": "free",
+      "isPodcast": true
+    }
   },
-  "metaAltLink": "",
   "mainImage": {
     "url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5d1a54aa-f49b-11e8-ae55-df4bf40f9d0d?source=next&fit=scale-down&compression=best&width=240",
     "width": 2048,
     "height": 1152
   },
-  "indicators": {
-    "isPodcast": true
-  },
   "status": "",
   "headshotTint": "",
-  "accessLevel": "free",
   "theme": "",
   "parentTheme": "",
   "modifiers": ""

--- a/components/x-teaser/__fixtures__/podcast.json
+++ b/components/x-teaser/__fixtures__/podcast.json
@@ -13,7 +13,7 @@
     "prefLabel": "Tech Tonic podcast"
   },
   "metaAltLink": "",
-  "image": {
+  "mainImage": {
     "url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fprod-upp-image-read.ft.com%2F5d1a54aa-f49b-11e8-ae55-df4bf40f9d0d?source=next&fit=scale-down&compression=best&width=240",
     "width": 2048,
     "height": 1152

--- a/components/x-teaser/__fixtures__/promoted.json
+++ b/components/x-teaser/__fixtures__/promoted.json
@@ -4,8 +4,13 @@
   "url": "#",
   "title": "Why eSports companies are on a winning streak",
   "standfirst": "ESports is big business and about to get bigger: global revenues could hit $1.5bn by 2020",
-  "promotedPrefixText": "Paid post",
-  "promotedSuffixText": "UBS",
+  "teaserMetadata": {
+    "promotedPrefixText": "Paid post",
+    "promotedSuffixText": "UBS",
+    "indicators": {
+      "accessLevel": "free"
+    }
+  },
   "mainImage": {
     "url": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCrm_3yahABGAEyCMx3RoLss603",
     "width": 700,
@@ -13,7 +18,6 @@
   },
   "status": "",
   "headshotTint": "",
-  "accessLevel": "free",
   "theme": "",
   "parentTheme": "",
   "modifiers": ""

--- a/components/x-teaser/__fixtures__/promoted.json
+++ b/components/x-teaser/__fixtures__/promoted.json
@@ -6,7 +6,7 @@
   "standfirst": "ESports is big business and about to get bigger: global revenues could hit $1.5bn by 2020",
   "promotedPrefixText": "Paid post",
   "promotedSuffixText": "UBS",
-  "image": {
+  "mainImage": {
     "url": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCrm_3yahABGAEyCMx3RoLss603",
     "width": 700,
     "height": 394

--- a/components/x-teaser/__fixtures__/top-story.json
+++ b/components/x-teaser/__fixtures__/top-story.json
@@ -9,15 +9,20 @@
   "publishedDate": "2018-01-23T15:07:00.000Z",
   "firstPublishedDate": "2018-01-23T13:53:00.000Z",
   "dataTrackable": "slice:hero-slice-1;slicePos:1;layout:standaloneimage;listPos:1",
-  "metaPrefixText": "",
-  "metaSuffixText": "",
-  "metaLink": {
-    "url": "#",
-    "prefLabel": "Sexual misconduct allegations"
-  },
-  "metaAltLink": {
-    "url": "#",
-    "prefLabel": "FT Investigations"
+  "teaserMetadata": {
+    "metaPrefixText": "",
+    "metaSuffixText": "",
+    "metaLink": {
+      "url": "#",
+      "prefLabel": "Sexual misconduct allegations"
+    },
+    "metaAltLink": {
+      "url": "#",
+      "prefLabel": "FT Investigations"
+    },
+    "indicators": {
+      "accessLevel": "free"
+    }
   },
   "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/a25832ea-0053-11e8-9650-9c0ad2d7c5b5",
@@ -46,7 +51,6 @@
   ],
   "status": "",
   "headshotTint": "",
-  "accessLevel": "free",
   "theme": "",
   "parentTheme": "",
   "modifiers": ""

--- a/components/x-teaser/__fixtures__/top-story.json
+++ b/components/x-teaser/__fixtures__/top-story.json
@@ -19,7 +19,7 @@
     "url": "#",
     "prefLabel": "FT Investigations"
   },
-  "image": {
+  "mainImage": {
     "url": "http://prod-upp-image-read.ft.com/a25832ea-0053-11e8-9650-9c0ad2d7c5b5",
     "width": 2048,
     "height": 1152

--- a/components/x-teaser/__fixtures__/video.json
+++ b/components/x-teaser/__fixtures__/video.json
@@ -6,16 +6,18 @@
   "standfirst": "The FT's Rob Armstrong looks at why Donald Trump is pushing trade tariffs",
   "publishedDate": "2018-03-26T08:12:28.137Z",
   "firstPublishedDate": "2018-03-26T08:12:28.137Z",
-  "metaPrefixText": "",
-  "metaSuffixText": "02:51min",
   "systemCode": "x-teaser",
-  "metaLink": {
-    "url": "#",
-    "prefLabel": "Global Trade"
-  },
-  "metaAltLink": {
-    "url": "#",
-    "prefLabel": "US"
+  "teaserMetadata": {
+    "metaPrefixText": "",
+    "metaSuffixText": "02:51min",
+    "metaLink": {
+      "url": "#",
+      "prefLabel": "Global Trade"
+    },
+    "metaAltLink": {
+      "url": "#",
+      "prefLabel": "US"
+    }
   },
   "mainImage": {
     "url": "http://com.ft.imagepublish.upp-prod-eu.s3.amazonaws.com/a27ce49b-85b8-445b-b883-db6e2f533194",

--- a/components/x-teaser/__fixtures__/video.json
+++ b/components/x-teaser/__fixtures__/video.json
@@ -17,7 +17,7 @@
     "url": "#",
     "prefLabel": "US"
   },
-  "image": {
+  "mainImage": {
     "url": "http://com.ft.imagepublish.upp-prod-eu.s3.amazonaws.com/a27ce49b-85b8-445b-b883-db6e2f533194",
     "width": 1920,
     "height": 1080,

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -122,25 +122,14 @@ As covered in the [features](#features) documentation the teaser properties, or 
 
 #### General Props
 
-| Property        | Type                           | Notes                                      |
-| --------------- | ------------------------------ | ------------------------------------------ |
-| `id`            | String                         | Content UUID                               |
-| `url`           | String                         | Canonical URL                              |
-| `relativeUrl`   | String                         | URL path, will take precendence over `url` |
-| `type`          | String                         | Content type (article, video, etc.)        |
-| `indicators`    | [indicators](#indicator-props) |
-| `dataTrackable` | String                         | Tracking data for the teaser               |
-
-#### Meta Props
-
-| Property             | Type                          | Notes                           |
-| -------------------- | ----------------------------- | ------------------------------- |
-| `metaPrefixText`     | String                        |
-| `metaSuffixText`     | String                        |
-| `metaLink`           | [meta link](#meta-link-props) |
-| `metaAltLink`        | [meta link](#meta-link-props) |
-| `promotedPrefixText` | String                        | Will take precedence over links |
-| `promotedSuffixText` | String                        |
+| Property         | Type                    | Notes                                      |
+| ---------------- | ----------------------- | ------------------------------------------ |
+| `id`             | String                  | Content UUID                               |
+| `url`            | String                  | Canonical URL                              |
+| `relativeUrl`    | String                  | URL path, will take precendence over `url` |
+| `type`           | String                  | Content type (article, video, etc.)        |
+| `dataTrackable`  | String                  | Tracking data for the teaser               |
+| `teaserMetadata` | [metadata](#meta-props) | Teaser-specific metadata |
 
 #### Title Props
 
@@ -215,6 +204,18 @@ As covered in the [features](#features) documentation the teaser properties, or 
 | `theme`       | String   | Package theme, setting this will override any other indicators |
 | `parentTheme` | String   | Theme inherited from any parent package                        |
 | `modifiers`   | String[] | Extra modifier class names to append                           |
+
+#### Meta Props
+
+| Property             | Type                           | Notes                           |
+| -------------------- | ------------------------------ | ------------------------------- |
+| `indicators`         | [indicators](#indicator-props) |
+| `metaPrefixText`     | String                         |
+| `metaSuffixText`     | String                         |
+| `metaLink`           | [meta link](#meta-link-props)  |
+| `metaAltLink`        | [meta link](#meta-link-props)  |
+| `promotedPrefixText` | String                         | Will take precedence over links |
+| `promotedSuffixText` | String                         |
 
 #### Meta Link Props
 

--- a/components/x-teaser/readme.md
+++ b/components/x-teaser/readme.md
@@ -52,7 +52,7 @@ const media = (props) => {
     return 'headshot'
   }
 
-  if (props.showImage && props.image && props.image.url) {
+  if (props.showImage && props.mainImage && props.mainImage.url) {
     return 'image'
   }
 }
@@ -169,7 +169,7 @@ As covered in the [features](#features) documentation the teaser properties, or 
 
 | Property              | Type                  | Notes                                                                                                         |
 | --------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `image`               | [media](#media-props) |
+| `mainImage`           | [media](#media-props) |
 | `imageSize`           | String                | XS, Small, Medium, Large, XL or XXL                                                                           |
 | `imageLazyLoad`       | Boolean, String       | Output image with `data-src` attribute. If this is a string it will be appended to the image as a class name. |
 | `imageHighestQuality` | Boolean               | Calls image service with "quality=highest" option, works only with XXL images                                 |

--- a/components/x-teaser/src/Image.jsx
+++ b/components/x-teaser/src/Image.jsx
@@ -24,15 +24,17 @@ const LazyImage = ({ src, lazyLoad, alt }) => {
 	return <img className={`o-teaser__image ${lazyClassName}`} data-src={src} alt={alt} />
 }
 
-export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, imageHighestQuality, ...props }) => {
-	if (!image || (image && !image.url)) {
+export default ({ relativeUrl, url, mainImage, imageSize, imageLazyLoad, imageHighestQuality, ...props }) => {
+	if (!mainImage || (mainImage && !mainImage.url)) {
 		return null
 	}
 	const displayUrl = relativeUrl || url
-	const useImageService = !(image.url.startsWith('data:') || image.url.startsWith('blob:'))
+	const useImageService = !(mainImage.url.startsWith('data:') || mainImage.url.startsWith('blob:'))
 	const options = imageSize === 'XXL' && imageHighestQuality ? { quality: 'highest' } : {}
-	const imageSrc = useImageService ? imageService(image.url, ImageSizes[imageSize], options) : image.url
-	const alt = (image.altText || '').trim()
+	const imageSrc = useImageService
+		? imageService(mainImage.url, ImageSizes[imageSize], options)
+		: mainImage.url
+	const alt = (mainImage.altText || '').trim()
 	const ImageComponent = imageLazyLoad ? LazyImage : NormalImage
 
 	return (
@@ -46,7 +48,7 @@ export default ({ relativeUrl, url, image, imageSize, imageLazyLoad, imageHighes
 					'aria-hidden': 'true'
 				}}
 			>
-				<div className="o-teaser__image-placeholder" style={{ paddingBottom: aspectRatio(image) }}>
+				<div className="o-teaser__image-placeholder" style={{ paddingBottom: aspectRatio(mainImage) }}>
 					<ImageComponent src={imageSrc} lazyLoad={imageLazyLoad} alt={alt} />
 				</div>
 			</Link>

--- a/components/x-teaser/src/Meta.jsx
+++ b/components/x-teaser/src/Meta.jsx
@@ -3,7 +3,9 @@ import MetaLink from './MetaLink'
 import Promoted from './Promoted'
 
 export default (props) => {
-	const showPromoted = props.promotedPrefixText && props.promotedSuffixText
+	const { teaserMetadata } = props
+	const showPromoted =
+		teaserMetadata && teaserMetadata.promotedPrefixText && teaserMetadata.promotedSuffixText
 
-	return showPromoted ? <Promoted {...props} /> : <MetaLink {...props} />
+	return showPromoted ? <Promoted {...teaserMetadata} /> : <MetaLink {...props} />
 }

--- a/components/x-teaser/src/MetaLink.jsx
+++ b/components/x-teaser/src/MetaLink.jsx
@@ -8,7 +8,11 @@ const sameLabel = (context = {}, label) => {
 	return label && context && context.parentLabel && label === context.parentLabel
 }
 
-export default ({ metaPrefixText, metaLink, metaAltLink, metaSuffixText, context }) => {
+export default ({ teaserMetadata, context }) => {
+	if (!teaserMetadata) {
+		return
+	}
+	const { metaPrefixText, metaSuffixText, metaLink, metaAltLink } = teaserMetadata
 	const showPrefixText = metaPrefixText && !sameLabel(context, metaPrefixText)
 	const showSuffixText = metaSuffixText && !sameLabel(context, metaSuffixText)
 	const linkId = metaLink && metaLink.id
@@ -24,7 +28,8 @@ export default ({ metaPrefixText, metaLink, metaAltLink, metaSuffixText, context
 					className="o-teaser__tag"
 					data-trackable="teaser-tag"
 					href={displayLink.relativeUrl || displayLink.url}
-					aria-label={`Category: ${displayLink.prefLabel}`}>
+					aria-label={`Category: ${displayLink.prefLabel}`}
+				>
 					{displayLink.prefLabel}
 				</a>
 			) : null}

--- a/components/x-teaser/src/Title.jsx
+++ b/components/x-teaser/src/Title.jsx
@@ -1,7 +1,7 @@
 import { h } from '@financial-times/x-engine'
 import Link from './Link'
 
-export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators, ...props }) => {
+export default ({ title, altTitle, headlineTesting, relativeUrl, url, teaserMetadata, ...props }) => {
 	const displayTitle = headlineTesting && altTitle ? altTitle : title
 	const displayUrl = relativeUrl || url
 	// o-labels--premium left for backwards compatibility for o-labels v3
@@ -22,10 +22,11 @@ export default ({ title, altTitle, headlineTesting, relativeUrl, url, indicators
 					'data-trackable': 'heading-link',
 					className: 'js-teaser-heading-link',
 					'aria-label': ariaLabel
-				}}>
+				}}
+			>
 				{displayTitle}
 			</Link>
-			{indicators && indicators.accessLevel === 'premium' ? (
+			{teaserMetadata && teaserMetadata.indicators && teaserMetadata.indicators.accessLevel === 'premium' ? (
 				<span>
 					{' '}
 					<span className={premiumClass}>Premium</span>

--- a/components/x-teaser/src/Title.jsx
+++ b/components/x-teaser/src/Title.jsx
@@ -26,7 +26,7 @@ export default ({ title, altTitle, headlineTesting, relativeUrl, url, teaserMeta
 			>
 				{displayTitle}
 			</Link>
-			{teaserMetadata && teaserMetadata.indicators && teaserMetadata.indicators.accessLevel === 'premium' ? (
+			{teaserMetadata?.indicators?.accessLevel === 'premium' ? (
 				<span>
 					{' '}
 					<span className={premiumClass}>Premium</span>

--- a/components/x-teaser/src/Video.jsx
+++ b/components/x-teaser/src/Video.jsx
@@ -5,7 +5,7 @@ import Image from './Image'
 const formatData = (props) =>
 	JSON.stringify({
 		renditions: [props.video],
-		mainImageUrl: props.image ? props.image.url : null
+		mainImageUrl: props.mainImage ? props.mainImage.url : null
 	})
 
 // To prevent React from touching the DOM after mounting… return an empty <div />

--- a/components/x-teaser/src/concerns/rules.js
+++ b/components/x-teaser/src/concerns/rules.js
@@ -9,7 +9,12 @@ const rulesets = {
 			return 'video'
 		}
 
-		if (props.showHeadshot && props.headshot && props.indicators.isColumn) {
+		if (
+			props.showHeadshot &&
+			props.headshot &&
+			props.teaserMetadata &&
+			props.teaserMetadata.indicators.isColumn
+		) {
 			return 'headshot'
 		}
 
@@ -26,11 +31,19 @@ const rulesets = {
 			return 'live'
 		}
 
-		if (props.indicators && props.indicators.isOpinion) {
+		if (
+			props.teaserMetadata &&
+			props.teaserMetadata.indicators &&
+			props.teaserMetadata.indicators.isOpinion
+		) {
 			return 'opinion'
 		}
 
-		if (props.indicators && props.indicators.isEditorsChoice) {
+		if (
+			props.teaserMetadata &&
+			props.teaserMetadata.indicators &&
+			props.teaserMetadata.indicators.isEditorsChoice
+		) {
 			return 'highlight'
 		}
 

--- a/components/x-teaser/src/concerns/rules.js
+++ b/components/x-teaser/src/concerns/rules.js
@@ -5,20 +5,15 @@
 const rulesets = {
 	media: (props) => {
 		// If this condition evaluates to true then no headshot nor image will be displayed.
-		if (props.showVideo && props.video && props.video.url) {
+		if (props.showVideo && props.video?.url) {
 			return 'video'
 		}
 
-		if (
-			props.showHeadshot &&
-			props.headshot &&
-			props.teaserMetadata &&
-			props.teaserMetadata.indicators.isColumn
-		) {
+		if (props.showHeadshot && props.headshot && props.teaserMetadata?.indicators?.isColumn) {
 			return 'headshot'
 		}
 
-		if (props.showImage && props.mainImage && props.mainImage.url) {
+		if (props.showImage && props.mainImage?.url) {
 			return 'image'
 		}
 	},
@@ -31,19 +26,11 @@ const rulesets = {
 			return 'live'
 		}
 
-		if (
-			props.teaserMetadata &&
-			props.teaserMetadata.indicators &&
-			props.teaserMetadata.indicators.isOpinion
-		) {
+		if (props.teaserMetadata?.indicators?.isOpinion) {
 			return 'opinion'
 		}
 
-		if (
-			props.teaserMetadata &&
-			props.teaserMetadata.indicators &&
-			props.teaserMetadata.indicators.isEditorsChoice
-		) {
+		if (props.teaserMetadata?.indicators?.isEditorsChoice) {
 			return 'highlight'
 		}
 

--- a/components/x-teaser/src/concerns/rules.js
+++ b/components/x-teaser/src/concerns/rules.js
@@ -13,7 +13,7 @@ const rulesets = {
 			return 'headshot'
 		}
 
-		if (props.showImage && props.image && props.image.url) {
+		if (props.showImage && props.mainImage && props.mainImage.url) {
 			return 'image'
 		}
 	},


### PR DESCRIPTION
The shape of x-teaser's props were historically designed to match [the shape of data](https://www.youtube.com/watch?v=XFYWazblaUA) that was stored in ElasticSearch. Now the data's shape is declared in `cp-content-pipeline-schema` as a GraphQL schema, and we should update the x-teaser properties to match. This will allow us to remove a hack that was previously in place in `cp-content-pipeline-schema` to support both the new [`Content`](https://github.com/Financial-Times/cp-content-pipeline/blob/609ff6c20a2a3b77df742b1320341fc31908fcbe/packages/schema/typedefs/content.graphql#L1) type (which will subsequently be updated to provide all the metadata x-teaser needs) and the legacy [`Teaser`](https://github.com/Financial-Times/cp-content-pipeline/blob/609ff6c20a2a3b77df742b1320341fc31908fcbe/packages/schema/typedefs/teaser.graphql#L1) type.

This is a breaking change for the component, which we can roll into one major release (v12), along with the changes to x-gift-article. We'll add a wiki page detailing how to migrate both of the components.