### PR TITLE
chore: update code owner to reflect new team name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,4 +10,5 @@ components/x-teaser-timeline @Financial-Times/content-discovery
 components/x-topic-search @Financial-Times/content-discovery
 components/x-live-blog-post @Financial-Times/storytelling
 components/x-live-blog-wrapper @Financial-Times/storytelling
-components/x-gift-article @Financial-Times/accounts
+components/x-gift-article @Financial-Times/cp-retention-team
+


### PR DESCRIPTION
As part of the overarching team objective to update our identity, this PR modifies the 'codeowner' entry to align with our newly adopted team name

[Ticket](https://financialtimes.atlassian.net/browse/ACC-2709)