### PR TITLE
ELES-1161 Preserve Include Highlights checkbox state through tabs

### DIFF
--- a/components/x-gift-article/src/SharingOptionsToggler.jsx
+++ b/components/x-gift-article/src/SharingOptionsToggler.jsx
@@ -18,7 +18,7 @@ export const SharingOptionsToggler = (props) => {
 				actions.showAdvancedSharingOptions()
 			} else {
 				actions.hideNonSubscriberSharingOptions(event)
-				actions.setIncludeHighlights(false)
+				actions.setIncludeHighlights(event.target.checked)
 			}
 			return
 		}
@@ -68,7 +68,7 @@ export const SharingOptionsToggler = (props) => {
 							<span className="o-forms-input__label">Non-subscriber</span>
 						</label>
 					)}
-					<label htmlFor="share-with-one-person-radio" className="no-margin">
+					<label htmlFor="share-with-subscribers-radio" className="no-margin">
 						<input
 							id="share-with-subscribers-radio"
 							name="share-option"


### PR DESCRIPTION
## Description 
Fix small issue related with Include highlight checkbox on Advanced sharing. After switching to second tab on the Advanced sharing modal, the "Include Sharing" checkbox was always unchecked, instead pf preserving its current state from the previous tab

## Ticket
https://financialtimes.atlassian.net/browse/ELES-1161

## Testing
Checkout the branch, install the dependencies and run the story book. From the storybook check behavior of the Share article modal (B2b with highlights) - http://local.ft.com:9001/?path=/story/x-gift-article--share-article-modal-b-2-b-highlights 
## 

- Discuss features first
- Update the documentation
- **Must** be tested in FT.com and Apps before merge
- No hacks, experiments or temporary workarounds
- Reviewers are empowered to say no
- Reference other issues
- Update affected stories and snapshots
- Follow the code style
- Decide on a version (major, minor, or patch)
