### PR TITLE
Privacy Manager - Setting permutiveAds as a consent category value

### DIFF
--- a/components/x-privacy-manager/src/__tests__/helpers.js
+++ b/components/x-privacy-manager/src/__tests__/helpers.js
@@ -38,6 +38,14 @@ export const buildPayload = ({ setConsentCookie, consent }) => {
 					status: consent
 				}
 			},
+			permutiveAds: {
+				onsite: {
+					fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',
+					lbi: true,
+					source: 'consuming-app',
+					status: consent
+				}
+			},
 			programmaticAds: {
 				onsite: {
 					fow: 'privacyCCPA/H0IeyQBalorD.6nTqqzhNTKECSgOPJCG',

--- a/components/x-privacy-manager/src/actions.js
+++ b/components/x-privacy-manager/src/actions.js
@@ -24,7 +24,6 @@ function sendConsent({
 
 	return async ({ isLoading, consent }) => {
 		if (isLoading) return
-
 		const categoryPayload = {
 			onsite: {
 				status: consent,
@@ -41,7 +40,8 @@ function sendConsent({
 			data: {
 				behaviouralAds: categoryPayload,
 				demographicAds: categoryPayload,
-				programmaticAds: categoryPayload
+				programmaticAds: categoryPayload,
+				permutiveAds: categoryPayload
 			}
 		}
 


### PR DESCRIPTION
In preparation for the rollout of the new Sourcepoint based Consent Management System (CMP) there is a small update required to ensure that the CCPA consent toggle choices are respected in the ads-stack.
Specifically, when the new CMP is live, the ad-stack will check for the `permutiveAds` value in the FTCONSENT cookie / SCS when determining wether or not to run Permutive code.

This small PR ensures that the CCPA block/allow toggles will set the new 'permutiveAds' category value in the SCS and FTCONSENT cookie.