### PR TITLE
[AT-6904] Update n-myft-ui to support v37 which removes o-errors

### DIFF
--- a/components/x-follow-button/package.json
+++ b/components/x-follow-button/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@financial-times/n-myft-ui": "^35.0.0",
+    "@financial-times/n-myft-ui": "^37.0.0",
     "@financial-times/o-buttons": "^7.7.4",
     "@financial-times/o-colors": "^6.4.2",
     "@financial-times/o-icons": "^7.2.1",
@@ -26,7 +26,7 @@
     "sass": "^1.49.0"
   },
   "peerDependencies": {
-    "@financial-times/n-myft-ui": "^35.0.0",
+    "@financial-times/n-myft-ui": "^37.0.0",
     "@financial-times/o-buttons": "^7.7.4",
     "@financial-times/o-colors": "^6.4.2",
     "@financial-times/o-icons": "^7.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "classnames": "^2.2.6"
       },
       "devDependencies": {
-        "@financial-times/n-myft-ui": "^35.0.0",
+        "@financial-times/n-myft-ui": "^37.0.0",
         "@financial-times/o-buttons": "^7.7.4",
         "@financial-times/o-colors": "^6.4.2",
         "@financial-times/o-icons": "^7.2.1",
@@ -99,7 +99,7 @@
         "npm": "7.x || 8.x || 9.x || 10.x"
       },
       "peerDependencies": {
-        "@financial-times/n-myft-ui": "^35.0.0",
+        "@financial-times/n-myft-ui": "^37.0.0",
         "@financial-times/o-buttons": "^7.7.4",
         "@financial-times/o-colors": "^6.4.2",
         "@financial-times/o-icons": "^7.2.1",
@@ -108,9 +108,9 @@
       }
     },
     "components/x-follow-button/node_modules/@financial-times/n-myft-ui": {
-      "version": "35.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-35.0.0.tgz",
-      "integrity": "sha512-LXV68TYn+VjmrfO/k8bkDvvTLxGA5ZcID16Zy+KcTqGhju8wwM8OfdvuA/WunOj7dqZnNNf0KNcK+mxRrn5mUA==",
+      "version": "37.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-37.0.0.tgz",
+      "integrity": "sha512-tkjenBASMRcvB7pIS8zsAgF1U9D95c3Hk5JkQ6HWVyfH9/f4FzMVWtaAhR7YAWfu8z2k/aHS7eHb8cOZCp4uKg==",
       "dev": true,
       "dependencies": {
         "date-fns": "2.30.0",
@@ -123,14 +123,12 @@
         "superstore-sync": "^2.1.1"
       },
       "engines": {
-        "node": "16.x || 18.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 22.x"
       },
       "peerDependencies": {
         "@financial-times/n-notification": "^8.2.2",
         "@financial-times/o-buttons": "^7.7.3",
         "@financial-times/o-editorial-typography": "^2.3.2",
-        "@financial-times/o-errors": "^5.0.0",
         "@financial-times/o-forms": "^9.4.0",
         "@financial-times/o-grid": "^6.1.1",
         "@financial-times/o-normalise": "^3.3.0",
@@ -138,7 +136,7 @@
         "@financial-times/o-spacing": "^3.0.0",
         "@financial-times/o-tooltip": "^5.2.4",
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
-        "next-myft-client": "^12.2.0",
+        "next-myft-client": "^13.0.0",
         "react": "^17.0.2"
       }
     },
@@ -2884,19 +2882,6 @@
         "@financial-times/o-fonts": "^5.0.0",
         "@financial-times/o-spacing": "^3.0.0",
         "@financial-times/o-typography": "^7.4.1"
-      }
-    },
-    "node_modules/@financial-times/o-errors": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-errors/-/o-errors-5.2.3.tgz",
-      "integrity": "sha512-kyjMpnh3e/+j7VjWAel29SmVZBtma4TP/ovi7eYyQMUZfv+2EXSatbRM4oXbUvGJlScWmWLZlvpI7zonqWfhgw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "raven-js": "^3.27.2"
-      },
-      "engines": {
-        "npm": ">7"
       }
     },
     "node_modules/@financial-times/o-fonts": {
@@ -22842,9 +22827,9 @@
       "dev": true
     },
     "node_modules/next-myft-client": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-12.2.0.tgz",
-      "integrity": "sha512-b6kZtr0/GP2O95SHaVWb1KZ21GEoNh8+zfix6XoU5KUVuxfYvzIcndCcLLdH1qZrY6vq0gfXlDKRYxrDs7z3hQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-13.0.0.tgz",
+      "integrity": "sha512-Zje1ll3CEF9pH5A0NTf6HCZVfwG9d87vODw+OgJG6xwIPkXWuXkwiA+XqhvMdvdtae69R+gsqPZs8q7/QZhrnw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -22853,8 +22838,7 @@
         "next-session-client": "^4.0.0"
       },
       "engines": {
-        "node": "16.x || 18.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "node_modules/next-session-client": {
@@ -24938,14 +24922,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/raven-js": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.2.tgz",
-      "integrity": "sha512-mFWQcXnhRFEQe5HeFroPaEghlnqy7F5E2J3Fsab189ondqUzcjwSVi7el7F36cr6PvQYXoZ1P2F5CSF2/azeMQ==",
-      "deprecated": "Please upgrade to @sentry/browser. See the migration guide https://bit.ly/3ybOlo7",
-      "dev": true,
-      "peer": true
     },
     "node_modules/raw-body": {
       "version": "2.5.1",


### PR DESCRIPTION
Customer Products has ended its partnership with Sentry. As part of this transition, we are removing the @financial-times/o-errors package from ft-app.

Currently, @financial-times/n-myft-ui@^35.0.0 needs to be upgraded to v37 to support this change.

Changes
- Upgraded @financial-times/n-myft-ui from ^35.0.0 to ^37.0.0.
- The major changes between v35 and v37 include:
  - Node 20 support, I can see recently this repo has been updated to support Node 20 as well

So, the upgrade of `n-myft-ui` should be a seamless transition without causing much of an issue.

I have tested this by running the storybook as documented in the readme of `x-dash`. Please let me know if I have missed anything.

