### PR TITLE
ENTST 807 | Keep include highlights box ticked when switching between options

### DIFF
--- a/components/x-gift-article/src/AdvancedSharingOptions.jsx
+++ b/components/x-gift-article/src/AdvancedSharingOptions.jsx
@@ -10,7 +10,6 @@ export const AdvancedSharingOptions = (props) => {
 			actions.showEnterpriseUrlSection(event)
 		} else if (event.target.value === ShareType.gift) {
 			actions.showGiftUrlSection(event)
-			actions.setIncludeHighlights(false)
 		}
 	}
 


### PR DESCRIPTION
## What does this change?

- Ensures that the `Include highlights` checkbox remains ticked when switching between one and multiple people.

## Screenshots

### Before
https://github.com/Financial-Times/x-dash/assets/1771189/2e3bee3a-1236-42cc-95fa-74a383b7d253

### After
https://github.com/Financial-Times/x-dash/assets/1771189/160422f7-5380-4e7e-804e-b919770dc954.mov




