### PR TITLE
add optional prop to make article save button icon only

### DIFF
--- a/components/x-article-save-button/src/ArticleSaveButton.jsx
+++ b/components/x-article-save-button/src/ArticleSaveButton.jsx
@@ -41,7 +41,7 @@ export const ArticleSaveButton = (props) => {
 				aria-pressed={props.saved}
 			>
 				<span className="x-article-save-button__icon" />
-				{props.saved ? 'Saved' : 'Save'}
+				{props.iconOnly ? '' : props.saved ? 'Saved' : 'Save'}
 			</button>
 		</form>
 	)


### PR DESCRIPTION
PR to add a property to `x-article-save-button` to make it icon only 

| Before  | After |
| ------------- | ------------- |
|![Screenshot from 2024-02-07 18-16-20](https://github.com/Financial-Times/x-dash/assets/110396496/3af370b3-7c8c-4acf-a1a1-00effaec41ae)|![Screenshot from 2024-02-07 19-21-02](https://github.com/Financial-Times/x-dash/assets/110396496/240e3943-f742-4832-b118-f322e990e900)|