### PR TITLE
CON-3316: bump n-myft-ui dependency

### DIFF
--- a/components/x-follow-button/package.json
+++ b/components/x-follow-button/package.json
@@ -26,7 +26,7 @@
     "sass": "^1.49.0"
   },
   "peerDependencies": {
-    "@financial-times/n-myft-ui": "^32.0.2",
+    "@financial-times/n-myft-ui": "^34.0.1",
     "@financial-times/o-buttons": "^7.7.4",
     "@financial-times/o-colors": "^6.4.2",
     "@financial-times/o-icons": "^7.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "npm": "7.x || 8.x || 9.x || 10.x"
       },
       "peerDependencies": {
-        "@financial-times/n-myft-ui": "^32.0.2",
+        "@financial-times/n-myft-ui": "^34.0.1",
         "@financial-times/o-buttons": "^7.7.4",
         "@financial-times/o-colors": "^6.4.2",
         "@financial-times/o-icons": "^7.2.1",


### PR DESCRIPTION
Description:
As part of this PR we need to update the instant alert component icon: https://financialtimes.atlassian.net/browse/CON-3316
n-myft-ui is dependency of next-myft-page as well of  "x-follow-button" as npm is not able to resolve different versions in next-myft-page of “n-myft-ui”, it is necessary to update this dependency in both projects hence the reason for this PR

Breaking changes:
[v34.0.0](https://github.com/Financial-Times/n-myft-ui/releases/tag/v34.0.0)

What's Changed
This version are mainly for these changes and it is a breaking release because it removes the browser alert preference.

[v33.0.0](https://github.com/Financial-Times/n-myft-ui/releases/tag/v33.0.0)


What's Changed
UG-1414: Remove notification for users referred from podcast links by @jamesnicholls in https://github.com/Financial-Times/n-myft-ui/pull/624