### PR TITLE
ElES-1039 changes to the share modal web 

### DIFF
--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -64,20 +64,6 @@ describe('x-gift-article', () => {
 		fetchMock.reset()
 	})
 
-	it('displays the article title', async () => {
-		const args = {
-			...baseArgs
-		}
-
-		args.article.title = 'A given test article title'
-
-		const subject = mount(<ShareArticleModal {...args} />)
-
-		expect(subject.find('.share-article-dialog__header-article-title').text()).toEqual(
-			'A given test article title'
-		)
-	})
-
 	it('should call correct endpoints on activate', async () => {
 		mount(<ShareArticleModal {...baseArgs} actionsRef={(a) => Object.assign(actions, a)} />)
 
@@ -244,6 +230,7 @@ describe('x-gift-article', () => {
 
 		await actions.activate()
 
+		await actions.showNonGiftUrlSection()
 		await actions.shortenNonGiftUrl()
 
 		subject.update()

--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -49,6 +49,7 @@ describe('x-gift-article', () => {
 			})
 			.get('path:/v1/users/me/allowance', {
 				limit: 120,
+				budget: 100,
 				hasCredits: true
 			})
 			.post('path:/v1/shares', {

--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -11,7 +11,7 @@ const articleUrlRedeemed = 'https://gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 const baseArgs = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/src/AdvancedSharingOptions.jsx
+++ b/components/x-gift-article/src/AdvancedSharingOptions.jsx
@@ -1,10 +1,10 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from './lib/constants'
 import { NoCreditAlert } from './NoCreditAlert'
-import { ReceivedHighlightsAlert } from './ReceivedHighlightsAlert'
 
 export const AdvancedSharingOptions = (props) => {
-	const { shareType, actions, enterpriseHasCredits, giftCredits, showHighlightsRecipientMessage } = props
+	const { shareType, actions, enterpriseHasCredits, giftCredits } = props
+
 	const onValueChange = (event) => {
 		if (event.target.value === ShareType.enterprise) {
 			actions.showEnterpriseUrlSection(event)
@@ -19,6 +19,9 @@ export const AdvancedSharingOptions = (props) => {
 				className="o-forms-field o-forms-field--optional o-forms-field--professional share-article-dialog__advanced-sharing-options"
 				role="group"
 			>
+				<h3 className="share-article-dialog__header">
+					<span className="share-article-dialog__header-share-article-title">Share using:</span>
+				</h3>
 				<span className="o-forms-input o-forms-input--radio-round">
 					<span className="o-forms-input--radio-round__container">
 						<label htmlFor="share-with-multiple-people-radio">
@@ -31,7 +34,14 @@ export const AdvancedSharingOptions = (props) => {
 								onChange={onValueChange}
 								disabled={!enterpriseHasCredits}
 							/>
-							<span className="o-forms-input__label">Multiple people</span>
+							<div className="o-forms-input__label share-article-dialog__advanced-sharing-options--element">
+								<span className="share-article-dialog__advanced-sharing-options--element-title">
+									Advanced Sharing
+								</span>
+								<span className="share-article-dialog__advanced-sharing-options--element-description">
+									Lets you share with multiple non-subscribers
+								</span>
+							</div>
 						</label>
 						<label htmlFor="share-with-one-person-radio">
 							<input
@@ -43,7 +53,15 @@ export const AdvancedSharingOptions = (props) => {
 								onChange={onValueChange}
 								disabled={!giftCredits}
 							/>
-							<span className="o-forms-input__label">One person</span>
+							<div className="o-forms-input__label share-article-dialog__advanced-sharing-options--element">
+								<span className="share-article-dialog__advanced-sharing-options--element-title">
+									Gift article
+								</span>
+								<span className="share-article-dialog__advanced-sharing-options--element-description">
+									Gift up to 20 articles per month to single non-subscribers. You have x articles left this
+									month.
+								</span>
+							</div>
 						</label>
 					</span>
 				</span>
@@ -54,7 +72,6 @@ export const AdvancedSharingOptions = (props) => {
 					other option.
 				</NoCreditAlert>
 			)}
-			{showHighlightsRecipientMessage && <ReceivedHighlightsAlert {...props} />}
 		</div>
 	)
 }

--- a/components/x-gift-article/src/AdvancedSharingOptions.jsx
+++ b/components/x-gift-article/src/AdvancedSharingOptions.jsx
@@ -58,8 +58,8 @@ export const AdvancedSharingOptions = (props) => {
 									Gift article
 								</span>
 								<span className="share-article-dialog__advanced-sharing-options--element-description">
-									Gift up to 20 articles per month to single non-subscribers. You have x articles left this
-									month.
+									Gift up to 20 articles per month to single non-subscribers. You have {giftCredits} articles
+									left this month.
 								</span>
 							</div>
 						</label>

--- a/components/x-gift-article/src/AdvancedSharingOptions.jsx
+++ b/components/x-gift-article/src/AdvancedSharingOptions.jsx
@@ -13,7 +13,7 @@ export const AdvancedSharingOptions = (props) => {
 		}
 	}
 
-	return (
+	return giftCredits || enterpriseHasCredits ? (
 		<div>
 			<div
 				className="o-forms-field o-forms-field--optional o-forms-field--professional share-article-dialog__advanced-sharing-options"
@@ -68,10 +68,9 @@ export const AdvancedSharingOptions = (props) => {
 			</div>
 			{(!giftCredits || !enterpriseHasCredits) && (
 				<NoCreditAlert>
-					One of the non-subscriber choices is not available because you’ve run out of credits. Please use the
-					other option.
+					One of the choices is not available because you’ve run out of credits. Please use the other option.
 				</NoCreditAlert>
 			)}
 		</div>
-	)
+	) : null
 }

--- a/components/x-gift-article/src/CreateLinkButton.jsx
+++ b/components/x-gift-article/src/CreateLinkButton.jsx
@@ -27,7 +27,7 @@ export const CreateLinkButton = ({ shareType, actions, enterpriseEnabled }) => {
 			data-trackable={shareType + 'Link'}
 			onClick={createLinkHandler}
 		>
-			Share
+			Get sharing link
 		</button>
 	)
 }

--- a/components/x-gift-article/src/CreateLinkButton.jsx
+++ b/components/x-gift-article/src/CreateLinkButton.jsx
@@ -1,8 +1,14 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from './lib/constants'
 import oShare from '@financial-times/o-share/main'
+import { canShareWithNonSubscribers, isNonSubscriberOption } from './lib/highlightsHelpers'
 
-export const CreateLinkButton = ({ shareType, actions, enterpriseEnabled }) => {
+export const CreateLinkButton = (props) => {
+	const { shareType, actions, enterpriseEnabled, isFreeArticle } = props
+
+	const _canShareWithNonSubscribers = canShareWithNonSubscribers(props)
+	const _isNonSubscriberOption = isNonSubscriberOption(props)
+
 	const createLinkHandler = async () => {
 		switch (shareType) {
 			case ShareType.gift:
@@ -20,6 +26,7 @@ export const CreateLinkButton = ({ shareType, actions, enterpriseEnabled }) => {
 	}
 	return (
 		<button
+			disabled={!_canShareWithNonSubscribers && _isNonSubscriberOption && !isFreeArticle}
 			id="create-link-button"
 			className={`o-buttons o-buttons--big o-buttons--primary share-article-dialog__create-link-button ${
 				enterpriseEnabled ? 'o-buttons--professional' : ''

--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -41,7 +41,8 @@ export const FooterMessage = ({
 	if (isFreeArticle) {
 		return !showFreeArticleAlert ? (
 			<p className="share-article-dialog__footer-message-shared-link">
-				Anyone will be able to see the full article using this link.
+				Anyone will be able to see the full article using this link.{' '}
+				{includeHighlights ? 'Your highlights will be visible to recipients.' : ''}
 			</p>
 		) : null
 	}

--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -13,7 +13,8 @@ export const FooterMessage = ({
 	includeHighlights,
 	isFreeArticle,
 	showFreeArticleAlert,
-	advancedSharingArticlesBudget
+	advancedSharingArticlesBudget,
+	isRegisteredUser
 }) => {
 	// if the share link button has not been clicked yet
 	if (!(isGiftUrlCreated || isNonGiftUrlShortened)) {
@@ -39,6 +40,9 @@ export const FooterMessage = ({
 	}
 
 	// when the share link has been created
+	if (isRegisteredUser) {
+		return null
+	}
 
 	if (isFreeArticle) {
 		return !showFreeArticleAlert ? (

--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -12,7 +12,8 @@ export const FooterMessage = ({
 	enterpriseRequestAccess,
 	includeHighlights,
 	isFreeArticle,
-	showFreeArticleAlert
+	showFreeArticleAlert,
+	advancedSharingArticlesBudget
 }) => {
 	// if the share link button has not been clicked yet
 	if (!(isGiftUrlCreated || isNonGiftUrlShortened)) {
@@ -84,7 +85,9 @@ export const FooterMessage = ({
 		return (
 			<div className="share-article-dialog__footer-message-shared-link">
 				<p>{advancedSharingLimitMessage}</p>
-				{/* <p>Your organisation can still share x articles via Advanced Sharing.</p> */}
+				<p>
+					Your organisation can still share {advancedSharingArticlesBudget} articles via Advanced Sharing.
+				</p>
 				<p>
 					<a
 						className="o-typography-professional o-typography-link"

--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -29,8 +29,7 @@ export const FooterMessage = ({
 					href="https://professional.ft.com/advanced-sharing-request-access"
 					target="_blank"
 					rel="noreferrer"
-					data-trackable="trial-link"
-				>
+					data-trackable="trial-link">
 					Advanced Sharing
 				</a>
 			</p>
@@ -49,11 +48,11 @@ export const FooterMessage = ({
 
 	if (shareType === ShareType.gift) {
 		const redemptionLimitUnit = redemptionLimit === 1 ? 'time' : 'times'
-		const creditUnit = giftCredits === 1 ? 'credit' : 'credits'
+		const creditUnit = giftCredits === 1 ? 'article' : 'articles'
 		const redemptionLimitMessage = `Link can be viewed ${redemptionLimit} ${redemptionLimitUnit} and is valid for 90 days. ${
 			includeHighlights ? 'Your highlights will be visible to recipients.' : ''
 		}`
-		const creditsMessage = `You still have ${giftCredits} ${creditUnit} left this month.`
+		const creditsMessage = `You now have ${giftCredits} gift ${creditUnit} remaining this month.`
 
 		return (
 			<div className="share-article-dialog__footer-message-shared-link">
@@ -68,28 +67,29 @@ export const FooterMessage = ({
 			includeHighlights ? 'Your highlights will be visible to recipients.' : ''
 		}`
 		return (
-			<p className="share-article-dialog__footer-message-shared-link">{advancedSharingFTsubscribersOnlyMessage}</p>
+			<p className="share-article-dialog__footer-message-shared-link">
+				{advancedSharingFTsubscribersOnlyMessage}
+			</p>
 		)
 	}
 
 	if (shareType === ShareType.enterprise) {
 		const advancedSharingLimitUnit = enterpriseLimit === 1 ? 'time' : 'times'
-		const advancedSharingLimitMessage = `Link can be viewed ${enterpriseLimit} ${advancedSharingLimitUnit}. ${
+		const advancedSharingLimitMessage = `Because you used Advanced Sharing, this shared article can be viewed ${enterpriseLimit} ${advancedSharingLimitUnit}. ${
 			includeHighlights ? 'Your highlights will be visible to recipients.' : ''
 		}`
 
 		return (
 			<div className="share-article-dialog__footer-message-shared-link">
 				<p>{advancedSharingLimitMessage}</p>
+				{/* <p>Your organisation can still share x articles via Advanced Sharing.</p> */}
 				<p>
-					We’ve added this link to your list.{' '}
 					<a
 						className="o-typography-professional o-typography-link"
 						href="https://enterprise-sharing-dashboard.ft.com"
 						target="_blank"
 						rel="noreferrer"
-						data-trackable="see-all-links"
-					>
+						data-trackable="see-all-links">
 						See all shared links
 					</a>
 				</p>

--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -23,7 +23,7 @@ export const FooterMessage = ({
 
 		return enterpriseEnabled ? ( // when the user is b2b
 			<p className="share-article-dialog__footer-message">
-				Send to multiple people with{' '}
+				Share with multiple non-subscribers via{' '}
 				<a
 					className="o-typography-professional o-typography-link"
 					href="https://professional.ft.com/advanced-sharing-request-access"

--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -29,7 +29,8 @@ export const FooterMessage = ({
 					href="https://professional.ft.com/advanced-sharing-request-access"
 					target="_blank"
 					rel="noreferrer"
-					data-trackable="trial-link">
+					data-trackable="trial-link"
+				>
 					Advanced Sharing
 				</a>
 			</p>
@@ -63,7 +64,7 @@ export const FooterMessage = ({
 		)
 	}
 
-	if (shareType === ShareType.nonGift) {
+	if (shareType === ShareType.nonGift && enterpriseEnabled) {
 		const advancedSharingFTsubscribersOnlyMessage = `Only FT subscribers will be able to see the full article using this link. ${
 			includeHighlights ? 'Your highlights will be visible to recipients.' : ''
 		}`
@@ -90,7 +91,8 @@ export const FooterMessage = ({
 						href="https://enterprise-sharing-dashboard.ft.com"
 						target="_blank"
 						rel="noreferrer"
-						data-trackable="see-all-links">
+						data-trackable="see-all-links"
+					>
 						See all shared links
 					</a>
 				</p>

--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -64,7 +64,7 @@ export const FooterMessage = ({
 		)
 	}
 
-	if (shareType === ShareType.nonGift && enterpriseEnabled) {
+	if (shareType === ShareType.nonGift) {
 		const advancedSharingFTsubscribersOnlyMessage = `Only FT subscribers will be able to see the full article using this link. ${
 			includeHighlights ? 'Your highlights will be visible to recipients.' : ''
 		}`

--- a/components/x-gift-article/src/FooterMessage.jsx
+++ b/components/x-gift-article/src/FooterMessage.jsx
@@ -18,19 +18,7 @@ export const FooterMessage = ({
 	if (!(isGiftUrlCreated || isNonGiftUrlShortened)) {
 		// when the user is b2b and has advanced sharing enabled
 		if (enterpriseEnabled && !enterpriseRequestAccess) {
-			return (
-				<div className="share-article-dialog__footer-message">
-					<a
-						className="o-typography-professional o-typography-link share-article-dialog__footer-message"
-						href="https://enterprise.ft.com/ft-enterprise-sharing-trial"
-						target="_blank"
-						rel="noreferrer"
-						data-trackable="learn-more"
-					>
-						Tell me more about Advanced Sharing
-					</a>
-				</div>
-			)
+			return null
 		}
 
 		return enterpriseEnabled ? ( // when the user is b2b

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -305,7 +305,7 @@ const withGiftFormActions = withActions(
 			userIsAHighlightsRecipient && userHasNotYetSavedSharedAnnotations && highlightsHaveNotBeenRemoved
 
 		const initialState = {
-			title: 'Share this article With:',
+			title: 'Share this article with:',
 			giftCredits: undefined,
 			monthlyAllowance: undefined,
 			showCopyButton: isCopySupported,

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -189,9 +189,13 @@ const withGiftFormActions = withActions(
 						enterpriseHasCredits: hasCredits,
 						enterpriseRequestAccess: requestAccess,
 						showAdvancedSharingOptions: advancedSharingEnabled,
-						showNonSubscriberOptions: true,
+						showNonSubscriberOptions: enabled && !advancedSharingEnabled,
 						shareType:
-							advancedSharingEnabled && !initialProps.isFreeArticle ? ShareType.enterprise : ShareType.nonGift
+							advancedSharingEnabled && !initialProps.isFreeArticle
+								? ShareType.enterprise
+								: enabled && !advancedSharingEnabled
+								? ShareType.gift
+								: ShareType.nonGift
 					}
 
 					if (enabled) {

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -189,13 +189,13 @@ const withGiftFormActions = withActions(
 						enterpriseHasCredits: hasCredits,
 						enterpriseRequestAccess: requestAccess,
 						showAdvancedSharingOptions: advancedSharingEnabled,
-						showNonSubscriberOptions: enabled && !advancedSharingEnabled,
+						showNonSubscriberOptions: !advancedSharingEnabled,
 						shareType:
 							advancedSharingEnabled && !initialProps.isFreeArticle
 								? ShareType.enterprise
-								: enabled && !advancedSharingEnabled
-								? ShareType.gift
-								: ShareType.nonGift
+								: advancedSharingEnabled
+								? ShareType.nonGift
+								: ShareType.gift
 					}
 
 					if (enabled) {

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -32,6 +32,10 @@ const withGiftFormActions = withActions(
 				return updaters.showGiftEnterpriseSection
 			},
 
+			showNonSubscriberSharingOptions() {
+				return updaters.showNonSubscriberSharingOptions
+			},
+
 			showNonGiftUrlSection() {
 				return updaters.showNonGiftUrlSection
 			},
@@ -40,8 +44,8 @@ const withGiftFormActions = withActions(
 				return updaters.showAdvancedSharingOptions
 			},
 
-			hideAdvancedSharingOptions() {
-				return updaters.hideAdvancedSharingOptions
+			hideNonSubscriberSharingOptions() {
+				return updaters.hideNonSubscriberSharingOptions
 			},
 
 			async createGiftUrl() {
@@ -178,10 +182,15 @@ const withGiftFormActions = withActions(
 					const { enabled, limit, hasCredits, requestAccess } =
 						await enterpriseApi.getEnterpriseArticleAllowance()
 
+					const advancedSharingEnabled = enabled && !requestAccess
+
 					const enterpriseState = {
 						enterpriseLimit: limit,
 						enterpriseHasCredits: hasCredits,
-						enterpriseRequestAccess: requestAccess
+						enterpriseRequestAccess: requestAccess,
+						showAdvancedSharingOptions: advancedSharingEnabled,
+						showNonSubscriberOptions: true,
+						shareType: advancedSharingEnabled ? ShareType.enterprise : undefined
 					}
 
 					if (enabled) {
@@ -208,6 +217,7 @@ const withGiftFormActions = withActions(
 							Object.assign(freeArticleState, updaters.setShortenedNonGiftUrl(url)(state))
 							freeArticleState.showFreeArticleAlert = true
 						}
+
 						return freeArticleState
 					} else {
 						const { giftCredits, monthlyAllowance, nextRenewalDate } = await api.getGiftArticleAllowance()
@@ -224,6 +234,7 @@ const withGiftFormActions = withActions(
 							return {
 								invalidResponseFromApi: true,
 								enterpriseEnabled: enabled,
+								test: true,
 								...enterpriseState
 							}
 						}
@@ -288,7 +299,7 @@ const withGiftFormActions = withActions(
 			userIsAHighlightsRecipient && userHasNotYetSavedSharedAnnotations && highlightsHaveNotBeenRemoved
 
 		const initialState = {
-			title: 'Share this article:',
+			title: 'Share this article With:',
 			giftCredits: undefined,
 			monthlyAllowance: undefined,
 			showCopyButton: isCopySupported,
@@ -297,6 +308,7 @@ const withGiftFormActions = withActions(
 			isNonGiftUrlShortened: false,
 			includeHighlights: false,
 			showAdvancedSharingOptions: false,
+			showNonSubscriberOptions: false,
 			hasHighlights: false,
 			showHighlightsRecipientMessage,
 			showHighlightsSuccessMessage: false,

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -190,7 +190,8 @@ const withGiftFormActions = withActions(
 						enterpriseRequestAccess: requestAccess,
 						showAdvancedSharingOptions: advancedSharingEnabled,
 						showNonSubscriberOptions: true,
-						shareType: advancedSharingEnabled ? ShareType.enterprise : undefined
+						shareType:
+							advancedSharingEnabled && !initialProps.isFreeArticle ? ShareType.enterprise : ShareType.nonGift
 					}
 
 					if (enabled) {
@@ -234,7 +235,6 @@ const withGiftFormActions = withActions(
 							return {
 								invalidResponseFromApi: true,
 								enterpriseEnabled: enabled,
-								test: true,
 								...enterpriseState
 							}
 						}

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -179,7 +179,7 @@ const withGiftFormActions = withActions(
 
 			activate() {
 				return async (state) => {
-					const { enabled, limit, hasCredits, requestAccess } =
+					const { enabled, limit, hasCredits, requestAccess, budget } =
 						await enterpriseApi.getEnterpriseArticleAllowance()
 
 					const advancedSharingEnabled = enabled && !requestAccess
@@ -190,11 +190,10 @@ const withGiftFormActions = withActions(
 						enterpriseRequestAccess: requestAccess,
 						showAdvancedSharingOptions: advancedSharingEnabled,
 						showNonSubscriberOptions: !advancedSharingEnabled,
+						advancedSharingArticlesBudget: budget,
 						shareType:
-							advancedSharingEnabled && !initialProps.isFreeArticle
+							advancedSharingEnabled && !initialProps.isFreeArticle && hasCredits
 								? ShareType.enterprise
-								: advancedSharingEnabled
-								? ShareType.nonGift
 								: ShareType.gift
 					}
 

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -179,20 +179,23 @@ const withGiftFormActions = withActions(
 
 			activate() {
 				return async (state) => {
-					const { enabled, limit, hasCredits, requestAccess, budget } =
+					const { enabled, limit, hasCredits, requestAccess, budget, isRegisteredUser } =
 						await enterpriseApi.getEnterpriseArticleAllowance()
 
 					const advancedSharingEnabled = enabled && !requestAccess
 
 					const enterpriseState = {
 						enterpriseLimit: limit,
+						isRegisteredUser: isRegisteredUser,
 						enterpriseHasCredits: hasCredits,
 						enterpriseRequestAccess: requestAccess,
 						showAdvancedSharingOptions: advancedSharingEnabled,
 						showNonSubscriberOptions: !advancedSharingEnabled,
 						advancedSharingArticlesBudget: budget,
 						shareType:
-							advancedSharingEnabled && !initialProps.isFreeArticle && hasCredits
+							initialProps.isFreeArticle || isRegisteredUser
+								? ShareType.nonGift
+								: advancedSharingEnabled && hasCredits
 								? ShareType.enterprise
 								: ShareType.gift
 					}

--- a/components/x-gift-article/src/GiftLinkSection.jsx
+++ b/components/x-gift-article/src/GiftLinkSection.jsx
@@ -4,9 +4,17 @@ import { ShareType } from './lib/constants'
 import { UrlSection } from './UrlSection'
 import { CreateLinkButton } from './CreateLinkButton'
 import { FreeArticleAlert } from './FreeArticleAlert'
+import { ReceivedHighlightsAlert } from './ReceivedHighlightsAlert'
+import { IncludeHighlights } from './IncludeHighlights'
 
 export const GiftLinkSection = (props) => {
-	const { isGiftUrlCreated, shareType, isNonGiftUrlShortened, showFreeArticleAlert } = props
+	const {
+		isGiftUrlCreated,
+		shareType,
+		isNonGiftUrlShortened,
+		showFreeArticleAlert,
+		showHighlightsRecipientMessage
+	} = props
 
 	// when the gift url is created or the non-gift url is shortened, show the url section
 	if (
@@ -20,6 +28,9 @@ export const GiftLinkSection = (props) => {
 		<div>
 			{showFreeArticleAlert && <FreeArticleAlert />}
 			{!showFreeArticleAlert && <SharedLinkTypeSelector {...props} />}
+			{showHighlightsRecipientMessage && <ReceivedHighlightsAlert {...props} />}
+			<IncludeHighlights {...props} />
+
 			<CreateLinkButton {...props} />
 		</div>
 	)

--- a/components/x-gift-article/src/GiftLinkSection.jsx
+++ b/components/x-gift-article/src/GiftLinkSection.jsx
@@ -29,6 +29,7 @@ export const GiftLinkSection = (props) => {
 			{showFreeArticleAlert && <FreeArticleAlert />}
 			{!showFreeArticleAlert && <SharedLinkTypeSelector {...props} />}
 			{showHighlightsRecipientMessage && <ReceivedHighlightsAlert {...props} />}
+
 			<IncludeHighlights {...props} />
 
 			<CreateLinkButton {...props} />

--- a/components/x-gift-article/src/Header.jsx
+++ b/components/x-gift-article/src/Header.jsx
@@ -1,7 +1,8 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from './lib/constants'
 
-export const Header = ({ isGiftUrlCreated, shareType, isNonGiftUrlShortened, showFreeArticleAlert }) => {
+export const Header = (props) => {
+	const { title, isGiftUrlCreated, shareType, isNonGiftUrlShortened, showFreeArticleAlert } = props
 	// when a gift link is created or shortened, the title is "Sharing link"
 	if (
 		isGiftUrlCreated ||
@@ -14,18 +15,11 @@ export const Header = ({ isGiftUrlCreated, shareType, isNonGiftUrlShortened, sho
 		)
 	}
 
-	// when a gift link is not created, the title should be "Share this article:"
 	return (
 		<header>
 			<h3 className="share-article-dialog__header">
-				<span className="share-article-dialog__header-share-article-title">Share this article with:</span>
+				<span className="share-article-dialog__header-share-article-title">{title}</span>
 			</h3>
-			<div className="o-buttons-group">
-				<button className="o-buttons o-buttons--primary o-buttons--professional">Non-subscriber</button>
-				<button className="o-buttons o-buttons--secondary o-buttons--professional">
-					FT subscribers only
-				</button>
-			</div>
 		</header>
 	)
 }

--- a/components/x-gift-article/src/Header.jsx
+++ b/components/x-gift-article/src/Header.jsx
@@ -1,14 +1,7 @@
 import { h } from '@financial-times/x-engine'
 import { ShareType } from './lib/constants'
 
-export const Header = ({
-	title,
-	article,
-	isGiftUrlCreated,
-	shareType,
-	isNonGiftUrlShortened,
-	showFreeArticleAlert
-}) => {
+export const Header = ({ isGiftUrlCreated, shareType, isNonGiftUrlShortened, showFreeArticleAlert }) => {
 	// when a gift link is created or shortened, the title is "Sharing link"
 	if (
 		isGiftUrlCreated ||
@@ -25,9 +18,14 @@ export const Header = ({
 	return (
 		<header>
 			<h3 className="share-article-dialog__header">
-				<span className="share-article-dialog__header-share-article-title">{title}</span>
-				<span className="share-article-dialog__header-article-title">{article.title}</span>
+				<span className="share-article-dialog__header-share-article-title">Share this article with:</span>
 			</h3>
+			<div className="o-buttons-group">
+				<button className="o-buttons o-buttons--primary o-buttons--professional">Non-subscriber</button>
+				<button className="o-buttons o-buttons--secondary o-buttons--professional">
+					FT subscribers only
+				</button>
+			</div>
 		</header>
 	)
 }

--- a/components/x-gift-article/src/IncludeHighlights.jsx
+++ b/components/x-gift-article/src/IncludeHighlights.jsx
@@ -1,0 +1,26 @@
+import { h } from '@financial-times/x-engine'
+
+export const IncludeHighlights = (props) => {
+	const { actions, hasHighlights, enterpriseEnabled, includeHighlights } = props
+
+	const includeHighlightsHandler = (event) => {
+		actions.setIncludeHighlights(event.target.checked)
+	}
+
+	return hasHighlights && enterpriseEnabled ? (
+		<div className="o-forms-input o-forms-input--checkbox o-forms-field share-article-dialog__include-highlights">
+			<label htmlFor="includeHighlights">
+				<input
+					type="checkbox"
+					id="includeHighlights"
+					name="includeHighlights"
+					value={includeHighlights}
+					checked={includeHighlights}
+					onChange={includeHighlightsHandler}
+					data-trackable="make-highlights-visible"
+				/>
+				<span className="o-forms-input__label x-gift-article__checkbox-span">Include highlights</span>
+			</label>
+		</div>
+	) : null
+}

--- a/components/x-gift-article/src/IncludeHighlights.jsx
+++ b/components/x-gift-article/src/IncludeHighlights.jsx
@@ -1,13 +1,16 @@
 import { h } from '@financial-times/x-engine'
+import { canShareWithNonSubscribers, isNonSubscriberOption } from './lib/highlightsHelpers'
 
 export const IncludeHighlights = (props) => {
 	const { actions, hasHighlights, enterpriseEnabled, includeHighlights } = props
+	const _canShareWithNonSubscribers = canShareWithNonSubscribers(props)
+	const _isNonSubscriberOption = isNonSubscriberOption(props)
 
 	const includeHighlightsHandler = (event) => {
 		actions.setIncludeHighlights(event.target.checked)
 	}
 
-	return hasHighlights && enterpriseEnabled ? (
+	return hasHighlights && enterpriseEnabled && (_canShareWithNonSubscribers || !_isNonSubscriberOption) ? (
 		<div
 			className="o-forms-field o-forms-field--optional o-forms-field--professional share-article-dialog__include-highlights"
 			role="group"

--- a/components/x-gift-article/src/IncludeHighlights.jsx
+++ b/components/x-gift-article/src/IncludeHighlights.jsx
@@ -8,19 +8,24 @@ export const IncludeHighlights = (props) => {
 	}
 
 	return hasHighlights && enterpriseEnabled ? (
-		<div className="o-forms-input o-forms-input--checkbox o-forms-field share-article-dialog__include-highlights">
-			<label htmlFor="includeHighlights">
-				<input
-					type="checkbox"
-					id="includeHighlights"
-					name="includeHighlights"
-					value={includeHighlights}
-					checked={includeHighlights}
-					onChange={includeHighlightsHandler}
-					data-trackable="make-highlights-visible"
-				/>
-				<span className="o-forms-input__label x-gift-article__checkbox-span">Include highlights</span>
-			</label>
+		<div
+			className="o-forms-field o-forms-field--optional o-forms-field--professional share-article-dialog__include-highlights"
+			role="group"
+		>
+			<div className="o-forms-input o-forms-input--checkbox o-forms-field">
+				<label htmlFor="includeHighlights">
+					<input
+						type="checkbox"
+						id="includeHighlights"
+						name="includeHighlights"
+						value={includeHighlights}
+						checked={includeHighlights}
+						onChange={includeHighlightsHandler}
+						data-trackable="make-highlights-visible"
+					/>
+					<span className="o-forms-input__label x-gift-article__checkbox-span">Include highlights</span>
+				</label>
+			</div>
 		</div>
 	) : null
 }

--- a/components/x-gift-article/src/ReceivedHighlightsAlert.jsx
+++ b/components/x-gift-article/src/ReceivedHighlightsAlert.jsx
@@ -42,7 +42,7 @@ export const ReceivedHighlightsAlert = ({ actions }) => {
 			<div className="o-message__container">
 				<div className="o-message__content">
 					<p className="o-message__content-main">
-						If you wish to share the highlighted article{' '}
+						If you wish to share the highlighted article{', '}
 						{/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
 						<a
 							className="o-typography-professional o-typography-link"

--- a/components/x-gift-article/src/ReceivedHighlightsAlert.jsx
+++ b/components/x-gift-article/src/ReceivedHighlightsAlert.jsx
@@ -42,7 +42,7 @@ export const ReceivedHighlightsAlert = ({ actions }) => {
 			<div className="o-message__container">
 				<div className="o-message__content">
 					<p className="o-message__content-main">
-						If you wish to share the article with the highlights, you need to{' '}
+						If you wish to share the highlighted article{' '}
 						{/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
 						<a
 							className="o-typography-professional o-typography-link"
@@ -52,7 +52,7 @@ export const ReceivedHighlightsAlert = ({ actions }) => {
 						>
 							save the highlights
 						</a>{' '}
-						first.
+						as your own before creating the link.
 					</p>
 				</div>
 				<button className="o-message__close" onClick={actions.closeHighlightsRecipientMessage} />

--- a/components/x-gift-article/src/RegisteredUserAlert.jsx
+++ b/components/x-gift-article/src/RegisteredUserAlert.jsx
@@ -1,0 +1,17 @@
+import { h } from '@financial-times/x-engine'
+
+export const RegisteredUserAlert = ({ children }) => {
+	return (
+		<div
+			id="registered-user-alert"
+			className="o-message o-message--alert o-message--neutral"
+			data-o-component="o-message"
+		>
+			<div className="o-message__container">
+				<div className="o-message__content">
+					<p className="o-message__content-main">{children}</p>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -2,7 +2,6 @@ import { h } from '@financial-times/x-engine'
 import { Header } from './Header'
 import { GiftLinkSection } from './GiftLinkSection'
 import { Footer } from './Footer'
-import { AdvancedSharingBanner } from './AdvancedSharingBanner'
 
 export default (props) => {
 	return (
@@ -16,7 +15,6 @@ export default (props) => {
 			aria-modal="true"
 		>
 			<button className="share-article-modal__close" aria-label="Close" />
-			<AdvancedSharingBanner {...props} />
 			<div className="share-article-dialog__main">
 				<Header {...props} />
 				<GiftLinkSection {...props} />

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -27,6 +27,7 @@ export default (props) => {
 			<div className="share-article-dialog__main">
 				<Header {...props} />
 				{!isFreeArticle &&
+				enterpriseEnabled &&
 				!(
 					isGiftUrlCreated ||
 					(shareType === ShareType.nonGift && isNonGiftUrlShortened && !showFreeArticleAlert)

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -6,14 +6,20 @@ import { SharingOptionsToggler } from './SharingOptionsToggler'
 import { ShareType } from './lib/constants'
 
 export default (props) => {
-	const { isGiftUrlCreated, shareType, isNonGiftUrlShortened, showFreeArticleAlert, isFreeArticle } = props
+	const {
+		isGiftUrlCreated,
+		shareType,
+		isNonGiftUrlShortened,
+		showFreeArticleAlert,
+		isFreeArticle,
+		enterpriseEnabled,
+		enterpriseRequestAccess
+	} = props
 	return (
 		<div
 			className="o-typography-wrapper share-article-dialog__wrapper"
 			hidden={props.isLoading}
-			data-trackable={`share-modal | ${
-				props.enterpriseEnabled && !props.enterpriseRequestAccess ? 'b2b' : 'b2c'
-			}`}
+			data-trackable={`share-modal | ${enterpriseEnabled && !enterpriseRequestAccess ? 'b2b' : 'b2c'}`}
 			role="dialog"
 			aria-modal="true"
 		>

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -3,8 +3,10 @@ import { Header } from './Header'
 import { GiftLinkSection } from './GiftLinkSection'
 import { Footer } from './Footer'
 import { SharingOptionsToggler } from './SharingOptionsToggler'
+import { ShareType } from './lib/constants'
 
 export default (props) => {
+	const { isGiftUrlCreated, shareType, isNonGiftUrlShortened, showFreeArticleAlert, isFreeArticle } = props
 	return (
 		<div
 			className="o-typography-wrapper share-article-dialog__wrapper"
@@ -17,8 +19,14 @@ export default (props) => {
 		>
 			<button className="share-article-modal__close" aria-label="Close" />
 			<div className="share-article-dialog__main">
-				{!props.isFreeArticle ? <SharingOptionsToggler {...props} /> : null}
 				<Header {...props} />
+				{!isFreeArticle &&
+				!(
+					isGiftUrlCreated ||
+					(shareType === ShareType.nonGift && isNonGiftUrlShortened && !showFreeArticleAlert)
+				) ? (
+					<SharingOptionsToggler {...props} />
+				) : null}
 				<GiftLinkSection {...props} />
 				<Footer {...props} />
 			</div>

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -13,8 +13,10 @@ export default (props) => {
 		showFreeArticleAlert,
 		isFreeArticle,
 		enterpriseEnabled,
-		enterpriseRequestAccess
+		enterpriseRequestAccess,
+		isRegisteredUser
 	} = props
+
 	return (
 		<div
 			className="o-typography-wrapper share-article-dialog__wrapper"
@@ -29,6 +31,7 @@ export default (props) => {
 				{!isFreeArticle &&
 				!(
 					isGiftUrlCreated ||
+					isRegisteredUser ||
 					(shareType === ShareType.nonGift && isNonGiftUrlShortened && !showFreeArticleAlert)
 				) ? (
 					<SharingOptionsToggler {...props} />

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -27,7 +27,6 @@ export default (props) => {
 			<div className="share-article-dialog__main">
 				<Header {...props} />
 				{!isFreeArticle &&
-				enterpriseEnabled &&
 				!(
 					isGiftUrlCreated ||
 					(shareType === ShareType.nonGift && isNonGiftUrlShortened && !showFreeArticleAlert)

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -2,6 +2,7 @@ import { h } from '@financial-times/x-engine'
 import { Header } from './Header'
 import { GiftLinkSection } from './GiftLinkSection'
 import { Footer } from './Footer'
+import { SharingOptionsToggler } from './SharingOptionsToggler'
 
 export default (props) => {
 	return (
@@ -16,6 +17,7 @@ export default (props) => {
 		>
 			<button className="share-article-modal__close" aria-label="Close" />
 			<div className="share-article-dialog__main">
+				{!props.isFreeArticle ? <SharingOptionsToggler {...props} /> : null}
 				<Header {...props} />
 				<GiftLinkSection {...props} />
 				<Footer {...props} />

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -209,7 +209,6 @@
 .share-article-dialog__advanced-sharing-options {
 	margin-block: oSpacingByName('s4');
 	&--element {
-		display: flex !important;
 		flex-direction: column;
 		gap: calc(oSpacingByName('s1') / 2);
 	}
@@ -222,6 +221,11 @@
 		@include oTypographySans($scale: -1, $weight: 'regular');
 		color: oColorsByName('black-60');
 	}
+}
+
+// This is to override the display: inline-block from .o-forms-input__label
+.share-article-dialog__advanced-sharing-options--element.o-forms-input__label {
+	display: flex;
 }
 
 .share-article-dialog__include-highlights {

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -170,6 +170,7 @@
 
 .share-article-dialog__create-link-button {
 	width: 100%;
+	margin-top: oSpacingByName('s6');
 }
 
 .share-article-dialog__footer {
@@ -217,7 +218,7 @@
 }
 
 .share-article-dialog__include-highlights {
-	margin-block: oSpacingByName('s6');
+	margin-top: oSpacingByName('s6');
 }
 
 .share-article-dialog__share-via-socials-title {
@@ -240,7 +241,6 @@
 
 .share-article-dialog__alert {
 	margin-top: oSpacingByName('s4');
-	margin-bottom: oSpacingByName('s4');
 	strong {
 		@include oTypographySans($weight: 'medium');
 	}

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -200,6 +200,12 @@
 	width: 100%;
 }
 
+.share-article-dialog__advanced-non-subscriber {
+	&--element {
+		margin-top: oSpacingByName('s4');
+	}
+}
+
 .share-article-dialog__advanced-sharing-options {
 	margin-block: oSpacingByName('s4');
 	&--element {

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -16,7 +16,8 @@
 			'big'
 		),
 		'types': (
-			'primary'
+			'primary',
+			'secondary'
 		),
 		'themes': (
 			'professional',

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -102,7 +102,8 @@
 
 .share-article-dialog__wrapper {
 	@include oNormaliseBoxSizing();
-	border-radius: oSpacingByName('s1');
+	border-radius: calc(oSpacingByName('s2') + 2px);
+	border: 1px solid oColorsByName('black-20');
 	background: oColorsByName('white');
 	box-shadow: 2px 2px 8px rgba(15, 10, 46, 0.09);
 	width: oSpacingByName('s8') * 11; // 32 * 11 = 352px

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -31,7 +31,8 @@
 		'elements': (
 			'text',
 			'radio-round',
-			'checkbox'
+			'checkbox',
+			'radio-box'
 		),
 		'features': (
 			'inline',
@@ -94,6 +95,11 @@
 	)
 );
 
+.o-forms-input,
+.o-forms-field {
+	margin: 0;
+}
+
 .share-article-dialog__wrapper {
 	@include oNormaliseBoxSizing();
 	border-radius: oSpacingByName('s1');
@@ -122,11 +128,12 @@
 }
 
 .share-article-dialog__main {
-	padding: oSpacingByName('s4');
+	padding: oSpacingByName('s6') oSpacingByName('s4') oSpacingByName('s4') oSpacingByName('s4');
 }
 
 .share-article-dialog__header {
 	margin: 0;
+	margin-bottom: oSpacingByName('s4');
 }
 
 .share-article-dialog__header-share-article-title {
@@ -176,7 +183,7 @@
 }
 
 .share-article-dialog__footer-message {
-	@include oTypographySans($scale: 0, $weight: 'regular');
+	@include oTypographySans($scale: -1, $weight: 'regular');
 	color: oColorsByName('ft-grey');
 	margin-bottom: 0;
 }
@@ -192,12 +199,25 @@
 }
 
 .share-article-dialog__advanced-sharing-options {
-	margin-left: oSpacingByName('s8') + 5;
-	margin-bottom: oSpacingByName('s4');
+	margin-block: oSpacingByName('s4');
+	&--element {
+		display: flex !important;
+		flex-direction: column;
+		gap: calc(oSpacingByName('s1') / 2);
+	}
+
+	&--element-title {
+		@include oTypographySans($scale: 0, $weight: 'semibold');
+	}
+
+	&--element-description {
+		@include oTypographySans($scale: -1, $weight: 'regular');
+		color: oColorsByName('black-60');
+	}
 }
 
 .share-article-dialog__include-highlights {
-	margin-bottom: oSpacingByName('s1');
+	margin-block: oSpacingByName('s6');
 }
 
 .share-article-dialog__share-via-socials-title {

--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -41,7 +41,7 @@ export const SharedLinkTypeSelector = (props) => {
 			)}
 			{isRegisteredUser && (
 				<RegisteredUserAlert>
-					Only FT subscribers will be able to see the full article using this link.
+					Only FT subscribers will be able to see the full article using this link.{' '}
 					<a
 						className="o-typography-professional o-typography-link"
 						href="https://subs.ft.com/"

--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -1,10 +1,17 @@
 import { h } from '@financial-times/x-engine'
 import { NoCreditAlert } from './NoCreditAlert'
+import { RegisteredUserAlert } from './RegisteredUserAlert'
 import { AdvancedSharingOptions } from './AdvancedSharingOptions'
 import { canShareWithNonSubscribers, isNonSubscriberOption } from './lib/highlightsHelpers'
 
 export const SharedLinkTypeSelector = (props) => {
-	const { enterpriseEnabled, giftCredits, showNonSubscriberOptions, showAdvancedSharingOptions } = props
+	const {
+		enterpriseEnabled,
+		giftCredits,
+		showNonSubscriberOptions,
+		showAdvancedSharingOptions,
+		isRegisteredUser
+	} = props
 	const _canShareWithNonSubscribers = canShareWithNonSubscribers(props)
 	const _isNonSubscriberOption = isNonSubscriberOption(props)
 
@@ -32,8 +39,23 @@ export const SharedLinkTypeSelector = (props) => {
 					.
 				</NoCreditAlert>
 			)}
+			{isRegisteredUser && (
+				<RegisteredUserAlert>
+					Only FT subscribers will be able to see the full article using this link.
+					<a
+						className="o-typography-professional o-typography-link"
+						href="https://subs.ft.com/"
+						rel="noreferrer"
+						target="_blank"
+						data-trackable="enterprise-out-of-credits"
+					>
+						Subscribe
+					</a>{' '}
+					to share with non-subscribers.
+				</RegisteredUserAlert>
+			)}
 			{showAdvancedSharingOptions && <AdvancedSharingOptions {...props} />}
-			{!showAdvancedSharingOptions && showNonSubscriberOptions && giftCredits > 0 && (
+			{!showAdvancedSharingOptions && showNonSubscriberOptions && giftCredits > 0 && !isRegisteredUser && (
 				<div className="o-forms-input__label share-article-dialog__advanced-non-subscriber--element">
 					<span className="share-article-dialog__advanced-sharing-options--element-description">
 						Gift up to 20 articles per month to single non-subscribers. You have {giftCredits} articles left

--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -7,7 +7,7 @@ export const SharedLinkTypeSelector = (props) => {
 		enterpriseEnabled,
 		enterpriseHasCredits,
 		giftCredits,
-
+		showNonSubscriberOptions,
 		showAdvancedSharingOptions
 	} = props
 	const canShareWithNonSubscribers = giftCredits > 0 || enterpriseHasCredits
@@ -36,6 +36,14 @@ export const SharedLinkTypeSelector = (props) => {
 				</NoCreditAlert>
 			)}
 			{showAdvancedSharingOptions && <AdvancedSharingOptions {...props} />}
+			{!showAdvancedSharingOptions && showNonSubscriberOptions && giftCredits > 0 && (
+				<div className="o-forms-input__label share-article-dialog__advanced-sharing-options--element">
+					<span className="share-article-dialog__advanced-sharing-options--element-description">
+						Gift up to 20 articles per month to single non-subscribers. You have {giftCredits} articles left
+						this month.
+					</span>
+				</div>
+			)}
 		</div>
 	)
 }

--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -1,48 +1,16 @@
 import { h } from '@financial-times/x-engine'
-import { AdvancedSharingOptions } from './AdvancedSharingOptions'
-import { ShareType } from './lib/constants'
 import { NoCreditAlert } from './NoCreditAlert'
+import { AdvancedSharingOptions } from './AdvancedSharingOptions'
 
 export const SharedLinkTypeSelector = (props) => {
 	const {
-		shareType,
-		actions,
 		enterpriseEnabled,
-		enterpriseRequestAccess,
-		showAdvancedSharingOptions,
 		enterpriseHasCredits,
 		giftCredits,
-		hasHighlights,
-		includeHighlights
+
+		showAdvancedSharingOptions
 	} = props
-	const advancedSharingEnabled = enterpriseEnabled && !enterpriseRequestAccess
 	const canShareWithNonSubscribers = giftCredits > 0 || enterpriseHasCredits
-
-	const handleChange = (event) => {
-		if (advancedSharingEnabled) {
-			if (event.target.checked) {
-				enterpriseHasCredits ? actions.showEnterpriseUrlSection(event) : actions.showGiftUrlSection(event)
-				actions.showAdvancedSharingOptions()
-			} else {
-				actions.hideAdvancedSharingOptions(event)
-				actions.setIncludeHighlights(false)
-			}
-			return
-		}
-
-		if (event.target.checked) {
-			// if the checkbox is checked, the user wants to share the article with non-subscribers
-			actions.showGiftUrlSection(event)
-		} else {
-			// if the checkbox is unchecked, the user wants to share the article with subscribers only
-			actions.showNonGiftUrlSection(event)
-		}
-	}
-
-	const includeHighlightsHandler = (event) => {
-		actions.setIncludeHighlights(event.target.checked)
-	}
-
 	return (
 		<div
 			id="share-with-non-subscribers-checkbox"
@@ -52,22 +20,6 @@ export const SharedLinkTypeSelector = (props) => {
 			role="group"
 			aria-labelledby="share-with-non-subscribers-checkbox"
 		>
-			<span className="o-forms-input o-forms-input--checkbox">
-				<label htmlFor="share-with-non-subscribers-checkbox">
-					<input
-						className="o-forms-field--professional"
-						id="share-with-non-subscribers-checkbox"
-						name="share-with-non-subscribers-checkbox"
-						type="checkbox"
-						checked={shareType === ShareType.gift || showAdvancedSharingOptions}
-						onChange={handleChange}
-						disabled={!canShareWithNonSubscribers}
-					/>
-					<span className="o-forms-input__label">
-						{advancedSharingEnabled ? 'Give access to non-subscribers' : 'Give access to a non-subscriber'}
-					</span>
-				</label>
-			</span>
 			{!canShareWithNonSubscribers && (
 				<NoCreditAlert>
 					You’ve run out of sharing credits for non-subscribers. You can still share it with FT subscribers
@@ -84,22 +36,6 @@ export const SharedLinkTypeSelector = (props) => {
 				</NoCreditAlert>
 			)}
 			{showAdvancedSharingOptions && <AdvancedSharingOptions {...props} />}
-			{hasHighlights && enterpriseEnabled && (
-				<div className="o-forms-input o-forms-input--checkbox o-forms-field share-article-dialog__include-highlights">
-					<label htmlFor="includeHighlights">
-						<input
-							type="checkbox"
-							id="includeHighlights"
-							name="includeHighlights"
-							value={includeHighlights}
-							checked={includeHighlights}
-							onChange={includeHighlightsHandler}
-							data-trackable="make-highlights-visible"
-						/>
-						<span className="o-forms-input__label x-gift-article__checkbox-span">Include highlights</span>
-					</label>
-				</div>
-			)}
 		</div>
 	)
 }

--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -1,16 +1,13 @@
 import { h } from '@financial-times/x-engine'
 import { NoCreditAlert } from './NoCreditAlert'
 import { AdvancedSharingOptions } from './AdvancedSharingOptions'
+import { canShareWithNonSubscribers, isNonSubscriberOption } from './lib/highlightsHelpers'
 
 export const SharedLinkTypeSelector = (props) => {
-	const {
-		enterpriseEnabled,
-		enterpriseHasCredits,
-		giftCredits,
-		showNonSubscriberOptions,
-		showAdvancedSharingOptions
-	} = props
-	const canShareWithNonSubscribers = giftCredits > 0 || enterpriseHasCredits
+	const { enterpriseEnabled, giftCredits, showNonSubscriberOptions, showAdvancedSharingOptions } = props
+	const _canShareWithNonSubscribers = canShareWithNonSubscribers(props)
+	const _isNonSubscriberOption = isNonSubscriberOption(props)
+
 	return (
 		<div
 			id="share-with-non-subscribers-checkbox"
@@ -20,7 +17,7 @@ export const SharedLinkTypeSelector = (props) => {
 			role="group"
 			aria-labelledby="share-with-non-subscribers-checkbox"
 		>
-			{!canShareWithNonSubscribers && (
+			{!_canShareWithNonSubscribers && _isNonSubscriberOption && (
 				<NoCreditAlert>
 					You’ve run out of sharing credits for non-subscribers. You can still share it with FT subscribers
 					via a link or{' '}
@@ -37,7 +34,7 @@ export const SharedLinkTypeSelector = (props) => {
 			)}
 			{showAdvancedSharingOptions && <AdvancedSharingOptions {...props} />}
 			{!showAdvancedSharingOptions && showNonSubscriberOptions && giftCredits > 0 && (
-				<div className="o-forms-input__label share-article-dialog__advanced-sharing-options--element">
+				<div className="o-forms-input__label share-article-dialog__advanced-non-subscriber--element">
 					<span className="share-article-dialog__advanced-sharing-options--element-description">
 						Gift up to 20 articles per month to single non-subscribers. You have {giftCredits} articles left
 						this month.

--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -26,8 +26,8 @@ export const SharedLinkTypeSelector = (props) => {
 		>
 			{!_canShareWithNonSubscribers && _isNonSubscriberOption && (
 				<NoCreditAlert>
-					You’ve run out of sharing credits for non-subscribers. You can still share it with FT subscribers
-					via a link or{' '}
+					You’ve run out of sharing credits, which you need to share articles with non-subscribers. Use FT
+					subscribers only option or{' '}
 					<a
 						href={`${enterpriseEnabled ? 'mailto:customer.success@ft.com' : 'mailto:help@ft.com'}`}
 						rel="noreferrer"

--- a/components/x-gift-article/src/SharingOptionsToggler.jsx
+++ b/components/x-gift-article/src/SharingOptionsToggler.jsx
@@ -1,0 +1,86 @@
+import { h } from '@financial-times/x-engine'
+
+export const SharingOptionsToggler = (props) => {
+	const {
+		enterpriseEnabled,
+		enterpriseRequestAccess,
+		actions,
+		enterpriseHasCredits,
+		showAdvancedSharingOptions,
+		showNonSubscriberOptions
+	} = props
+
+	const advancedSharingEnabled = enterpriseEnabled && !enterpriseRequestAccess
+	const onValueChange = (event) => {
+		if (advancedSharingEnabled) {
+			if (event.target.value === 'anyone') {
+				enterpriseHasCredits ? actions.showEnterpriseUrlSection(event) : actions.showGiftUrlSection(event)
+				actions.showAdvancedSharingOptions()
+			} else {
+				actions.hideNonSubscriberSharingOptions(event)
+				actions.setIncludeHighlights(false)
+			}
+			return
+		}
+
+		if (event.target.value === 'non-subscriber') {
+			// if the checkbox is checked, the user wants to share the article with non-subscribers
+			actions.showGiftUrlSection(event)
+		} else {
+			// if the checkbox is unchecked, the user wants to share the article with subscribers only
+			actions.showNonGiftUrlSection(event)
+		}
+	}
+
+	return (
+		<div
+			className={`o-forms-field o-forms-field--optional share-article-dialog__sharing-options-toggler ${
+				enterpriseEnabled ? 'o-forms-field--professional' : ''
+			}`}
+			role="group"
+			aria-labelledby="o-forms-labelledby_sharing-options"
+			aria-describedby="o-forms-labelledby_sharing-options"
+		>
+			<span className="o-forms-input o-forms-input--saving o-forms-input--radio-box">
+				<span className="o-forms-input--radio-box__container">
+					{advancedSharingEnabled ? (
+						<label htmlFor="share-with-anyone-people-radio">
+							<input
+								id="share-with-anyone-people-radio"
+								name="share-option"
+								type="radio"
+								value="anyone"
+								checked={showAdvancedSharingOptions}
+								onChange={onValueChange}
+							/>
+							<span className="o-forms-input__label">Anyone</span>
+						</label>
+					) : (
+						<label htmlFor="share-with-a-non-subscriber-radio">
+							<input
+								id="share-with-a-non-subscriber-radio"
+								name="share-option"
+								type="radio"
+								value="non-subscriber"
+								checked={showNonSubscriberOptions}
+								onChange={onValueChange}
+							/>
+							<span className="o-forms-input__label">Non-subscriber</span>
+						</label>
+					)}
+					<label htmlFor="share-with-one-person-radio">
+						<input
+							id="share-with-subscribers-radio"
+							name="share-option"
+							type="radio"
+							value="subscribers"
+							checked={!showAdvancedSharingOptions && !showNonSubscriberOptions}
+							onChange={onValueChange}
+						/>
+						<span className="o-forms-input__label">FT subscribers only</span>
+					</label>
+				</span>
+			</span>
+		</div>
+	)
+}

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -68,15 +68,16 @@ export default class EnterpriseApiClient {
 			return {
 				limit: json.limit,
 				hasCredits: json.hasCredits,
+				budget: json.budget ?? 0,
 				enabled: true,
 				requestAccess: false
 			}
 		} catch (e) {
 			if (e?.message === 'ShowRequestAccess') {
 				// limit = 100 is the default value used for marketing ES ("share with up to 100 people")
-				return { enabled: true, limit: 100, hasCredits: false, requestAccess: true }
+				return { enabled: true, limit: 100, hasCredits: false, requestAccess: true, budget: 0 }
 			}
-			return { enabled: false, limit: 0, hasCredits: false, requestAccess: false }
+			return { enabled: false, limit: 0, hasCredits: false, requestAccess: false, budget: 0 }
 		}
 	}
 

--- a/components/x-gift-article/src/lib/enterpriseApi.js
+++ b/components/x-gift-article/src/lib/enterpriseApi.js
@@ -41,8 +41,9 @@ export default class EnterpriseApiClient {
 			throw new Error('ShowRequestAccess')
 		}
 		if (response.status === 404) {
-			// If ES API response code is 404 - User is not B2B and should not see anything about ES
-			throw new Error('UserIsNotB2b')
+			const body = await response.json()
+			// If ES API response code is 404 - User is not B2c and should not see anything about ES
+			throw new Error(body.message.includes('b2c') ? 'UserIsB2C' : 'UserIsRegistered')
 		}
 		const responseJSON = await response.json()
 		return responseJSON
@@ -70,14 +71,29 @@ export default class EnterpriseApiClient {
 				hasCredits: json.hasCredits,
 				budget: json.budget ?? 0,
 				enabled: true,
-				requestAccess: false
+				requestAccess: false,
+				isRegisteredUser: false
 			}
 		} catch (e) {
 			if (e?.message === 'ShowRequestAccess') {
 				// limit = 100 is the default value used for marketing ES ("share with up to 100 people")
-				return { enabled: true, limit: 100, hasCredits: false, requestAccess: true, budget: 0 }
+				return {
+					enabled: true,
+					limit: 100,
+					hasCredits: false,
+					requestAccess: true,
+					budget: 0,
+					isRegisteredUser: false
+				}
 			}
-			return { enabled: false, limit: 0, hasCredits: false, requestAccess: false, budget: 0 }
+			return {
+				enabled: false,
+				limit: 0,
+				hasCredits: false,
+				requestAccess: false,
+				budget: 0,
+				isRegisteredUser: e?.message === 'UserIsRegistered'
+			}
 		}
 	}
 

--- a/components/x-gift-article/src/lib/highlightsHelpers.js
+++ b/components/x-gift-article/src/lib/highlightsHelpers.js
@@ -28,3 +28,14 @@ export const parsedSavedAnnotationsFromLocalStorage = () => {
 
 	return savedSharedAnnotationArticleIds
 }
+
+/**
+ * Checks if the user can share with non-subscriber users
+ * @param {giftCredits: number, enterpriseHasCredits: boolean } param0
+ * @returns {boolean}
+ */
+export const canShareWithNonSubscribers = ({ giftCredits, enterpriseHasCredits }) =>
+	giftCredits > 0 || enterpriseHasCredits
+
+export const isNonSubscriberOption = ({ showNonSubscriberOptions, showAdvancedSharingOptions }) =>
+	showNonSubscriberOptions || showAdvancedSharingOptions

--- a/components/x-gift-article/src/lib/updaters.js
+++ b/components/x-gift-article/src/lib/updaters.js
@@ -23,7 +23,8 @@ export const showGiftUrlSection = (props) => ({
 	mailtoUrl: props.mailtoUrls.gift,
 	isGiftUrlCreated: !!props.urls.gift,
 	showCopyConfirmation: false,
-	invalidResponseFromApi: false
+	invalidResponseFromApi: false,
+	showNonSubscriberOptions: true
 })
 
 export const showGiftEnterpriseSection = (props) => ({
@@ -43,16 +44,23 @@ export const showNonGiftUrlSection = (props) => ({
 	mailtoUrl: props.mailtoUrls.nonGift,
 	isGiftUrlCreated: false,
 	showCopyConfirmation: false,
-	invalidResponseFromApi: false
+	invalidResponseFromApi: false,
+	showAdvancedSharingOptions: false,
+	showNonSubscriberOptions: false
 })
 
 export const showAdvancedSharingOptions = () => ({
 	showAdvancedSharingOptions: true
 })
 
-export const hideAdvancedSharingOptions = (props) => ({
+export const showNonSubscriberSharingOptions = () => ({
+	showNonSubscriberOptions: true
+})
+
+export const hideNonSubscriberSharingOptions = (props) => ({
 	...showNonGiftUrlSection(props),
-	showAdvancedSharingOptions: false
+	showAdvancedSharingOptions: false,
+	showNonSubscriberOptions: false
 })
 
 export const setGiftUrl =

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -107,6 +107,20 @@ ShareArticleModalWithAdvancedSharingNoEnterpriseCredits.storyName =
 ShareArticleModalWithAdvancedSharingNoEnterpriseCredits.args =
 	require('./share-article-modal-with-advanced-sharing-no-enterprise-credits').args
 
+export const ShareArticleModalWithAdvancedSharingNoBothCredits = (args) => {
+	require('./share-article-modal-with-advanced-sharing-no-both-credits').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalWithAdvancedSharingNoBothCredits.storyName = 'Share article modal (AS no enterprise credits)'
+ShareArticleModalWithAdvancedSharingNoBothCredits.args =
+	require('./share-article-modal-with-advanced-sharing-no-both-credits').args
+
 export const ShareArticleModalWithAdvancedSharingSaveHighlightsMessage = (args) => {
 	require('./share-article-modal-with-advanced-sharing-save-highlights-message').fetchMock(fetchMock)
 	return (

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -52,6 +52,19 @@ export const ShareArticleModalB2C = (args) => {
 ShareArticleModalB2C.storyName = 'Share article modal (B2C)'
 ShareArticleModalB2C.args = require('./share-article-modal-b2c').args
 
+export const ShareArticleModalB2BHighlights = (args) => {
+	require('./share-article-modal-b2b-highlights').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalB2BHighlights.storyName = 'Share article modal (B2B with highlights)'
+ShareArticleModalB2BHighlights.args = require('./share-article-modal-b2b-highlights').args
+
 export const ShareArticleModalWithAdvanceSharing = (args) => {
 	require('./share-article-modal-with-advanced-sharing').fetchMock(fetchMock)
 	return (

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -136,6 +136,20 @@ ShareArticleModalWithAdvancedSharingSaveHighlightsMessage.storyName =
 ShareArticleModalWithAdvancedSharingSaveHighlightsMessage.args =
 	require('./share-article-modal-with-advanced-sharing-save-highlights-message').args
 
+export const ShareArticleModalB2BSaveHighlightsMessage = (args) => {
+	require('./share-article-modal-b2b-save-highlights-message').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalB2BSaveHighlightsMessage.storyName = 'Share article modal (B2B save highlights message)'
+ShareArticleModalB2BSaveHighlightsMessage.args =
+	require('./share-article-modal-b2b-save-highlights-message').args
+
 export const ShareArticleModalB2BFreeArticle = (args) => {
 	require('./share-article-modal-b2b-free-article').fetchMock(fetchMock)
 	return (

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -26,6 +26,19 @@ export const ShareArticleModalB2B = (args) => {
 ShareArticleModalB2B.storyName = 'Share article modal (B2B)'
 ShareArticleModalB2B.args = require('./share-article-modal').args
 
+export const ShareArticleModalRegistered = (args) => {
+	require('./share-article-modal-registered').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalRegistered.storyName = 'Share article modal (Registered)'
+ShareArticleModalRegistered.args = require('./share-article-modal-registered').args
+
 export const ShareArticleModalB2C = (args) => {
 	require('./share-article-modal-b2c').fetchMock(fetchMock)
 	return (

--- a/components/x-gift-article/storybook/share-article-modal-b2b-free-article.js
+++ b/components/x-gift-article/storybook/share-article-modal-b2b-free-article.js
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: true,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-b2b-highlights.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2b-highlights.jsx
@@ -21,8 +21,8 @@ exports.fetchMock = (fetchMock) => {
 		.restore()
 		.get('path:/article/gift-credits', {
 			allowance: 20,
-			consumedCredits: 20,
-			remainingCredits: 0,
+			consumedCredits: 5,
+			remainingCredits: 15,
 			renewalDate: '2018-08-01T00:00:00Z'
 		})
 		.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
@@ -36,11 +36,7 @@ exports.fetchMock = (fetchMock) => {
 			redemptionLimit: 3,
 			remainingAllowance: 1
 		})
-		.get('path:/v1/users/me/allowance', {
-			limit: 120,
-			budget: 100,
-			hasCredits: true
-		})
+		.get('path:/v1/users/me/allowance', 403)
 		.post('path:/v1/shares', {
 			url: articleUrlRedeemed,
 			redeemLimit: 120

--- a/components/x-gift-article/storybook/share-article-modal-b2b-save-highlights-message.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2b-save-highlights-message.jsx
@@ -1,0 +1,46 @@
+const articleId = 'e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrl = 'https://www.ft.com/content/e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article:',
+	isFreeArticle: false,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
+	},
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: false,
+	showHighlightsCheckbox: false,
+	showHighlightsRecipientMessage: true
+}
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('path:/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`path:/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			redemptionLimit: 3,
+			remainingAllowance: 1
+		})
+		.get('path:/v1/users/me/allowance', 403)
+		.post('path:/v1/shares', {
+			url: articleUrlRedeemed,
+			redeemLimit: 120
+		})
+}

--- a/components/x-gift-article/storybook/share-article-modal-b2b-save-highlights-message.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2b-save-highlights-message.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-b2c-free-article.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2c-free-article.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: true,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-b2c-no-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2c-no-credits.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-b2c-no-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2c-no-credits.jsx
@@ -35,7 +35,15 @@ exports.fetchMock = (fetchMock) => {
 			redemptionLimit: 3,
 			remainingAllowance: 1
 		})
-		.get('path:/v1/users/me/allowance', 404)
+		.get(
+			'path:/v1/users/me/allowance',
+			new Response(
+				JSON.stringify({
+					message: 'NotFoundError: b2c'
+				}),
+				{ status: 404 }
+			)
+		)
 		.post('path:/v1/shares', {
 			url: articleUrlRedeemed,
 			redeemLimit: 120

--- a/components/x-gift-article/storybook/share-article-modal-b2c.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2c.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-b2c.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-b2c.jsx
@@ -35,7 +35,15 @@ exports.fetchMock = (fetchMock) => {
 			redemptionLimit: 3,
 			remainingAllowance: 1
 		})
-		.get('path:/v1/users/me/allowance', 404)
+		.get(
+			'path:/v1/users/me/allowance',
+			new Response(
+				JSON.stringify({
+					message: 'NotFoundError: b2c'
+				}),
+				{ status: 404 }
+			)
+		)
 		.post('path:/v1/shares', {
 			url: articleUrlRedeemed,
 			redeemLimit: 120

--- a/components/x-gift-article/storybook/share-article-modal-no-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-no-credits.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-registered.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-registered.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-registered.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-registered.jsx
@@ -5,7 +5,7 @@ const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
 	title: 'Share this article:',
-	isFreeArticle: true,
+	isFreeArticle: false,
 	article: {
 		id: articleId,
 		url: articleUrl,
@@ -39,7 +39,7 @@ exports.fetchMock = (fetchMock) => {
 			'path:/v1/users/me/allowance',
 			new Response(
 				JSON.stringify({
-					message: 'NotFoundError: b2c'
+					message: 'NotFoundError: registered'
 				}),
 				{ status: 404 }
 			)

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-free-article.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-free-article.jsx
@@ -38,6 +38,7 @@ exports.fetchMock = (fetchMock) => {
 		})
 		.get('path:/v1/users/me/allowance', {
 			limit: 120,
+			budget: 100,
 			hasCredits: true
 		})
 		.post('path:/v1/shares', {

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-free-article.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-free-article.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: true,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-both-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-both-credits.jsx
@@ -1,0 +1,47 @@
+const articleId = 'e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrl = 'https://www.ft.com/content/e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article:',
+	isFreeArticle: false,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
+	},
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	hasHighlights: true
+}
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('path:/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 0,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`path:/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			redemptionLimit: 3,
+			remainingAllowance: 1
+		})
+		.get('path:/v1/users/me/allowance', {
+			limit: 120,
+			hasCredits: false
+		})
+		.post('path:/v1/shares', {
+			url: articleUrlRedeemed,
+			redeemLimit: 120
+		})
+}

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-both-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-both-credits.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-enterprise-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-enterprise-credits.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-gift-credits.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-gift-credits.jsx
@@ -38,6 +38,7 @@ exports.fetchMock = (fetchMock) => {
 		})
 		.get('path:/v1/users/me/allowance', {
 			limit: 120,
+			budget: 100,
 			hasCredits: true
 		})
 		.post('path:/v1/shares', {

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-save-highlights-message.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-save-highlights-message.jsx
@@ -40,6 +40,7 @@ exports.fetchMock = (fetchMock) => {
 		})
 		.get('path:/v1/users/me/allowance', {
 			limit: 120,
+			budget: 100,
 			hasCredits: true
 		})
 		.post('path:/v1/shares', {

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-save-highlights-message.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-save-highlights-message.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
@@ -38,6 +38,7 @@ exports.fetchMock = (fetchMock) => {
 		})
 		.get('path:/v1/users/me/allowance', {
 			limit: 120,
+			budget: 100,
 			hasCredits: true
 		})
 		.post('path:/v1/shares', {

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing.jsx
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/components/x-gift-article/storybook/share-article-modal.js
+++ b/components/x-gift-article/storybook/share-article-modal.js
@@ -4,7 +4,7 @@ const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
 const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
 
 exports.args = {
-	title: 'Share this article:',
+	title: 'Share this article with:',
 	isFreeArticle: false,
 	article: {
 		id: articleId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30493,7 +30493,7 @@
         "npm": "7.x || 8.x || 9.x || 10.x"
       },
       "peerDependencies": {
-        "webpack": "4.x"
+        "webpack": ">=4.0.0"
       }
     },
     "packages/x-handlebars": {


### PR DESCRIPTION
# Description

In this PR I have made the necessary changes to update the UI/UX for x-gift component according to the [ELES-1039](https://financialtimes.atlassian.net/browse/ELES-1039) ,[ELES-1047](https://financialtimes.atlassian.net/browse/ELES-1047) and [ELES-1066](https://financialtimes.atlassian.net/browse/ELES-1066)
 
according to the [Figma design](https://www.figma.com/file/4AB1PoaYn5JfIjmXx0a3v1/Advanced-Sharing?node-id=6023%3A3087&mode=dev)

[ELES-1039]: https://financialtimes.atlassian.net/browse/ELES-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ELES-1047]: https://financialtimes.atlassian.net/browse/ELES-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Screenshots

### b2c 

### Free article
![Screenshot 2024-03-01 at 6 45 41 PM](https://github.com/Financial-Times/x-dash/assets/139355573/7de09ae8-1524-4070-80ad-1ef1f6533eca)
![Screenshot 2024-03-01 at 6 54 42 PM](https://github.com/Financial-Times/x-dash/assets/139355573/916b90bc-5b64-482c-b14f-6067f30badc7)

### Gift article 
![Screenshot 2024-03-01 at 6 41 50 PM](https://github.com/Financial-Times/x-dash/assets/139355573/34742f22-d300-4640-bd10-38ee1fe5abbe)
![Screenshot 2024-03-01 at 6 46 21 PM](https://github.com/Financial-Times/x-dash/assets/139355573/c60c992d-649f-4659-b29d-dd797fd77509)

### Subscribers
![Screenshot 2024-03-01 at 6 42 05 PM](https://github.com/Financial-Times/x-dash/assets/139355573/826c5040-a2d3-4b51-bfa7-9d2d24accd92)
![Screenshot 2024-03-01 at 6 42 10 PM](https://github.com/Financial-Times/x-dash/assets/139355573/e52a7f58-5daa-47d3-ae1d-07ca6fe18507)

### No credit
![Screenshot 2024-03-01 at 6 45 32 PM](https://github.com/Financial-Times/x-dash/assets/139355573/f16b8825-b4b7-4ed5-bde1-cff90c20c7f2)

### b2b

### Normal flow
![Screenshot 2024-03-01 at 7 02 53 PM](https://github.com/Financial-Times/x-dash/assets/139355573/d55d6292-e531-4afd-9e0b-c09ba9da7997)
![Screenshot 2024-03-01 at 7 02 57 PM](https://github.com/Financial-Times/x-dash/assets/139355573/5150e34c-398e-4873-beab-5d5ad0da24c3)
![Screenshot 2024-03-01 at 7 02 39 PM](https://github.com/Financial-Times/x-dash/assets/139355573/9fcb22e1-d9c9-4860-bd43-1a6a526e1bb2)
![Screenshot 2024-03-01 at 7 02 45 PM](https://github.com/Financial-Times/x-dash/assets/139355573/7fe4dc71-8067-4002-9510-886782055179)

### Normal flow with save highlights message
![Screenshot 2024-03-01 at 7 05 23 PM](https://github.com/Financial-Times/x-dash/assets/139355573/e75c4f37-896c-44ea-a785-121890c44358)
![Screenshot 2024-03-01 at 7 05 17 PM](https://github.com/Financial-Times/x-dash/assets/139355573/5b575381-1bc8-4163-9d71-42393fe94a1f)

### Normal flow with highlights
![Screenshot 2024-03-04 at 6 36 45 AM](https://github.com/Financial-Times/x-dash/assets/139355573/fd6c0bba-a96f-43d8-a315-bc1c2263a36d)
![Screenshot 2024-03-04 at 6 36 48 AM](https://github.com/Financial-Times/x-dash/assets/139355573/f1e532a4-20b7-494f-90c0-12af614fa269)
![Screenshot 2024-03-04 at 6 36 33 AM](https://github.com/Financial-Times/x-dash/assets/139355573/64cc742f-469f-4eca-9a7d-255ffc11ea75)
![Screenshot 2024-03-04 at 6 36 37 AM](https://github.com/Financial-Times/x-dash/assets/139355573/947aabf7-3a01-4681-844c-2595006bd45e)

### No credit
![Screenshot 2024-03-04 at 6 40 43 AM](https://github.com/Financial-Times/x-dash/assets/139355573/f4a7cdbd-9d08-476d-8503-20680cf314de)

### Free article
![Screenshot 2024-03-04 at 6 41 32 AM](https://github.com/Financial-Times/x-dash/assets/139355573/aee078f6-a1e3-4b9a-bc26-401ea7d376d2)


### b2b with advanced sharing

### Normal flow
![Screenshot 2024-03-04 at 6 43 30 AM](https://github.com/Financial-Times/x-dash/assets/139355573/0f6f1eb5-65ed-4161-8120-77c047d194ab)
![Screenshot 2024-03-04 at 6 43 34 AM](https://github.com/Financial-Times/x-dash/assets/139355573/0ebe2d0b-60fe-4daa-b98c-a73955d5924e)

![Screenshot 2024-03-04 at 6 43 18 AM](https://github.com/Financial-Times/x-dash/assets/139355573/a25bf04f-0c35-4fae-b43c-1bbda775f8f7)
![Screenshot 2024-03-04 at 6 43 22 AM](https://github.com/Financial-Times/x-dash/assets/139355573/94d555f5-45bb-48eb-a70c-c4133bc4eda0)

![Screenshot 2024-03-04 at 6 43 08 AM](https://github.com/Financial-Times/x-dash/assets/139355573/42609400-ecfc-44b8-9d11-0c584cb032c0)
![Screenshot 2024-03-04 at 6 43 12 AM](https://github.com/Financial-Times/x-dash/assets/139355573/a8fbd515-0662-40f9-a6a9-a6721da72daf)

![Screenshot 2024-03-04 at 6 42 49 AM](https://github.com/Financial-Times/x-dash/assets/139355573/10641aa1-1891-418c-98c7-192497cbcea6)
![Screenshot 2024-03-04 at 6 43 02 AM](https://github.com/Financial-Times/x-dash/assets/139355573/01bed520-ae6b-428a-a6ac-6765d116823a)

### Highlight message
![Screenshot 2024-03-04 at 6 46 11 AM](https://github.com/Financial-Times/x-dash/assets/139355573/cfbad18f-877b-4c87-9385-1e41eb27493f)

### Corner cases
![Screenshot 2024-03-04 at 6 47 34 AM](https://github.com/Financial-Times/x-dash/assets/139355573/c23d310c-54c2-4916-ad84-d4d21982b2d4)
![Screenshot 2024-03-04 at 6 48 57 AM](https://github.com/Financial-Times/x-dash/assets/139355573/a10403f5-4795-4cdf-b2ef-80cd74549c4e)
![Screenshot 2024-03-04 at 6 48 52 AM](https://github.com/Financial-Times/x-dash/assets/139355573/b29dc26d-6110-4e6d-a805-29ba081d81c6)
![Screenshot 2024-03-04 at 6 47 38 AM](https://github.com/Financial-Times/x-dash/assets/139355573/ca3fb157-97ad-409e-99ff-faf2ebdb6ea3)
![Screenshot 2024-03-04 at 6 47 25 AM](https://github.com/Financial-Times/x-dash/assets/139355573/2dbf6ab7-1a66-4dc2-a9c3-b5af26778c9c)
![Screenshot 2024-03-04 at 6 47 17 AM](https://github.com/Financial-Times/x-dash/assets/139355573/930b7707-1232-459f-b3f4-5b767d1bc20b)
![Screenshot 2024-03-04 at 6 47 20 AM](https://github.com/Financial-Times/x-dash/assets/139355573/95428a36-b774-4d50-ba9a-5da0154a5c72)



[ELES-1066]: https://financialtimes.atlassian.net/browse/ELES-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ