### PR TITLE
Modify close button

### DIFF
--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -13,7 +13,7 @@ export default (props) => {
 				props.enterpriseEnabled && !props.enterpriseRequestAccess ? 'b2b' : 'b2c'
 			}`}
 		>
-			<div className="o-overlay__close" />
+			<button className="share-article-modal__close" aria-label="Close" />
 			<AdvancedSharingBanner {...props} />
 			<main className="share-article-dialog__main">
 				<Header {...props} />

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -179,3 +179,39 @@
 		@include oTypographySans($weight: 'medium');
 	}
 }
+
+.share-article-modal__close {
+	display: inline-block;
+	background-repeat: no-repeat;
+	background-size: contain;
+	background-position: 50%;
+	background-color: transparent;
+	vertical-align: baseline;
+	width: 20px;
+	height: 20px;
+	background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?format=svg&source=next-article&tint=%2366605C%2C%2366605C);
+	-webkit-appearance: none;
+	appearance: none;
+	border: 0;
+	font: inherit;
+	outline: inherit;
+	box-sizing: content-box;
+	float: right;
+	position: relative;
+	margin: 12px;
+	padding: 0.25em;
+	cursor: pointer;
+	font-size: 8px;
+	line-height: 1;
+	-webkit-user-select: none;
+	user-select: none;
+		// Increase hit zone of the button around it for better usability
+		&:after {
+			position: absolute;
+			content: '';
+			top: -(oSpacingByName('s3'));
+			right: -(oSpacingByName('s3'));
+			left: -(oSpacingByName('s3'));
+			bottom: -(oSpacingByName('s3'));
+		}
+}


### PR DESCRIPTION
## Description

- Since we don't use `o-overlay` for the sharing modal, we had to get rid of the `o-overlay__close` style for the close button. 
  - Created a custom style class and copied the style of the close button from `o-overlay` so the style of the button does not break in the future when the o-overlay gets updated. 
- The modal is closed with an event in `next-article`
  - Link to the PR in `next-article` https://github.com/Financial-Times/next-article/pull/5281

## Link to the Jira ticket
https://financialtimes.atlassian.net/browse/ENTST-644   