### PR TITLE
Update Twitter handle when sharing live blog posts

### DIFF
--- a/components/x-live-blog-post/src/ShareButtons.jsx
+++ b/components/x-live-blog-post/src/ShareButtons.jsx
@@ -8,7 +8,7 @@ export default ({ postId, articleUrl, title }) => {
 
 	const twitterUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(
 		shareUrl
-	)}&text=${encodeURIComponent(title)}&via=financialtimes`
+	)}&text=${encodeURIComponent(title)}&via=ft`
 	const facebookUrl = `http://www.facebook.com/sharer.php?u=${encodeURIComponent(
 		shareUrl
 	)}&t=${encodeURIComponent(title)}`

--- a/components/x-live-blog-post/src/__tests__/ShareButtons.test.jsx
+++ b/components/x-live-blog-post/src/__tests__/ShareButtons.test.jsx
@@ -16,7 +16,7 @@ describe('x-live-blog-post', () => {
 			const twitterButton = shareButtons.find('.o-share__icon--x').first()
 
 			expect(twitterButton.prop('href')).toEqual(
-				'https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.ft.com%2F%23post-12345&text=Test%20title&via=financialtimes'
+				'https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.ft.com%2F%23post-12345&text=Test%20title&via=ft'
 			)
 		})
 


### PR DESCRIPTION
### Version
Patch

### What
When sharing a live blog post to Twitter/X, the Tweet gets appended with 'via @financialtimes'. We want to change this to 'via @ft'.

### Tested in
✅ Old content pipeline
✅ New content pipeline
❌ App (the app doesn't use share buttons on live blog posts)

### Before
<img width="643" alt="Screenshot 2023-10-03 at 11 29 26" src="https://github.com/Financial-Times/x-dash/assets/22509772/a3731a8a-3113-4c43-9591-1b01e4385f7f">

### After
<img width="612" alt="Screenshot 2023-10-03 at 12 57 46" src="https://github.com/Financial-Times/x-dash/assets/22509772/37a3eaee-e75c-434d-9119-9ce1f0440fd5">
