### PR TITLE
ELES-1055 Change confirmation copy in the sharing modal

### DIFF
--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -62,7 +62,9 @@ export const FooterMessage = ({
 	if (shareType === ShareType.gift) {
 		const redemptionLimitUnit = redemptionLimit === 1 ? 'time' : 'times'
 		const creditUnit = giftCredits === 1 ? 'credit' : 'credits'
-		const redemptionLimitMessage = `Link can be viewed ${redemptionLimit} ${redemptionLimitUnit} and is valid for 90 days.`
+		const redemptionLimitMessage = `Link can be viewed ${redemptionLimit} ${redemptionLimitUnit} and is valid for 90 days. ${
+			includeHighlights ? 'Your highlights will be visible to recipients.' : ''
+		}`
 		const creditsMessage = `You still have ${giftCredits} ${creditUnit} left this month.`
 
 		return (
@@ -74,10 +76,11 @@ export const FooterMessage = ({
 	}
 
 	if (shareType === ShareType.nonGift) {
+		const advancedSharingFTsubscribersOnlyMessage = `Only FT subscribers will be able to see the full article using this link. ${
+			includeHighlights ? 'Your highlights will be visible to recipients.' : ''
+		}`
 		return (
-			<p className="share-article-dialog__footer-message-shared-link">
-				Only FT subscribers will be able to see the full article using this link.
-			</p>
+			<p className="share-article-dialog__footer-message-shared-link">{advancedSharingFTsubscribersOnlyMessage}</p>
 		)
 	}
 


### PR DESCRIPTION
With this PR is added missing ‘Your highlights will be visible to recipients.’ sentence each time a user has shared the article with highlights using 'one person' or 'FT subscribers only' options.

Related JIRA ticket: [ELES-1055](https://financialtimes.atlassian.net/browse/ELES-1055)
