### PR TITLE
Social Share Url Fix in x-gift-article

### DIFF
--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -267,21 +267,6 @@ const withGiftFormActions = withActions(
 				enterprise: undefined,
 				nonGift: createMailtoUrl(props.article.title, `${props.article.url}?shareType=nongift`)
 			},
-
-			mobileShareLinks: {
-				facebook: `http://www.facebook.com/sharer.php?u=${encodeURIComponent(
-					props.article.url
-				)}&t=${encodeURIComponent(props.article.title)}`,
-				twitter: `https://twitter.com/intent/tweet?url=${encodeURIComponent(
-					props.article.url
-				)}&text=${encodeURIComponent(props.article.title)}&via=financialtimes`,
-				linkedin: `http://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(
-					props.article.url
-				)}&title=${encodeURIComponent(props.article.title)}&source=Financial+Times`,
-				whatsapp: `whatsapp://send?text=${encodeURIComponent(props.article.title)}%20-%20${encodeURIComponent(
-					props.article.url
-				)}`
-			},
 			showFreeArticleAlert: false
 		}
 

--- a/components/x-gift-article/src/SocialShareButtons.jsx
+++ b/components/x-gift-article/src/SocialShareButtons.jsx
@@ -4,9 +4,10 @@ import { ShareType } from './lib/constants'
 export const SocialShareButtons = ({
 	actions,
 	mailtoUrl,
-	mobileShareLinks,
 	shareType,
-	enterpriseEnabled
+	enterpriseEnabled,
+	url,
+	article
 }) => {
 	const onClickHandler = (event) => {
 		switch (shareType) {
@@ -22,6 +23,21 @@ export const SocialShareButtons = ({
 			default:
 		}
 	}
+
+	const mobileShareLinks = {
+		facebook: `http://www.facebook.com/sharer.php?u=${encodeURIComponent(
+			url
+		)}&t=${encodeURIComponent(article.title)}`,
+		twitter: `https://twitter.com/intent/tweet?url=${encodeURIComponent(
+			url
+		)}&text=${encodeURIComponent(article.title)}&via=financialtimes`,
+		linkedin: `http://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(
+			url
+		)}&title=${encodeURIComponent(article.title)}&source=Financial+Times`,
+		whatsapp: `whatsapp://send?text=${encodeURIComponent(article.title)}%20-%20${encodeURIComponent(
+			url
+		)}`
+	};
 
 	return (
 		<div>


### PR DESCRIPTION
## Description

- Previous behavior
  - When a user clicks a social share icon the link associated with the icon is a standard link(even for Advanced Sharing). 
- Current behavior 
  - When a user clicks a social share icon the link associated with the icon will be the same as what the user has chosen to generate. 

## Link to the Jira ticket
https://financialtimes.atlassian.net/browse/ENTST-591


## Video Example - Before and After
Now the share link that appears in Twitter's modal is the same as the link generated in the `x-gift-article` modal. 


https://github.com/Financial-Times/x-dash/assets/22678655/f809d226-c12d-410a-8077-9b391d1e774d

