### PR TITLE
ENTST 788 | Remove save message for highlighted article with different content

### DIFF
--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -134,6 +134,33 @@ describe('x-gift-article', () => {
 		expect(subject.find('#no-credit-alert')).not.toExist()
 	})
 
+	it('when the article content has changed since highlights were shared, a message to save highlights is not shown', async () => {
+		const args = {
+			...baseArgs,
+			userIsAHighlightsRecipient: true,
+			showAdvancedSharingOptions: true,
+			giftCredits: 10,
+			monthlyAllowance: 100,
+			hasHighlights: true
+		}
+
+		// Add a message to the document body to simulate the banner that is shown when the article content has changed.
+		// We rely on the presence of this banner to determine whether to show the message to save highlights.
+		document.body.innerHTML += '<div class="missing-highlight-message"></div>'
+
+		const subject = mount(<ShareArticleModal {...args} actionsRef={(a) => Object.assign(actions, a)} />)
+
+		await actions.activate()
+
+		subject.update()
+
+		// We expect this message to not appear when the article content has changed, as any included highlights are invalidated.
+		expect(subject.find({ children: 'save the highlights' })).not.toExist()
+
+		// Clean up the message we added to the document body.
+		document.body.removeChild(document.querySelector('.missing-highlight-message'))
+	})
+
 	it('when a highlights token is included in the url, a message is shown offering to save highlights', async () => {
 		const args = {
 			...baseArgs,

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -276,9 +276,19 @@ const withGiftFormActions = withActions(
 		const userHasNotYetSavedSharedAnnotations =
 			!parsedSavedAnnotationsFromLocalStorage().includes(highlightsToken)
 
-		// We only want to display the highlights recipient message if the user is a
-		// highlights recipient and has not yet saved the shared annotations for this highlight token.
-		const showHighlightsRecipientMessage = userIsAHighlightsRecipient && userHasNotYetSavedSharedAnnotations
+		// We use the absence of the missing-highlight-message class to determine
+		// if the article has not changed since the highlights were shared.
+		const articleHasNotChangedSinceHighlightsWereShared =
+			document.querySelector('.missing-highlight-message') === null
+
+		// We only want to display the highlights recipient message if:
+		// - The user is a highlights recipient
+		// - Has not yet saved the shared annotations for this highlight token.
+		// - Has visited an article that hasn't changed since the highlights were shared.
+		const showHighlightsRecipientMessage =
+			userIsAHighlightsRecipient &&
+			userHasNotYetSavedSharedAnnotations &&
+			articleHasNotChangedSinceHighlightsWereShared
 
 		const initialState = {
 			title: 'Share this article:',

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -277,18 +277,15 @@ const withGiftFormActions = withActions(
 			!parsedSavedAnnotationsFromLocalStorage().includes(highlightsToken)
 
 		// We use the absence of the missing-highlight-message class to determine
-		// if the article has not changed since the highlights were shared.
-		const articleHasNotChangedSinceHighlightsWereShared =
-			document.querySelector('.missing-highlight-message') === null
+		// if the highlights have not been removed.
+		const highlightsHaveNotBeenRemoved = document.querySelector('.missing-highlight-message') === null
 
 		// We only want to display the highlights recipient message if:
 		// - The user is a highlights recipient
 		// - Has not yet saved the shared annotations for this highlight token.
-		// - Has visited an article that hasn't changed since the highlights were shared.
+		// - Has visited an article that hasn't changed since the highlights were shared (if it had changed, the highlights would have been removed).
 		const showHighlightsRecipientMessage =
-			userIsAHighlightsRecipient &&
-			userHasNotYetSavedSharedAnnotations &&
-			articleHasNotChangedSinceHighlightsWereShared
+			userIsAHighlightsRecipient && userHasNotYetSavedSharedAnnotations && highlightsHaveNotBeenRemoved
 
 		const initialState = {
 			title: 'Share this article:',


### PR DESCRIPTION
## What does this change?

- Don't show the highlights recipient message if the article content has changed since the shared article highlights were first added
- Adds a test to ensure that the save the highlights message is not displayed when the article content has changed since highlights were added

## How was this tested?

- Locally using an instance of `next-article` with the `x-gift-article` package linked.

## Screenshots

### Before

![Screenshot 2024-02-05 at 16 42 19](https://github.com/Financial-Times/x-dash/assets/1771189/74bfc90b-b781-4e67-9e34-eeaac0b14081)

### After

![Screenshot 2024-02-05 at 16 44 08](https://github.com/Financial-Times/x-dash/assets/1771189/4b9a6183-4824-430d-b391-8a3b3141acb0)
