### PR TITLE
Fix automatic 'setIncludeHighlights' + handle errors from highlights token request (ELES-1237)

### DIFF
--- a/components/x-gift-article/src/SharingOptionsToggler.jsx
+++ b/components/x-gift-article/src/SharingOptionsToggler.jsx
@@ -18,7 +18,6 @@ export const SharingOptionsToggler = (props) => {
 				actions.showAdvancedSharingOptions()
 			} else {
 				actions.hideNonSubscriberSharingOptions(event)
-				actions.setIncludeHighlights(event.target.checked)
 			}
 			return
 		}

--- a/components/x-gift-article/src/lib/highlightsApi.js
+++ b/components/x-gift-article/src/lib/highlightsApi.js
@@ -38,6 +38,11 @@ export default class HighlightsApiClient {
 		)
 
 		const response = await fetch(url, options)
+
+		if (!response.ok) {
+			throw new Error(`failed to fetch ${url}, received ${response.status}`)
+		}
+
 		const responseJSON = await response.json()
 		return responseJSON
 	}
@@ -62,6 +67,7 @@ export default class HighlightsApiClient {
 			if (!includeHighlights) {
 				return {}
 			}
+
 			return await this.fetchJson('/create-token', {
 				method: 'POST',
 				body: JSON.stringify({ articleId })


### PR DESCRIPTION
This PR fixes a couple of issues related to the 'share with highlights' feature.

Currently, whenever a user selects "FT subscribers only", even if the article contains no highlights for the user, we still request a highlights access token.

Whenever the user selected "FT subscribers only", we `setIncludeHighlights` to the value of _the "Anyone/FT subscribers only"_ switcher, which evaluates to true. This is an issue particularly when the article contains no highlights, as we don't display the 'Include Highlights' checkbox, but we're still setting it to true.

This PR makes sure that we're only setting `includeHighlights` when the user wishes to.

If also adds some error handling to the code that requests the highlights token. Currently this endpoint does not return an error, but it soon will in an upcoming change to the Highlights backend, where the /create-token will return 404 when the given article contains no highlights.