### PR TITLE
fix: give webpack >=4 support to x-engine

### DIFF
--- a/packages/x-engine/package.json
+++ b/packages/x-engine/package.json
@@ -21,7 +21,6 @@
   "publishConfig": {
     "access": "public"
   },
-
   "volta": {
     "extends": "../../package.json"
   },
@@ -29,7 +28,7 @@
     "check-engine": "^1.10.1"
   },
   "peerDependencies": {
-    "webpack": "4.x"
+    "webpack": ">=4.0.0"
   },
   "dependencies": {
     "assign-deep": "^1.0.1"


### PR DESCRIPTION
Allow to install x-engine along with webpack 5 or greater.
I have tested with it and works right. Also i think probably is going to work with future versions too thats why set greater than version 4.