### PR TITLE
chore: make x-interaction a peerDependency of x-live-blog-wrapper to …

### DIFF
--- a/components/x-live-blog-wrapper/package.json
+++ b/components/x-live-blog-wrapper/package.json
@@ -16,13 +16,15 @@
   "license": "ISC",
   "dependencies": {
     "@financial-times/x-engine": "file:../../packages/x-engine",
-    "@financial-times/x-interaction": "file:../x-interaction",
     "@financial-times/x-live-blog-post": "file:../x-live-blog-post"
   },
   "devDependencies": {
     "@financial-times/x-rollup": "file:../../packages/x-rollup",
     "@financial-times/x-test-utils": "file:../../packages/x-test-utils",
     "check-engine": "^1.10.1"
+  },
+  "peerDependencies": {
+    "@financial-times/x-interaction": "file:../x-interaction"
   },
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,7 +216,6 @@
       "license": "ISC",
       "dependencies": {
         "@financial-times/x-engine": "file:../../packages/x-engine",
-        "@financial-times/x-interaction": "file:../x-interaction",
         "@financial-times/x-live-blog-post": "file:../x-live-blog-post"
       },
       "devDependencies": {
@@ -227,6 +226,9 @@
       "engines": {
         "node": "16.x || 18.x",
         "npm": "7.x || 8.x || 9.x"
+      },
+      "peerDependencies": {
+        "@financial-times/x-interaction": "file:../x-interaction"
       }
     },
     "components/x-privacy-manager": {
@@ -28567,7 +28569,6 @@
       "version": "file:components/x-live-blog-wrapper",
       "requires": {
         "@financial-times/x-engine": "file:../../packages/x-engine",
-        "@financial-times/x-interaction": "file:../x-interaction",
         "@financial-times/x-live-blog-post": "file:../x-live-blog-post",
         "@financial-times/x-rollup": "file:../../packages/x-rollup",
         "@financial-times/x-test-utils": "file:../../packages/x-test-utils",


### PR DESCRIPTION
#### Version
Patch

#### Context
We had an incident on Monday where live blogs were failing to load when using the new content pipeline. This was investigated and found to be caused by a mismatch of `x-interaction` versions (v12 in `cp-content-pipeline` and v14 in `x-live-blog-wrapper`).
[#inc-2278-live-blogpost-not-rendering-in-content-pipeline](https://financialtimes.slack.com/archives/C05RQDUHECV/p1694440106588729)
https://response.ftops.tech/incident/2278/

#### Solution
The agreed solution is to make `x-interaction` a peerDependency of `x-live-blog-wrapper` instead of a dependency, and to use the newest version of `x-live-blog-wrapper` in `cp-content-pipeline`.