### PR TITLE
feat: truncated posts in live blog

### DIFF
--- a/components/x-live-blog-post/package.json
+++ b/components/x-live-blog-post/package.json
@@ -16,6 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@financial-times/o-icons": "^7.7.0",
     "@financial-times/x-engine": "file:../../packages/x-engine"
   },
   "devDependencies": {
@@ -46,8 +47,8 @@
   },
   "peerDependencies": {
     "@financial-times/o-colors": "^6.4.2",
+    "@financial-times/o-share": "^10.0.0",
     "@financial-times/o-spacing": "^3.2.1",
-    "@financial-times/o-typography": "^7.2.2",
-    "@financial-times/o-share" : "^10.0.0"
+    "@financial-times/o-typography": "^7.2.2"
   }
 }

--- a/components/x-live-blog-post/src/LiveBlogPost.jsx
+++ b/components/x-live-blog-post/src/LiveBlogPost.jsx
@@ -48,7 +48,7 @@ const LiveBlogPost = ({
 	showShareButtons = false,
 	byline,
 	ad,
-	backToTop
+	backToTop,
 }) => {
 	const showBreakingNewsLabel = standout.breakingNews || isBreakingNews
 

--- a/components/x-live-blog-post/src/LiveBlogPost.scss
+++ b/components/x-live-blog-post/src/LiveBlogPost.scss
@@ -1,6 +1,9 @@
+$system-code: 'github:Financial-Times/x-dash' !default;
+
 @import '@financial-times/o-typography/main';
 @import '@financial-times/o-spacing/main';
 @import '@financial-times/o-colors/main';
+@import '@financial-times/o-icons/main';
 
 .x-live-blog-post {
 	border-bottom: 1px solid oColorsByName('black-20');
@@ -99,4 +102,50 @@
 .x-live-blog-post:first-child .x-live-blog-post-controls__back-to-top-link,
 .x-live-blog-post:first-child .x-live-blog-post-controls__back-to-top-button {
 	display: none;
+}
+
+
+.truncated-post {
+
+	.o-expander__content--expanded {
+		.x-live-blog-post__controls {
+			display: block;
+			margin-bottom: oSpacingByName('s6');
+		}
+	}
+
+	.x-live-blog-post__controls {
+		display: none;
+	}
+
+	.x-live-blog-post {
+		margin-top: 0;
+		border-bottom: 0;
+		padding-bottom: 0;
+	}
+
+	.x-live-blog-post__body {
+		margin-bottom: oSpacingByName('s6');;
+	}
+	
+	.o-expander__text--custom {
+		@include oTypographySans($scale: 1);
+		color: oColorsByName('teal');
+		margin-bottom: oSpacingByName('s6');
+		padding-bottom : oSpacingByName('s6');
+		border-bottom: 1px solid oColorsByName('black-20');
+		width: 100%;
+		&[aria-expanded='true']:after {
+			content: '';
+			@include oIconsContent('arrow-up', oColorsByName('teal'), 24);
+			vertical-align: middle;
+			transform: none;
+		}
+	
+		&[aria-expanded='false']:after {
+			content: '';
+			@include oIconsContent('arrow-down', oColorsByName('teal'), 24);
+			vertical-align: middle;
+		}
+	}
 }

--- a/components/x-live-blog-post/storybook/index.jsx
+++ b/components/x-live-blog-post/storybook/index.jsx
@@ -51,6 +51,16 @@ export const ContentBodyWithBackToTopButton = (args) => {
 	)
 }
 
+export const ContentBodyTruncatedPost = (args) => {
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<LiveBlogPost {...args} />
+			<LiveBlogPost {...args} />
+		</div>
+	)
+}
+
 ContentBodyWithBackToTopButton.args = {
 	title: 'Turkey’s virus deaths may be 25% higher than official figure',
 	byline: 'George Russell',
@@ -64,5 +74,22 @@ ContentBodyWithBackToTopButton.args = {
 	publishedDate: '2020-05-13T18:52:28.000Z',
 	articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
 	showShareButtons: true,
+	backToTop: () => {}
+}
+
+ContentBodyTruncatedPost.args = {
+	title: 'Turkey’s virus deaths may be 25% higher than official figure',
+	byline: 'George Russell',
+	isBreakingNews: false,
+	standout: {
+		breakingNews: false
+	},
+	bodyHTML:
+		'<p>Turkey&#x2019;s death toll from coronavirus could be as much as 25 per cent higher than the government&#x2019;s official tally, adding the country of 83m people to the raft of nations that have struggled to accurately capture the impact of the pandemic.</p>\n<p>Ankara has previously rejected suggestions that municipal data from Istanbul, the epicentre of the country&#x2019;s Covid-19 outbreak, showed that there were more deaths from the disease than reported.</p>\n<p>But an analysis of individual death records by the Financial Times raises questions about the Turkish government&#x2019;s explanation for a spike in all-cause mortality in the city of almost 16m people.</p>\n<p><a href="https://www.ft.com/content/80bb222c-b6eb-40ea-8014-563cbe9e0117" target="_blank">Read the article here</a></p>\n<p><img class="picture" src="http://blogs.ft.com/the-world/files/2020/05/istanbul_excess_morts_l.jpg"></p>',
+	id: '12345',
+	publishedDate: '2020-05-13T18:52:28.000Z',
+	articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
+	showShareButtons: true,
+	truncatedPost : true,
 	backToTop: () => {}
 }

--- a/components/x-live-blog-wrapper/package.json
+++ b/components/x-live-blog-wrapper/package.json
@@ -24,6 +24,8 @@
     "check-engine": "^1.10.1"
   },
   "peerDependencies": {
+    "@financial-times/o-expander": "^6.2.6",
+    "@financial-times/o-tracking": "^4.5.0",
     "@financial-times/x-interaction": "file:../x-interaction"
   },
   "repository": {

--- a/components/x-live-blog-wrapper/storybook/index.jsx
+++ b/components/x-live-blog-wrapper/storybook/index.jsx
@@ -1,8 +1,10 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { LiveBlogWrapper } from '../src/LiveBlogWrapper'
+import './index.scss'
 import '@financial-times/x-live-blog-post/src/LiveBlogPost.scss'
 import BuildService from '../../../.storybook/build-service'
-
+import oTracking from '@financial-times/o-tracking';
+import Expander  from '@financial-times/o-expander'
 const dependencies = {
 	'o-fonts': '^5.3.0'
 }
@@ -100,6 +102,79 @@ const defaultProps = {
 	}
 }
 
+
+
+const defaultPropsTruncated = {
+	message: 'Test',
+	id: 'live-blog-wrapper',
+	truncated: true,
+	postTrackerConfig: {
+		onEntersViewport: () => {},
+		onRead: () => {},
+		onError: () => {},
+		usePostTracker: true
+	},
+	posts: [
+		{
+			id: 12345,
+			title: 'Title 1',
+			bodyHTML: `<div data-trackable="header-menu">
+			<span>
+				<div data-trackable="country-selector">
+					<ul>
+						<li data-trackable="china"><button>China</button></li>
+					</ul>
+				</div>
+			</span>
+		</div><p>Post 1</p><p>Post 1</p><p>Post 1</p><p>Post 1</p><p>Post 1</p><p>Post 1</p>`,
+			isBreakingNews: false,
+			publishedDate: '2020-05-13T18:52:28.000Z',
+			articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
+			showShareButtons: true
+		},
+		{
+			id: 12346,
+			title: 'Title 2',
+			bodyHTML: '<p>Post 2</p><p>Post 2</p><p>Post 2</p><p>Post 2</p><p>Post 2</p><p>Post 2</p><p>Post 2</p>',
+			isBreakingNews: true,
+			publishedDate: '2020-05-13T19:52:28.000Z',
+			articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
+			showShareButtons: true
+		},
+		{
+			id: 12347,
+			title: 'Title 3',
+			bodyHTML: '<p>Post 3</p>',
+			isBreakingNews: false,
+			publishedDate: '2020-05-13T20:52:28.000Z',
+			articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
+			showShareButtons: true
+		},
+		{
+			id: 12348,
+			title: 'Title 4',
+			bodyHTML: '<p>Post 4</p><p>Post 4</p><p>Post 4</p><p>Post 4</p><p>Post 4</p><p>Post 4</p>',
+			isBreakingNews: false,
+			publishedDate: '2020-05-13T20:52:28.000Z',
+			articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
+			showShareButtons: true
+		},
+		{
+			id: 12349,
+			title: 'Title 5',
+			bodyHTML: '<p>Post 5</p><p>Post 5</p><p>Post 5</p><p>Post 5</p><p>Post 5</p>',
+			isBreakingNews: false,
+			publishedDate: '2020-05-13T20:52:28.000Z',
+			articleUrl: 'https://www.ft.com/content/2b665ec7-a88f-3998-8f39-5371f9c791ed',
+			showShareButtons: true
+		}
+	],
+	ads: {
+		1: <Ad />,
+		2: <Ad />
+	}
+}
+
 export default {
 	title: 'x-live-blog-wrapper',
 	parameters: {
@@ -115,3 +190,20 @@ export const ContentBody = (args) => (
 )
 
 ContentBody.args = defaultProps
+
+export const ContentBodyTruncated = (args) => {
+	useEffect(() => {console.log("INIT O TRACKER")
+		oTracking.init({test: true})
+		oTracking.click.init("truncated-post");
+		
+			const posts = document.querySelectorAll('.x-live-blog-wrapper .truncated-post')
+			if (posts) posts.forEach((post) => Expander.init(post))
+		
+	})
+	return <div className="story-container">
+		<BuildService dependencies={dependencies} />
+		<LiveBlogWrapper {...args} />
+	</div>
+}
+
+ContentBodyTruncated.args = defaultPropsTruncated

--- a/components/x-live-blog-wrapper/storybook/index.scss
+++ b/components/x-live-blog-wrapper/storybook/index.scss
@@ -1,0 +1,5 @@
+$system-code: 'github:Financial-Times/x-dash' !default;
+
+@import '@financial-times/o-expander/main';
+
+@include oExpander();

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,6 +186,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@financial-times/o-icons": "^7.7.0",
         "@financial-times/x-engine": "file:../../packages/x-engine"
       },
       "devDependencies": {
@@ -215,6 +216,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "@financial-times/o-tracking": "^4.5.0",
         "@financial-times/x-engine": "file:../../packages/x-engine",
         "@financial-times/x-live-blog-post": "file:../x-live-blog-post"
       },
@@ -228,6 +230,7 @@
         "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
+        "@financial-times/o-expander": "^6.2.6",
         "@financial-times/x-interaction": "file:../x-interaction"
       }
     },
@@ -2447,10 +2450,6 @@
         "npm": "^7 || ^8"
       }
     },
-    "node_modules/@financial-times/fticons": {
-      "version": "1.23.1",
-      "peer": true
-    },
     "node_modules/@financial-times/math": {
       "version": "1.1.0",
       "license": "MIT",
@@ -2616,6 +2615,20 @@
         "npm": "^7 || ^8"
       }
     },
+    "node_modules/@financial-times/o-expander": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-expander/-/o-expander-6.2.6.tgz",
+      "integrity": "sha512-KS75UD+gE7LbYpCRR5p3G04tsd1gJb7EJCqsQu7zgLWWfbSnvsvNyBVyiPyc/SLS9w3dnocM6CabrbLFpFF6Eg==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-icons": "^7.0.0",
+        "@financial-times/o-normalise": "^3.3.0",
+        "@financial-times/o-viewport": "^5.0.0"
+      }
+    },
     "node_modules/@financial-times/o-fonts": {
       "version": "5.3.4",
       "license": "MIT",
@@ -2665,13 +2678,11 @@
       }
     },
     "node_modules/@financial-times/o-icons": {
-      "version": "7.5.0",
-      "license": "MIT",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.7.0.tgz",
+      "integrity": "sha512-6peB03pHRpBBn0F2TEHap6dkWO8Ovq4nytS3mNIBDtLEZWBYU97RESpIlq1aARZ7RIxZek2uEtT1oRaSfFv8zw==",
       "engines": {
         "npm": "^7 || ^8"
-      },
-      "peerDependencies": {
-        "@financial-times/fticons": "^1.23.1"
       }
     },
     "node_modules/@financial-times/o-labels": {
@@ -2854,6 +2865,22 @@
         "@financial-times/o-typography": "^7.0.1"
       }
     },
+    "node_modules/@financial-times/o-tracking": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.5.0.tgz",
+      "integrity": "sha512-gPnAmMPqlYWf8xXNJkAYKQMpEWvHpjxajB4YnadbGhOGl2Zy8y5LJJqyzsfpqoBh51P7VDIc7yBF+A7fgaymYw==",
+      "dependencies": {
+        "ftdomdelegate": "^5"
+      },
+      "engines": {
+        "npm": "^7 || ^8"
+      }
+    },
+    "node_modules/@financial-times/o-tracking/node_modules/ftdomdelegate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ftdomdelegate/-/ftdomdelegate-5.0.0.tgz",
+      "integrity": "sha512-P9UmLMIq/ibxxFVBHlE2EIoHcFNDpamn3urRCwVWMnj3o9nAgLtqe64WVuqcGtkN4wujrBYeyxKCuN1/WO+bQw=="
+    },
     "node_modules/@financial-times/o-typography": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-typography/-/o-typography-7.4.1.tgz",
@@ -2878,7 +2905,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.2.0.tgz",
       "integrity": "sha512-fCm8428H6GOpNhpwNXDKCe5Gx9GPyrwgFg26UsAfVCVmyjOMFCp2TxJECP6Y+NaXJqx6ZYU4lhARxSiL2HO+5A==",
-      "dev": true,
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -2888,7 +2914,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-viewport/-/o-viewport-5.1.1.tgz",
       "integrity": "sha512-9v4R2a291ZFhyFalEx3MOMUTHaJ3TDKWJNfgiPtXHtjTR33xsrrnb+DH74jYOzn9L2ixxakOdUTHHPfpJMWwOA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -28240,10 +28265,6 @@
       "version": "2.1.0",
       "dev": true
     },
-    "@financial-times/fticons": {
-      "version": "1.23.1",
-      "peer": true
-    },
     "@financial-times/math": {
       "version": "1.1.0",
       "peer": true,
@@ -28327,6 +28348,13 @@
         "raven-js": "^3.27.2"
       }
     },
+    "@financial-times/o-expander": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-expander/-/o-expander-6.2.6.tgz",
+      "integrity": "sha512-KS75UD+gE7LbYpCRR5p3G04tsd1gJb7EJCqsQu7zgLWWfbSnvsvNyBVyiPyc/SLS9w3dnocM6CabrbLFpFF6Eg==",
+      "peer": true,
+      "requires": {}
+    },
     "@financial-times/o-fonts": {
       "version": "5.3.4",
       "peer": true,
@@ -28347,8 +28375,9 @@
       "requires": {}
     },
     "@financial-times/o-icons": {
-      "version": "7.5.0",
-      "requires": {}
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.7.0.tgz",
+      "integrity": "sha512-6peB03pHRpBBn0F2TEHap6dkWO8Ovq4nytS3mNIBDtLEZWBYU97RESpIlq1aARZ7RIxZek2uEtT1oRaSfFv8zw=="
     },
     "@financial-times/o-labels": {
       "version": "6.5.3",
@@ -28425,6 +28454,21 @@
         "@financial-times/n-map-content-to-topper": "^3.2.0"
       }
     },
+    "@financial-times/o-tracking": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.5.0.tgz",
+      "integrity": "sha512-gPnAmMPqlYWf8xXNJkAYKQMpEWvHpjxajB4YnadbGhOGl2Zy8y5LJJqyzsfpqoBh51P7VDIc7yBF+A7fgaymYw==",
+      "requires": {
+        "ftdomdelegate": "^5"
+      },
+      "dependencies": {
+        "ftdomdelegate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ftdomdelegate/-/ftdomdelegate-5.0.0.tgz",
+          "integrity": "sha512-P9UmLMIq/ibxxFVBHlE2EIoHcFNDpamn3urRCwVWMnj3o9nAgLtqe64WVuqcGtkN4wujrBYeyxKCuN1/WO+bQw=="
+        }
+      }
+    },
     "@financial-times/o-typography": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-typography/-/o-typography-7.4.1.tgz",
@@ -28437,14 +28481,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.2.0.tgz",
       "integrity": "sha512-fCm8428H6GOpNhpwNXDKCe5Gx9GPyrwgFg26UsAfVCVmyjOMFCp2TxJECP6Y+NaXJqx6ZYU4lhARxSiL2HO+5A==",
-      "dev": true,
       "peer": true
     },
     "@financial-times/o-viewport": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-viewport/-/o-viewport-5.1.1.tgz",
       "integrity": "sha512-9v4R2a291ZFhyFalEx3MOMUTHaJ3TDKWJNfgiPtXHtjTR33xsrrnb+DH74jYOzn9L2ixxakOdUTHHPfpJMWwOA==",
-      "dev": true,
       "peer": true,
       "requires": {}
     },
@@ -28555,6 +28597,7 @@
       "requires": {
         "@financial-times/cp-content-pipeline-ui": "^0.4.0",
         "@financial-times/o-colors": "^6.4.2",
+        "@financial-times/o-icons": "^7.7.0",
         "@financial-times/o-spacing": "^3.2.1",
         "@financial-times/o-typography": "^7.2.2",
         "@financial-times/x-engine": "file:../../packages/x-engine",
@@ -28568,6 +28611,7 @@
     "@financial-times/x-live-blog-wrapper": {
       "version": "file:components/x-live-blog-wrapper",
       "requires": {
+        "@financial-times/o-tracking": "*",
         "@financial-times/x-engine": "file:../../packages/x-engine",
         "@financial-times/x-live-blog-post": "file:../x-live-blog-post",
         "@financial-times/x-rollup": "file:../../packages/x-rollup",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "x-dash",
   "private": true,
   "volta": {
-    "node": "18.16.1"
+    "node": "16.20.2"
   },
   "scripts": {
     "clean": "git clean -fxdi",


### PR DESCRIPTION
Changes for truncated post experiment in live blog.
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?selectedIssue=CI-1913)

We want to create an experiment were we truncate all the post of the live blog. 
The experiment is going to have three variants that the only difference is the text for expand and hide the post.


