### PR TITLE
Gift Article Tracking changes

### DIFF
--- a/components/x-gift-article/src/CreateLinkButton.jsx
+++ b/components/x-gift-article/src/CreateLinkButton.jsx
@@ -24,6 +24,7 @@ export const CreateLinkButton = ({ shareType, actions, enterpriseEnabled }) => {
 			className={`o-buttons o-buttons--big o-buttons--primary share-article-dialog__create-link-button ${
 				enterpriseEnabled ? 'o-buttons--professional' : ''
 			}`}
+			data-trackable={shareType + 'Link'}
 			onClick={createLinkHandler}
 		>
 			Create link

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -6,7 +6,13 @@ import { AdvancedSharingBanner } from './AdvancedSharingBanner'
 
 export default (props) => {
 	return (
-		<div className="o-typography-wrapper share-article-dialog__wrapper" hidden={props.isLoading}>
+		<div
+			className="o-typography-wrapper share-article-dialog__wrapper"
+			hidden={props.isLoading}
+			data-trackable={`share-modal | ${
+				props.enterpriseEnabled && !props.enterpriseRequestAccess ? 'b2b' : 'b2c'
+			}`}
+		>
 			<div className="o-overlay__close" />
 			<AdvancedSharingBanner {...props} />
 			<main className="share-article-dialog__main">

--- a/components/x-gift-article/src/SocialShareButtons.jsx
+++ b/components/x-gift-article/src/SocialShareButtons.jsx
@@ -96,6 +96,7 @@ export const SocialShareButtons = ({
 							href={mailtoUrl}
 							rel="noopener noreferrer"
 							onClick={onClickHandler}
+							data-trackable="email"
 						>
 							<div className="o-share__icon__image">
 								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">

--- a/components/x-gift-article/src/UrlSection.jsx
+++ b/components/x-gift-article/src/UrlSection.jsx
@@ -26,7 +26,7 @@ export const UrlSection = (props) => {
 			<div
 				className="o-forms-input o-forms-input--text o-forms-input--suffix js-gift-article__url-section"
 				data-section-id={shareType + 'Link'}
-				data-trackable={shareType + 'Link'}
+				data-trackable="copy-link"
 			>
 				<input id="share-link" type="text" name={urlType} value={url} readOnly />
 				<button


### PR DESCRIPTION
## Description
Added new data-tracking values in gift article to improve the statistics diagrams in Amplitude.

- Moved the tracking for the link type from copy to create link
- Added new tracking for copying link
- Added `share-modal` value to distinguish from where the social share was made
- Added `b2b` and `b2c` to identify the user

All available tracking journeys for the gift article: 

- Share -> Create link
  - data_trackable_path = “share | top | share-modal | b2b | nonGiftLink"
- Share -> Give access to non-subscribers -> Multiple people
  - data_trackable_path = share | top | share-modal | b2b | enterpriseLink"
- Share -> Give access to non-subscribers -> One person
  - data_trackable_path = “share | top | share-modal | b2b | giftLink"
- Share -> Create link(does not matter which type of link) -> Copy link
  - data_trackable_path = "share | top | share-modal | b2b | copy-link"
- Share -> Create link -> Twitter (all socials - their values -> twitter, facebook, whatsapp, linkedin, email)
  - data_trackable_path = "share | top | share-modal | b2b | twitter"
- Share -> Give access to non-subscribers -> Include highlights
  - data_trackable_path = "share | top | share-modal | b2b | make-highlights-visible"

If the user does not have Advanced sharing enabled it will add 'b2c' as property instead of 'b2b'.

## Link to Jira ticket
https://financialtimes.atlassian.net/browse/ENTST-596