### PR TITLE
ENTST-1194 | Sharing Monetary Policy Radar(MPR) articles

### DIFF
--- a/components/x-gift-article/__tests__/x-gift-article.test.jsx
+++ b/components/x-gift-article/__tests__/x-gift-article.test.jsx
@@ -260,4 +260,20 @@ describe('x-gift-article', () => {
 		expect(subject.find('#free-article-alert')).toExist()
 		expect(subject.find('#share-with-non-subscribers-checkbox')).not.toExist()
 	})
+
+	it('should hide the Sharing options toggler when isMPRArticle is true', async () => {
+		const args = {
+			...baseArgs,
+			isMPRArticle: true
+		}
+		const subject = mount(<ShareArticleModal {...args} actionsRef={(a) => Object.assign(actions, a)} />)
+
+		await actions.activate()
+
+		subject.update()
+
+		expect(subject.find({ children: 'FT subscribers only' })).not.toExist()
+		expect(subject.find({ children: 'Anyone' })).not.toExist()
+		expect(subject.find({ children: 'Non-subscriber' })).not.toExist()
+	})
 })

--- a/components/x-gift-article/readme.md
+++ b/components/x-gift-article/readme.md
@@ -84,4 +84,5 @@ All `x-` components are designed to be compatible with a variety of runtimes, no
 | `title`                          | String  | no       | The title for the modal                                                                                                      |
 | `showHighlightsCheckbox`         | Boolean | no       | Show or hide the option to include highlights                                                                                |
 | `showHighlightsRecipientMessage` | Boolean | no       | Show or hide `ReceivedHighlightsAlert` component                                                                             |
-| `highlight`                      | String  | no       | The text of the quote or highlight to be shared                                                                              |
+| `highlight`                      | String  | no       | The text of the quote or highlight to be shared 
+| `isMPRArticle`                   | Boolean | no       | Hides the sharing option toggle and displays MPR version of the copies of modal's header and zero credits message                                                                              |

--- a/components/x-gift-article/src/AdvancedSharingOptions.jsx
+++ b/components/x-gift-article/src/AdvancedSharingOptions.jsx
@@ -3,7 +3,7 @@ import { ShareType } from './lib/constants'
 import { NoCreditAlert } from './NoCreditAlert'
 
 export const AdvancedSharingOptions = (props) => {
-	const { shareType, actions, enterpriseHasCredits, giftCredits, monthlyAllowance } = props
+	const { shareType, actions, enterpriseHasCredits, giftCredits, monthlyAllowance, isMPRArticle } = props
 
 	const onValueChange = (event) => {
 		if (event.target.value === ShareType.enterprise) {
@@ -16,12 +16,17 @@ export const AdvancedSharingOptions = (props) => {
 	return giftCredits || enterpriseHasCredits ? (
 		<div>
 			<div
-				className="o-forms-field o-forms-field--optional o-forms-field--professional share-article-dialog__advanced-sharing-options"
+				className={`o-forms-field o-forms-field--optional o-forms-field--professional share-article-dialog__advanced-sharing-options ${
+					isMPRArticle ? 'share-article-dialog__advanced-sharing-options--mpr' : ''
+				}`}
 				role="group"
 			>
-				<h3 className="share-article-dialog__header">
-					<span className="share-article-dialog__header-share-article-title">Share using:</span>
-				</h3>
+				{!isMPRArticle && (
+					<h3 className="share-article-dialog__header">
+						<span className="share-article-dialog__header-share-article-title">Share using:</span>
+					</h3>
+				)}
+
 				<span className="o-forms-input o-forms-input--radio-round">
 					<span className="o-forms-input--radio-round__container">
 						<label htmlFor="share-with-multiple-people-radio">

--- a/components/x-gift-article/src/Header.jsx
+++ b/components/x-gift-article/src/Header.jsx
@@ -2,7 +2,16 @@ import { h } from '@financial-times/x-engine'
 import { ShareType } from './lib/constants'
 
 export const Header = (props) => {
-	const { title, isGiftUrlCreated, shareType, isNonGiftUrlShortened, showFreeArticleAlert } = props
+	const {
+		title,
+		isGiftUrlCreated,
+		shareType,
+		isNonGiftUrlShortened,
+		showFreeArticleAlert,
+		isMPRArticle,
+		enterpriseEnabled,
+		enterpriseRequestAccess
+	} = props
 	// when a gift link is created or shortened, the title is "Sharing link"
 	if (
 		isGiftUrlCreated ||
@@ -11,6 +20,20 @@ export const Header = (props) => {
 		return (
 			<header>
 				<h3 className="share-article-dialog__header-share-link-title">Sharing link</h3>
+			</header>
+		)
+	}
+
+	if (isMPRArticle) {
+		return (
+			<header>
+				<h3 className="share-article-dialog__header">
+					<span className="share-article-dialog__header-share-article-title">
+						{enterpriseEnabled && !enterpriseRequestAccess
+							? 'Share this article using:'
+							: 'Share this article'}
+					</span>
+				</h3>
 			</header>
 		)
 	}

--- a/components/x-gift-article/src/ShareArticleDialog.jsx
+++ b/components/x-gift-article/src/ShareArticleDialog.jsx
@@ -14,7 +14,8 @@ export default (props) => {
 		isFreeArticle,
 		enterpriseEnabled,
 		enterpriseRequestAccess,
-		isRegisteredUser
+		isRegisteredUser,
+		isMPRArticle
 	} = props
 
 	return (
@@ -30,6 +31,7 @@ export default (props) => {
 				<Header {...props} />
 				{!isFreeArticle &&
 				!(
+					isMPRArticle ||
 					isGiftUrlCreated ||
 					isRegisteredUser ||
 					(shareType === ShareType.nonGift && isNonGiftUrlShortened && !showFreeArticleAlert)

--- a/components/x-gift-article/src/ShareArticleDialog.scss
+++ b/components/x-gift-article/src/ShareArticleDialog.scss
@@ -147,7 +147,7 @@
 			margin: 0;
 		}
 
-		#share-link {
+		textarea#share-link {
 			margin-bottom: oSpacingByName('s4');
 		}
 
@@ -184,6 +184,11 @@
 
 		.share-article-dialog__advanced-sharing-options {
 			margin-block: oSpacingByName('s4');
+
+			&--mpr {
+				margin-block: 0;
+			}
+			
 			&--element {
 				flex-direction: column;
 				gap: calc(oSpacingByName('s1') / 2);
@@ -249,6 +254,10 @@
 			&--element {
 				margin-top: oSpacingByName('s4');
 			}
+
+			&--mpr {
+				margin-top: 0;
+			}
 		}
 
 		.share-article-dialog__share-via-socials-title {
@@ -273,6 +282,10 @@
 			margin-top: oSpacingByName('s4');
 			strong {
 				@include oTypographySans($weight: 'medium');
+			}
+
+			&:has(.no-credit-alert--mpr-version) {
+				margin-top: 0;
 			}
 		}
 	}

--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -11,7 +11,8 @@ export const SharedLinkTypeSelector = (props) => {
 		monthlyAllowance,
 		showNonSubscriberOptions,
 		showAdvancedSharingOptions,
-		isRegisteredUser
+		isRegisteredUser,
+		isMPRArticle
 	} = props
 	const _canShareWithNonSubscribers = canShareWithNonSubscribers(props)
 	const _isNonSubscriberOption = isNonSubscriberOption(props)
@@ -27,8 +28,12 @@ export const SharedLinkTypeSelector = (props) => {
 		>
 			{!_canShareWithNonSubscribers && _isNonSubscriberOption && !isRegisteredUser && (
 				<NoCreditAlert>
-					You’ve run out of sharing credits, which you need to share articles with non-subscribers. Use FT
-					subscribers only option or{' '}
+					You’ve run out of sharing credits, which you need to share articles with non-subscribers.
+					{isMPRArticle ? (
+						<span className="no-credit-alert--mpr-version"> For help on how to get more, </span>
+					) : (
+						' Use FT subscribers only option or '
+					)}
 					<a
 						href={`${enterpriseEnabled ? 'mailto:customer.success@ft.com' : 'mailto:help@ft.com'}`}
 						rel="noreferrer"
@@ -57,7 +62,11 @@ export const SharedLinkTypeSelector = (props) => {
 			)}
 			{showAdvancedSharingOptions && <AdvancedSharingOptions {...props} />}
 			{!showAdvancedSharingOptions && showNonSubscriberOptions && giftCredits > 0 && !isRegisteredUser && (
-				<div className="o-forms-input__label share-article-dialog__advanced-non-subscriber--element">
+				<div
+					className={`o-forms-input__label share-article-dialog__advanced-non-subscriber--element ${
+						isMPRArticle ? 'share-article-dialog__advanced-non-subscriber--mpr' : ''
+					}`}
+				>
 					<span className="share-article-dialog__advanced-sharing-options--element-description">
 						Gift up to {monthlyAllowance} articles per month to single non-subscribers. You have {giftCredits}{' '}
 						articles left this month.

--- a/components/x-gift-article/storybook/index.jsx
+++ b/components/x-gift-article/storybook/index.jsx
@@ -215,3 +215,59 @@ export const ShareArticleModalWithAdvancedSharingFreeArticle = (args) => {
 ShareArticleModalWithAdvancedSharingFreeArticle.storyName = 'Share article modal (AS free article)'
 ShareArticleModalWithAdvancedSharingFreeArticle.args =
 	require('./share-article-modal-with-advanced-sharing-free-article').args
+
+export const ShareArticleModalWithAdvanceSharingMPRVersion = (args) => {
+	require('./share-article-modal-with-advanced-sharing-mpr-version').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalWithAdvanceSharingMPRVersion.storyName =
+	'Share article modal (B2B with Advanced Sharing, MPR version)'
+ShareArticleModalWithAdvanceSharingMPRVersion.args =
+	require('./share-article-modal-with-advanced-sharing-mpr-version').args
+
+export const ShareArticleModalWithAdvancedSharingNoEnterpriseCreditsMPRVersion = (args) => {
+	require('./share-article-modal-with-advanced-sharing-no-enterprise-credits-mpr').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalWithAdvancedSharingNoEnterpriseCreditsMPRVersion.storyName =
+	'Share article modal (AS no enterprise credits, MPR version)'
+ShareArticleModalWithAdvancedSharingNoEnterpriseCreditsMPRVersion.args =
+	require('./share-article-modal-with-advanced-sharing-no-enterprise-credits-mpr').args
+
+export const ShareArticleModalB2BMPRVersion = (args) => {
+	require('./share-article-modal-mpr-version').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalB2BMPRVersion.storyName = 'Share article modal (B2B, MPR version)'
+ShareArticleModalB2BMPRVersion.args = require('./share-article-modal-mpr-version').args
+
+export const ShareArticleModalB2BNoCreditsMPRVersion = (args) => {
+	require('./share-article-modal-no-credits-mpr-version').fetchMock(fetchMock)
+	return (
+		<div className="story-container">
+			{dependencies && <BuildService dependencies={dependencies} />}
+			<ShareArticleModal {...args} actionsRef={(actions) => actions?.activate()} />
+		</div>
+	)
+}
+
+ShareArticleModalB2BNoCreditsMPRVersion.storyName = 'Share article modal (B2B no credits, MPR version)'
+ShareArticleModalB2BNoCreditsMPRVersion.args = require('./share-article-modal-no-credits-mpr-version').args

--- a/components/x-gift-article/storybook/share-article-modal-mpr-version.js
+++ b/components/x-gift-article/storybook/share-article-modal-mpr-version.js
@@ -1,0 +1,46 @@
+const articleId = 'e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrl = 'https://www.ft.com/content/e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article',
+	isFreeArticle: false,
+	isMPRArticle: true,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
+	},
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	highlight:
+		'Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolorum quos, quis quas ad, minima fuga at nemo deleniti hic repellendus totam. Impedit mollitia quam repellat harum. Nostrum sapiente minima soluta , Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolorum quos, quis quas ad, minima fuga at nemo deleniti hic repellendus totam. Impedit mollitia quam repellat harum. Nostrum sapiente minima soluta.'
+}
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('path:/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`path:/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			redemptionLimit: 3,
+			remainingAllowance: 1
+		})
+		.get('path:/v1/users/me/allowance', 403)
+		.post('path:/v1/shares', {
+			url: articleUrlRedeemed,
+			redeemLimit: 120
+		})
+}

--- a/components/x-gift-article/storybook/share-article-modal-no-credits-mpr-version.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-no-credits-mpr-version.jsx
@@ -1,0 +1,44 @@
+const articleId = 'e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrl = 'https://www.ft.com/content/e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article',
+	isFreeArticle: false,
+	isMPRArticle: true,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
+	},
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`
+}
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('path:/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 20,
+			remainingCredits: 0,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`path:/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			redemptionLimit: 3,
+			remainingAllowance: 1
+		})
+		.get('path:/v1/users/me/allowance', 403)
+		.post('path:/v1/shares', {
+			url: articleUrlRedeemed,
+			redeemLimit: 120
+		})
+}

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-mpr-version.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-mpr-version.jsx
@@ -1,0 +1,50 @@
+const articleId = 'e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrl = 'https://www.ft.com/content/e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article using:',
+	isFreeArticle: false,
+	isMPRArticle: true,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
+	},
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	highlight:
+		'Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolorum quos, quis quas ad, minima fuga at nemo deleniti hic repellendus totam. Impedit mollitia quam repellat harum. Nostrum sapiente minima soluta , Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolorum quos, quis quas ad, minima fuga at nemo deleniti hic repellendus totam. Impedit mollitia quam repellat harum. Nostrum sapiente minima soluta.'
+}
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('path:/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 15,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`path:/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			redemptionLimit: 3,
+			remainingAllowance: 1
+		})
+		.get('path:/v1/users/me/allowance', {
+			limit: 120,
+			budget: 100,
+			hasCredits: true
+		})
+		.post('path:/v1/shares', {
+			url: articleUrlRedeemed,
+			redeemLimit: 120
+		})
+}

--- a/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-enterprise-credits-mpr.jsx
+++ b/components/x-gift-article/storybook/share-article-modal-with-advanced-sharing-no-enterprise-credits-mpr.jsx
@@ -1,0 +1,49 @@
+const articleId = 'e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrl = 'https://www.ft.com/content/e4b5ade3-01d1-4db8-b197-257051656684'
+const articleUrlRedeemed = 'https://enterprise-sharing.ft.com/gift-url-redeemed'
+const nonGiftArticleUrl = `${articleUrl}?shareType=nongift`
+
+exports.args = {
+	title: 'Share this article using:',
+	isFreeArticle: false,
+	isMPRArticle: true,
+	article: {
+		id: articleId,
+		url: articleUrl,
+		title: 'Equinor and Daimler Truck cut Russia ties as Volvo and JLR halt car deliveries'
+	},
+	id: 'base-gift-article-static-id',
+	enterpriseApiBaseUrl: `https://enterprise-sharing-api.ft.com`,
+	highlight:
+		'Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolorum quos, quis quas ad, minima fuga at nemo deleniti hic repellendus totam. Impedit mollitia quam repellat harum. Nostrum sapiente minima soluta , Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolorum quos, quis quas ad, minima fuga at nemo deleniti hic repellendus totam. Impedit mollitia quam repellat harum. Nostrum sapiente minima soluta.'
+}
+
+exports.fetchMock = (fetchMock) => {
+	fetchMock
+		.restore()
+		.get('path:/article/gift-credits', {
+			allowance: 20,
+			consumedCredits: 5,
+			remainingCredits: 0,
+			renewalDate: '2018-08-01T00:00:00Z'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(articleUrlRedeemed)}`, {
+			shortenedUrl: 'https://shortened-gift-url'
+		})
+		.get(`path:/article/shorten-url/${encodeURIComponent(nonGiftArticleUrl)}`, {
+			shortenedUrl: 'https://shortened-non-gift-url'
+		})
+		.get(`path:/article/gift-link/${encodeURIComponent(articleId)}`, {
+			redemptionUrl: articleUrlRedeemed,
+			redemptionLimit: 3,
+			remainingAllowance: 0
+		})
+		.get('path:/v1/users/me/allowance', {
+			limit: 120,
+			hasCredits: false
+		})
+		.post('path:/v1/shares', {
+			url: articleUrlRedeemed,
+			redeemLimit: 120
+		})
+}


### PR DESCRIPTION
## What's changed

The sharing functionality is now available for MPR articles, requiring some x-gift-article features to be hidden. 

-  A new prop `isMPRArticle` is passed to the modal when initialized in `next-article`  to indicate whether the article is MPR, based on its `editorialDesk` value
-  Sharing options toggler(`SharingOptionsToggler`) is hidden for MPR articles. Due to this change the title of `AdvancedSharingOptions` is hidden to match the design.  
- The copy in the header is changed to `Share this article using:` for users with Advanced Sharing access and `Share this article` for B2B users.
- Zero credits copy is also changed
- Added some styles to adjust the margins since the toggler is missing and the style of the modal looks disproportionate
- Adjusted the margin of the textarea after sharing the highlights 
- Added stories to storybook for different cases

## Link to Jira ticket
https://financialtimes.atlassian.net/browse/ENTST-1194

## Link to next-article PR
https://github.com/Financial-Times/next-article/pull/5777

## Screenshots

**B2B user with Advanced Sharing access**
|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/6163c441-6e7a-44f4-bc59-6bab7931af0b)|![image](https://github.com/user-attachments/assets/3f87a3cb-68e6-406f-87c2-cf3b614221bc)|
|![image](https://github.com/user-attachments/assets/9a3e6ffd-089a-401d-8d11-8a7a5f70f588)| ![image](https://github.com/user-attachments/assets/3494b172-fc2e-41d4-b559-1ecae093111a)| 

**B2B user without Advanced Sharing access**
|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/3c318889-7ec6-49ef-88f5-b25d39788d38)|![image](https://github.com/user-attachments/assets/f60087c5-154b-4f18-8ed8-1cab87fc70cb)
|![image](https://github.com/user-attachments/assets/50128743-fbb4-4d85-b295-47a8a729e5e7)|![image](https://github.com/user-attachments/assets/42a3c322-b6e5-403b-9e0a-2297464bf338)|


