### PR TITLE
x-gift-article release branch

### DIFF
--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -73,7 +73,7 @@ describe('x-gift-article', () => {
 
 		const subject = mount(<ShareArticleModal {...args} />)
 
-		expect(subject.find('.share-article-dialog__header_article-title').text()).toEqual(
+		expect(subject.find('.share-article-dialog__header-article-title').text()).toEqual(
 			'A given test article title'
 		)
 	})

--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -73,7 +73,9 @@ describe('x-gift-article', () => {
 
 		const subject = mount(<ShareArticleModal {...args} />)
 
-		expect(subject.find('h2').text()).toEqual('A given test article title')
+		expect(subject.find('.share-article-dialog__header_article-title').text()).toEqual(
+			'A given test article title'
+		)
 	})
 
 	it('should call correct endpoints on activate', async () => {

--- a/components/x-gift-article/src/AdvancedSharingBanner.jsx
+++ b/components/x-gift-article/src/AdvancedSharingBanner.jsx
@@ -4,7 +4,7 @@ export const AdvancedSharingBanner = ({ enterpriseEnabled, enterpriseRequestAcce
 	return enterpriseEnabled && !enterpriseRequestAccess ? (
 		<div>
 			<div className="share-article-dialog__banner-strip" />
-			<h4 className="share-article-dialog__banner-title">Advanced Sharing</h4>
+			<h2 className="share-article-dialog__banner-title">Advanced Sharing</h2>
 		</div>
 	) : null
 }

--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -37,7 +37,7 @@ export const FooterMessage = ({
 				Send to multiple people with{' '}
 				<a
 					className="o-typography-professional o-typography-link"
-					href="https://enterprise.ft.com/ft-enterprise-sharing-trial"
+					href="https://professional.ft.com/advanced-sharing-request-access"
 					target="_blank"
 					rel="noreferrer"
 				>

--- a/components/x-gift-article/src/Header.jsx
+++ b/components/x-gift-article/src/Header.jsx
@@ -16,7 +16,7 @@ export const Header = ({
 	) {
 		return (
 			<header>
-				<h3 className="share-article-dialog__header_share-link-title">Sharing link</h3>
+				<h3 className="share-article-dialog__header-share-link-title">Sharing link</h3>
 			</header>
 		)
 	}
@@ -25,8 +25,8 @@ export const Header = ({
 	return (
 		<header>
 			<h3 className="share-article-dialog__header">
-				<span className="share-article-dialog__header_share-article-title">{title}</span>
-				<span className="share-article-dialog__header_article-title">{article.title}</span>
+				<span className="share-article-dialog__header-share-article-title">{title}</span>
+				<span className="share-article-dialog__header-article-title">{article.title}</span>
 			</h3>
 		</header>
 	)

--- a/components/x-gift-article/src/Header.jsx
+++ b/components/x-gift-article/src/Header.jsx
@@ -16,7 +16,7 @@ export const Header = ({
 	) {
 		return (
 			<header>
-				<div className="share-article-dialog__header-share-link-title">Sharing link</div>
+				<h3 className="share-article-dialog__header_share-link-title">Sharing link</h3>
 			</header>
 		)
 	}
@@ -24,8 +24,10 @@ export const Header = ({
 	// when a gift link is not created, the title should be "Share this article:"
 	return (
 		<header>
-			<h5 className="share-article-dialog__header-share-article-title">{title}</h5>
-			<h2 className="share-article-dialog__header-article-title">{article.title}</h2>
+			<h3 className="share-article-dialog__header">
+				<span className="share-article-dialog__header_share-article-title">{title}</span>
+				<span className="share-article-dialog__header_article-title">{article.title}</span>
+			</h3>
 		</header>
 	)
 }

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -12,6 +12,7 @@ export default (props) => {
 			data-trackable={`share-modal | ${
 				props.enterpriseEnabled && !props.enterpriseRequestAccess ? 'b2b' : 'b2c'
 			}`}
+			role="dialog"
 			aria-modal="true"
 		>
 			<button className="share-article-modal__close" aria-label="Close" />

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -12,6 +12,7 @@ export default (props) => {
 			data-trackable={`share-modal | ${
 				props.enterpriseEnabled && !props.enterpriseRequestAccess ? 'b2b' : 'b2c'
 			}`}
+			aria-modal="true"
 		>
 			<button className="share-article-modal__close" aria-label="Close" />
 			<AdvancedSharingBanner {...props} />

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -15,11 +15,11 @@ export default (props) => {
 		>
 			<button className="share-article-modal__close" aria-label="Close" />
 			<AdvancedSharingBanner {...props} />
-			<main className="share-article-dialog__main">
+			<div className="share-article-dialog__main">
 				<Header {...props} />
 				<GiftLinkSection {...props} />
 				<Footer {...props} />
-			</main>
+			</div>
 		</div>
 	)
 }

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -13,7 +13,7 @@ export default (props) => {
 				props.enterpriseEnabled && !props.enterpriseRequestAccess ? 'b2b' : 'b2c'
 			}`}
 		>
-			<div className="o-overlay__close" />
+			<button className="share-article-modal__close" aria-label="Close" />
 			<AdvancedSharingBanner {...props} />
 			<main className="share-article-dialog__main">
 				<Header {...props} />

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -91,7 +91,7 @@
 	margin: 0;
 }
 
-.share-article-dialog__header_share-article-title {
+.share-article-dialog__header-share-article-title {
 	display: block;
 	@include oTypographySans($scale: -1, $weight: 'medium');
 	color: oColorsByName('black');
@@ -99,7 +99,7 @@
 	margin-bottom: oSpacingByName('s1');
 }
 
-.share-article-dialog__header_article-title {
+.share-article-dialog__header-article-title {
 	display: block;
 	@include oTypographyDisplay($scale: 3, $weight: 'medium');
 	color: oColorsByName('black');
@@ -111,7 +111,7 @@
 	text-overflow: ellipsis;
 }
 
-.share-article-dialog__header_share-link-title {
+.share-article-dialog__header-share-link-title {
 	@include oTypographySans($scale: 0, $weight: 'semibold');
 	margin-top: oSpacingByName('s2');
 	margin-bottom: oSpacingByName('s3');
@@ -200,7 +200,6 @@
 	width: 20px;
 	height: 20px;
 	background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?format=svg&source=next-article&tint=%2366605C%2C%2366605C);
-	-webkit-appearance: none;
 	appearance: none;
 	border: 0;
 	font: inherit;
@@ -213,7 +212,6 @@
 	cursor: pointer;
 	font-size: 8px;
 	line-height: 1;
-	-webkit-user-select: none;
 	user-select: none;
 		// Increase hit zone of the button around it for better usability
 		&:after {

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -179,3 +179,39 @@
 		@include oTypographySans($weight: 'medium');
 	}
 }
+
+.share-article-modal__close {
+	display: inline-block;
+	background-repeat: no-repeat;
+	background-size: contain;
+	background-position: 50%;
+	background-color: transparent;
+	vertical-align: baseline;
+	width: 20px;
+	height: 20px;
+	background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?format=svg&source=next-article&tint=%2366605C%2C%2366605C);
+	-webkit-appearance: none;
+	appearance: none;
+	border: 0;
+	font: inherit;
+	outline: inherit;
+	box-sizing: content-box;
+	float: right;
+	position: relative;
+	margin: 12px;
+	padding: 0.25em;
+	cursor: pointer;
+	font-size: 8px;
+	line-height: 1;
+	-webkit-user-select: none;
+	user-select: none;
+		// Increase hit zone of the button around it for better usability
+		&:after {
+			position: absolute;
+			content: '';
+			top: -(oSpacingByName('s3'));
+			right: -(oSpacingByName('s3'));
+			left: -(oSpacingByName('s3'));
+			bottom: -(oSpacingByName('s3'));
+		}
+}

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -180,6 +180,8 @@
 	}
 }
 
+// Stopped using o-overlay but preserved its close functionality
+// Styles copied from o-overlay
 .share-article-modal__close {
 	display: inline-block;
 	background-repeat: no-repeat;

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -87,14 +87,20 @@
 	padding: oSpacingByName('s4');
 }
 
-.share-article-dialog__header-share-article-title {
+.share-article-dialog__header {
+	margin: 0;
+}
+
+.share-article-dialog__header_share-article-title {
+	display: block;
 	@include oTypographySans($scale: -1, $weight: 'medium');
 	color: oColorsByName('black');
 	margin-top: oSpacingByName('s1');
 	margin-bottom: oSpacingByName('s1');
 }
 
-.share-article-dialog__header-article-title {
+.share-article-dialog__header_article-title {
+	display: block;
 	@include oTypographyDisplay($scale: 3, $weight: 'medium');
 	color: oColorsByName('black');
 	margin-top: oSpacingByName('s2');
@@ -105,8 +111,10 @@
 	text-overflow: ellipsis;
 }
 
-.share-article-dialog__header-share-link-title {
+.share-article-dialog__header_share-link-title {
 	@include oTypographySans($scale: 0, $weight: 'semibold');
+	margin-top: oSpacingByName('s2');
+	margin-bottom: oSpacingByName('s3');
 }
 
 .share-article-dialog__non-subscriber-checkbox {

--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -57,7 +57,9 @@ export const SharedLinkTypeSelector = (props) => {
 						onChange={handleChange}
 						disabled={!canShareWithNonSubscribers}
 					/>
-					<span className="o-forms-input__label">Give access to non-subscribers</span>
+					<span className="o-forms-input__label">
+						{advancedSharingEnabled ? 'Give access to non-subscribers' : 'Give access to a non-subscriber'}
+					</span>
 				</label>
 			</span>
 			{!canShareWithNonSubscribers && (

--- a/components/x-gift-article/src/SocialShareButtons.jsx
+++ b/components/x-gift-article/src/SocialShareButtons.jsx
@@ -32,7 +32,7 @@ export const SocialShareButtons = ({ actions, mailtoUrl, shareType, enterpriseEn
 
 	return (
 		<div>
-			<h4 className="share-article-dialog__share-via-socials-title">Or share via</h4>
+			<h3 className="share-article-dialog__share-via-socials-title">Or share via</h3>
 			<div id="social-share-buttons" data-o-component="o-share" className="o-share">
 				<ul className="share-article-dialog__share-via-socials-wrapper">
 					<li className="o-share__action">


### PR DESCRIPTION
## Description
This PR includes multiple bug fixes in `x-gift-article`:

- Updated the Advance Sharing marketing link
- Replaced `main` tag with `div` because only one `main` tag should be present in the page. 
- Updated the close button of the modal.
  - Since we don't use `o-overlay` for the sharing modal, we had to get rid of the `o-overlay__close` style for the close button.
  - Created a custom style class and copied the style of the close button from `o-overlay` so the style of the button does not break in the future when the `o-overlay` gets updated.
- Updated the headings hierarchy and their styles to match the previous design. That change helps screen readers to navigate easily through the modal. 
- Changes to the copy in modal so that we distinguish between plural and singular for users depending on whether the user has Advanced sharing or not.
- Added `aria-modal` to indicate that the sharing dialog is a modal.

## Links to the PRs 
- #741 
- #743 
- https://github.com/Financial-Times/x-dash/pull/744
- https://github.com/Financial-Times/x-dash/pull/745
- https://github.com/Financial-Times/x-dash/pull/749
- https://github.com/Financial-Times/x-dash/pull/748
