### PR TITLE
ELES-1532 Advanced Sharing Gift Articles - wrong monthly allowance count for B2C customers with standard subscription

### DIFF
--- a/components/x-gift-article/src/AdvancedSharingOptions.jsx
+++ b/components/x-gift-article/src/AdvancedSharingOptions.jsx
@@ -3,7 +3,7 @@ import { ShareType } from './lib/constants'
 import { NoCreditAlert } from './NoCreditAlert'
 
 export const AdvancedSharingOptions = (props) => {
-	const { shareType, actions, enterpriseHasCredits, giftCredits } = props
+	const { shareType, actions, enterpriseHasCredits, giftCredits, monthlyAllowance } = props
 
 	const onValueChange = (event) => {
 		if (event.target.value === ShareType.enterprise) {
@@ -58,8 +58,8 @@ export const AdvancedSharingOptions = (props) => {
 									Gift article
 								</span>
 								<span className="share-article-dialog__advanced-sharing-options--element-description">
-									Gift up to 20 articles per month to single non-subscribers. You have {giftCredits} articles
-									left this month.
+									Gift up to {monthlyAllowance} articles per month to single non-subscribers. You have{' '}
+									{giftCredits} articles left this month.
 								</span>
 							</div>
 						</label>

--- a/components/x-gift-article/src/SharedLinkTypeSelector.jsx
+++ b/components/x-gift-article/src/SharedLinkTypeSelector.jsx
@@ -8,6 +8,7 @@ export const SharedLinkTypeSelector = (props) => {
 	const {
 		enterpriseEnabled,
 		giftCredits,
+		monthlyAllowance,
 		showNonSubscriberOptions,
 		showAdvancedSharingOptions,
 		isRegisteredUser
@@ -58,8 +59,8 @@ export const SharedLinkTypeSelector = (props) => {
 			{!showAdvancedSharingOptions && showNonSubscriberOptions && giftCredits > 0 && !isRegisteredUser && (
 				<div className="o-forms-input__label share-article-dialog__advanced-non-subscriber--element">
 					<span className="share-article-dialog__advanced-sharing-options--element-description">
-						Gift up to 20 articles per month to single non-subscribers. You have {giftCredits} articles left
-						this month.
+						Gift up to {monthlyAllowance} articles per month to single non-subscribers. You have {giftCredits}{' '}
+						articles left this month.
 					</span>
 				</div>
 			)}


### PR DESCRIPTION
The B2C customers with Standard subscription says it misleading to say they can gift up to 20 articles while only having 10 credits for Standard. The monthly allowance count of gift article (20 articles) was hardcoded in the `AdvancedSharingOptions` and `SharedLinkTypeSelector` components. But actually, we have already had information about the monthly allowance of gift articles for the given user. So, this actual count of gift article is used and issue is fixed with this PR. 

**Link to the reported issue in Slack** -> https://financialtimes.slack.com/archives/C03AKKF5A5R/p1736205606862409

| Before | After |
| ---- | ---- |
| <img width="1384" alt="Screenshot 2025-01-07 at 17 36 26" src="https://github.com/user-attachments/assets/b9e3afae-51e0-4959-9ab0-32b7d6a27ed9" /> | <img width="1382" alt="Screenshot 2025-01-07 at 17 10 36" src="https://github.com/user-attachments/assets/c6a88d00-29c7-4b7f-b825-6960034ada4a" /> |
