### PR TITLE
Add Advance Sharing first use event dispatch

### DIFF
--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -100,6 +100,13 @@ const withGiftFormActions = withActions(
 
 					if (redemptionUrl) {
 						tracking.createESLink(redemptionUrl)
+
+						const sharesCount = document.cookie.match(new RegExp(`(^| )ES_COUNT=([^;]+)`))?.at(2)
+						if (Number(sharesCount) === 1) {
+							const firstUseEvent = new Event('advanced-sharing-first-use')
+							document.dispatchEvent(firstUseEvent)
+						}
+
 						return updaters.setGiftUrl(redemptionUrl, redemptionLimit, false, true)(state)
 					} else {
 						return updaters.setErrorState(true)


### PR DESCRIPTION
## Description

A New Advanced Sharing tooltip will be displayed on `next-article` after the first use of AS.  
Every time a user creates a new  Adanvced Sharing link the `ES_COUNT` cookie gets updated with the total number of shares.

Changes: 
- A new custom event will be dispatched based on the `ES_COUNT` value after the user creates a new Advanced Sharing link. 
  -  If `ES_COUNT` is equal to 1 an `advanced-sharing-first-use` event will be dispatched and later on caught by `next-article`.

### Link to Jira ticket
https://financialtimes.atlassian.net/browse/ENTST-790