### PR TITLE
add data-trackables to footer message on gift-article

### DIFF
--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -25,6 +25,7 @@ export const FooterMessage = ({
 						href="https://enterprise.ft.com/ft-enterprise-sharing-trial"
 						target="_blank"
 						rel="noreferrer"
+						data-trackable="learn-more"
 					>
 						Tell me more about Advanced Sharing
 					</a>
@@ -40,6 +41,7 @@ export const FooterMessage = ({
 					href="https://enterprise.ft.com/ft-enterprise-sharing-trial"
 					target="_blank"
 					rel="noreferrer"
+					data-trackable="trial-link"
 				>
 					Advanced Sharing
 				</a>
@@ -95,6 +97,7 @@ export const FooterMessage = ({
 						href="https://enterprise-sharing-dashboard.ft.com"
 						target="_blank"
 						rel="noreferrer"
+						data-trackable="see-all-links"
 					>
 						See all shared links
 					</a>


### PR DESCRIPTION
Following Arman's comments on the [Advanced Sharing Highlights tracking spec](https://docs.google.com/spreadsheets/d/1_0Oe5nG-zF_zgFAWFipkXazch_gG8_eQ_0Hsk7IngSY/edit#gid=473047355), I'm adding data-trackables to the footer message