### PR TITLE
ELES-1100  Fix whatsapp linking

### DIFF
--- a/components/x-gift-article/src/SocialShareButtons.jsx
+++ b/components/x-gift-article/src/SocialShareButtons.jsx
@@ -27,7 +27,7 @@ export const SocialShareButtons = ({ actions, mailtoUrl, shareType, enterpriseEn
 		linkedin: `http://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(
 			url
 		)}&title=${encodeURIComponent(article.title)}&source=Financial+Times`,
-		whatsapp: `whatsapp://send?text=${encodeURIComponent(article.title)}%20-%20${encodeURIComponent(url)}`
+		whatsapp: `https://wa.me?text=${encodeURIComponent(article.title)}%20-%20${encodeURIComponent(url)}`
 	}
 
 	return (


### PR DESCRIPTION
# Description
[ELES-1100](https://financialtimes.atlassian.net/browse/ELES-1100)

Currently the share via whatsapp only works when the users have the app installed on their machine, 

In this PR we changed the whatsapp url to the universal format to fallback to whatsapp web if the app is not installed

[ELES-1100]: https://financialtimes.atlassian.net/browse/ELES-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ