### PR TITLE
Fix includeHighlights initial value

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,4 @@ components/x-topic-search @Financial-Times/content-discovery
 components/x-live-blog-post @Financial-Times/storytelling
 components/x-live-blog-wrapper @Financial-Times/storytelling
 components/x-gift-article @Financial-Times/cp-retention-team
-components/x-gift-article @Financial-Times/professional-differentiate
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,4 @@ components/x-topic-search @Financial-Times/content-discovery
 components/x-live-blog-post @Financial-Times/storytelling
 components/x-live-blog-wrapper @Financial-Times/storytelling
 components/x-gift-article @Financial-Times/cp-retention-team
-
+components/x-gift-article @Financial-Times/professional-differentiate

--- a/components/x-gift-article/src/GiftArticle.jsx
+++ b/components/x-gift-article/src/GiftArticle.jsx
@@ -263,7 +263,12 @@ const withGiftFormActions = withActions(
 				return (state) => {
 					state.highlight = document.querySelector(`.${state.highlightClassName}`)?.textContent
 					state.highlightClassName = document.querySelector(`.${state.highlightClassName}`)?.classList.value
-					return { highlight: state.highlight, highlightClassName: state.highlightClassName }
+					state.includeHighlights = true
+					return {
+						highlight: state.highlight,
+						highlightClassName: state.highlightClassName,
+						includeHighlights: state.includeHighlights
+					}
 				}
 			}
 		}
@@ -296,7 +301,7 @@ const withGiftFormActions = withActions(
 			isGiftUrlCreated: false,
 			isGiftUrlShortened: false,
 			isNonGiftUrlShortened: false,
-			includeHighlights: true,
+			includeHighlights: props.highlight !== undefined,
 			showAdvancedSharingOptions: false,
 			showNonSubscriberOptions: false,
 			highlight: undefined,


### PR DESCRIPTION
# Description 

PR #782 has introduced a small bug since the initial value for `includeHiglights` prop is now true it caused a bug when sharing an article that doesn't have highlights this PR is a fix for it