### PR TITLE
Update n-myft-ui

### DIFF
--- a/components/x-follow-button/package.json
+++ b/components/x-follow-button/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@financial-times/n-myft-ui": "^30.1.0",
+    "@financial-times/n-myft-ui": "^32.0.2",
     "@financial-times/o-buttons": "^7.7.4",
     "@financial-times/o-colors": "^6.4.2",
     "@financial-times/o-icons": "^7.2.1",
@@ -26,7 +26,7 @@
     "sass": "^1.49.0"
   },
   "peerDependencies": {
-    "@financial-times/n-myft-ui": "^30.1.0",
+    "@financial-times/n-myft-ui": "^32.0.2",
     "@financial-times/o-buttons": "^7.7.4",
     "@financial-times/o-colors": "^6.4.2",
     "@financial-times/o-icons": "^7.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "classnames": "^2.2.6"
       },
       "devDependencies": {
-        "@financial-times/n-myft-ui": "^30.1.0",
+        "@financial-times/n-myft-ui": "^32.0.2",
         "@financial-times/o-buttons": "^7.7.4",
         "@financial-times/o-colors": "^6.4.2",
         "@financial-times/o-icons": "^7.2.1",
@@ -99,12 +99,76 @@
         "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
-        "@financial-times/n-myft-ui": "^30.1.0",
+        "@financial-times/n-myft-ui": "^32.0.2",
         "@financial-times/o-buttons": "^7.7.4",
         "@financial-times/o-colors": "^6.4.2",
         "@financial-times/o-icons": "^7.2.1",
         "@financial-times/o-normalise": "^3.3.0",
         "@financial-times/o-typography": "^7.2.2"
+      }
+    },
+    "components/x-follow-button/node_modules/@financial-times/n-myft-ui": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-32.0.2.tgz",
+      "integrity": "sha512-BzgKrfMUuoNRDEShmgvrn4GI4Miw9PxKzxKNLK+ffDqBAUGv7I6qrsW60VHjJzvqCRbalRIQd5AiMBKTYn1CVg==",
+      "dev": true,
+      "dependencies": {
+        "date-fns": "2.30.0",
+        "fetchres": "^1.7.2",
+        "form-serialize": "^0.7.2",
+        "ftdomdelegate": "^4.0.6",
+        "js-cookie": "^2.2.1",
+        "next-myft-client": "^12.0.1",
+        "next-session-client": "^4.0.0",
+        "ready-state": "^2.0.5",
+        "superstore-sync": "^2.1.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      },
+      "peerDependencies": {
+        "@financial-times/n-notification": "^8.2.2",
+        "@financial-times/o-buttons": "^7.7.3",
+        "@financial-times/o-editorial-typography": "^2.3.2",
+        "@financial-times/o-errors": "^5.0.0",
+        "@financial-times/o-forms": "^9.4.0",
+        "@financial-times/o-grid": "^6.1.1",
+        "@financial-times/o-normalise": "^3.3.0",
+        "@financial-times/o-overlay": "^4.0.0",
+        "@financial-times/o-spacing": "^3.0.0",
+        "@financial-times/o-tooltip": "^5.2.4",
+        "n-ui-foundations": "^9.0.0 || ^10.0.0",
+        "react": "^17.0.2"
+      }
+    },
+    "components/x-follow-button/node_modules/next-myft-client": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-12.1.0.tgz",
+      "integrity": "sha512-JDnM23YJa3VrVREmnxxMQM01zaTazP+YQl0zFk+Q5rD3VnRpph7hhi/RSQZk7j7MzVvCFBWmQ4pBOMWNM7BfwA==",
+      "dev": true,
+      "dependencies": {
+        "black-hole-stream": "0.0.1",
+        "fetchres": "^1.7.2",
+        "next-session-client": "^4.0.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "components/x-follow-button/node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "components/x-gift-article": {
@@ -2751,55 +2815,6 @@
       },
       "peerDependencies": {
         "mathsass": "0.10.1"
-      }
-    },
-    "node_modules/@financial-times/n-myft-ui": {
-      "version": "30.4.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-30.4.5.tgz",
-      "integrity": "sha512-h+FiEsJVdeLwBceFkDhjAQ2eeSl2FhcO0UOq8OgQXuoW0OaOvSiXAlfxfqZd/97+oNN2EphiY4IMqOnIBo/Rhg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "date-fns": "2.16.1",
-        "fetchres": "^1.7.2",
-        "form-serialize": "^0.7.2",
-        "ftdomdelegate": "^4.0.6",
-        "js-cookie": "^2.2.1",
-        "next-myft-client": "^10.3.0",
-        "next-session-client": "^4.0.0",
-        "ready-state": "^2.0.5",
-        "superstore-sync": "^2.1.1"
-      },
-      "engines": {
-        "node": "16.x",
-        "npm": "7.x || 8.x || 9.x"
-      },
-      "peerDependencies": {
-        "@financial-times/n-notification": "^8.2.2",
-        "@financial-times/o-buttons": "^7.7.3",
-        "@financial-times/o-editorial-typography": "^2.3.2",
-        "@financial-times/o-errors": "^5.0.0",
-        "@financial-times/o-forms": "^9.4.0",
-        "@financial-times/o-grid": "^6.1.1",
-        "@financial-times/o-normalise": "^3.3.0",
-        "@financial-times/o-overlay": "^4.0.0",
-        "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-tooltip": "^5.2.4",
-        "n-ui-foundations": "^9.0.0",
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/@financial-times/n-myft-ui/node_modules/date-fns": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
-      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/@financial-times/n-notification": {
@@ -22840,22 +22855,6 @@
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz",
       "integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==",
       "dev": true
-    },
-    "node_modules/next-myft-client": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.5.0.tgz",
-      "integrity": "sha512-IQqMJpc3wSzdkk2YOqPl6sJApcWzmOWBliNMZJLcSzgSqKEKVt0YCuQrpuRqKFGkqpduvZ47BL1g7lwXlUjD6g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "black-hole-stream": "0.0.1",
-        "fetchres": "^1.7.2",
-        "next-session-client": "^4.0.0"
-      },
-      "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
-      }
     },
     "node_modules/next-session-client": {
       "version": "4.0.0",


### PR DESCRIPTION
## Why ? 

HI ! I am updating `n-myft-ui` because: 
1. The "save article" feature seems to rely on an old session cookie ([origin convo](https://financialtimes.slack.com/archives/C042NBBTM/p1702907414857149))
2. Alex found that the pb was probably `n-myft-ui` using an old `next-myft-client` and updated it. 
3. So now we want that updated `n-myft-ui` for `next-myft-page`

And this is where the fun begins. 
To update `n-myft-ui` on `next-myft-page`, I need to update a bunch of stuff :), including having `x-follow-button` using the last  `n-myft-ui`. 

## What are the changes on n-myft-ui

1. Of course it got that update for **next-myft-client**, which is what we want here. 
2. It also got some minor support work for n-ui-foundation 
3. It is now using react 17 ! But from react themselves,  "The React 17 release is unusual because it doesn’t add any new developer-facing features. Instead, this release is primarily focused on making it easier to upgrade React itself." ([source](https://legacy.reactjs.org/blog/2020/10/20/react-v17.html)) so I think it's all good. 
5. The error message style has changed, which should not affect us here
6. It also supports node 18 

## Test

How did I test that?   
I ran the tests. lol.  
I also checked storybook.  
I linked x-follow-button to next-myft-page on my machine and run it and tried playing with it, including on different screen sizes and it looks like nothing broke. 
