### PR TITLE
feat: rename promo content wrapper to match image container

### DIFF
--- a/components/x-teaser/src/PromotionaContent.jsx
+++ b/components/x-teaser/src/PromotionaContent.jsx
@@ -1,7 +1,7 @@
 import { h } from '@financial-times/x-engine'
 
 const PromotionalContent = ({ promotionalContent }) => (
-	<div className="o-teaser__promotional-content">{promotionalContent}</div>
+	<div className="o-teaser__image-container js-teaser-image-container">{promotionalContent}</div>
 )
 
 export default PromotionalContent


### PR DESCRIPTION
This change applies the existing logic added to the image container on the ft-app. We can avoiding duplication of this logic for the promotional content wrapper in the ft-app and wouldn't need to replicate it for the new class name.

### note:

Downside of this method is the situation where promotional content has a class name of `o-teaser__image-container`, _but_ it is way safer than trying to rename this class and image container class to something like `o-teaser__media-container`. 

We do have the same logic for the next-home-page where we reused the existing image class name for the teaser image and the clip component.