### PR TITLE
Cp o3 migration extra

### DIFF
--- a/components/x-gift-article/package.json
+++ b/components/x-gift-article/package.json
@@ -33,14 +33,14 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "@financial-times/o-banner": "^4.4.9",
+    "@financial-times/o-banner": "^5.0.0",
     "@financial-times/o-forms": "^10.0.1",
-    "@financial-times/o-labels": "^6.2.2",
+    "@financial-times/o-labels": "^7.0.0",
     "@financial-times/o-loading": "^6.0.0",
     "@financial-times/o-message": "^6.0.0",
     "@financial-times/o-share": "^11.0.0",
+    "@financial-times/o-visual-effects": "^5.0.1",
     "@financial-times/o3-button": "^3.0.1",
-    "@financial-times/o3-foundation": "^3.1.0",
-    "@financial-times/o-visual-effects": "^5.0.1"
+    "@financial-times/o3-foundation": "^3.1.0"
   }
 }

--- a/components/x-topic-search/package.json
+++ b/components/x-topic-search/package.json
@@ -40,7 +40,6 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "@financial-times/o-editorial-typography": "^2.3.2",
     "@financial-times/o3-foundation": "^3.1.0"
   }
 }

--- a/components/x-topic-search/src/TopicSearch.scss
+++ b/components/x-topic-search/src/TopicSearch.scss
@@ -1,8 +1,6 @@
 @import '@financial-times/o3-foundation/css/core.css';
 $system-code: 'github:Financial-Times/x-dash' !default;
 
-@import '@financial-times/o-editorial-typography/main';
-
 @import '@financial-times/x-follow-button/src/styles/main';
 
 .x-topic-search {

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,9 +112,9 @@
         "npm": "7.x || 8.x || 9.x || 10.x"
       },
       "peerDependencies": {
-        "@financial-times/o-banner": "^4.4.9",
+        "@financial-times/o-banner": "^5.0.0",
         "@financial-times/o-forms": "^10.0.1",
-        "@financial-times/o-labels": "^6.2.2",
+        "@financial-times/o-labels": "^7.0.0",
         "@financial-times/o-loading": "^6.0.0",
         "@financial-times/o-message": "^6.0.0",
         "@financial-times/o-share": "^11.0.0",
@@ -2599,22 +2599,17 @@
       }
     },
     "node_modules/@financial-times/o-banner": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-banner/-/o-banner-4.5.2.tgz",
-      "integrity": "sha512-ZMZLPDmousPkboh0wB0BVnGcPpNTT00ESHnEY+NwoxYLA2wEr/xcCoL/P3tRgXsUuVhqYB81FDFLyD3C1Mj9kQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-banner/-/o-banner-5.0.0.tgz",
+      "integrity": "sha512-yGSLfoSknf4xuKb4fX/znA9DMFqlMC0JHXu0u61vDtvsJUqCss+9iK0JH2YE9KETRQf7SQMTfVt1hE+HExgO6g==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "npm": ">7"
       },
       "peerDependencies": {
         "@financial-times/math": "^1.0.0",
-        "@financial-times/o-buttons": "^7.8.0",
-        "@financial-times/o-colors": "^6.5.0",
-        "@financial-times/o-grid": "^6.0.0",
-        "@financial-times/o-icons": "^7.0.1",
-        "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-typography": "^7.4.1",
-        "@financial-times/o-visual-effects": "^4.0.1"
+        "@financial-times/o-private-foundation": "^1.0.0"
       }
     },
     "node_modules/@financial-times/o-brand": {
@@ -2624,22 +2619,6 @@
       "peer": true,
       "engines": {
         "npm": ">7"
-      }
-    },
-    "node_modules/@financial-times/o-buttons": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-buttons/-/o-buttons-7.9.1.tgz",
-      "integrity": "sha512-dyMU7P3FeG7VbmsuYo6WCBcKxeX3T7AomQgCQx8hJUyz0KB1DF607lLzsNFA8TcXsZ9KZEnFxsd1FW/wKj6AGw==",
-      "peer": true,
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/o-brand": "^4.1.0",
-        "@financial-times/o-colors": "^6.5.0",
-        "@financial-times/o-icons": "^7.0.0",
-        "@financial-times/o-normalise": "^3.3.0",
-        "@financial-times/o-typography": "^7.4.1"
       }
     },
     "node_modules/@financial-times/o-colors": {
@@ -2726,19 +2705,17 @@
       }
     },
     "node_modules/@financial-times/o-labels": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-labels/-/o-labels-6.5.8.tgz",
-      "integrity": "sha512-mPLAWuf3HRewwkQfcg5qvMHBCF17fKnlKeMHPERADAJCEGXZIAr53H4YnmKIcRsAmQHbtxE/ZFI80T1U7Q1j9Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-labels/-/o-labels-7.0.0.tgz",
+      "integrity": "sha512-st0ymO6yxppai/o7M3aurXyt5e55EJMFI8M4jFL6bCl3GAnbSU17TJ2ssJxteKYsrwolUiaHPXY6PyNrB2KPWA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "npm": ">7"
       },
       "peerDependencies": {
         "@financial-times/o-brand": "^4.1.0",
-        "@financial-times/o-colors": "^6.5.0",
-        "@financial-times/o-editorial-typography": "^2.0.1",
-        "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-typography": "^7.4.1"
+        "@financial-times/o-private-foundation": "^1.0.0"
       }
     },
     "node_modules/@financial-times/o-loading": {
@@ -2903,18 +2880,6 @@
       },
       "peerDependencies": {
         "@financial-times/o-utils": "^2.0.0"
-      }
-    },
-    "node_modules/@financial-times/o-visual-effects": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-visual-effects/-/o-visual-effects-4.2.2.tgz",
-      "integrity": "sha512-0o0JOR4a3ViMzJqNZLpl2hmMAHCbP0fnnN4Txee6aRLa6Hqk4TrtsJfu8dQsNe5jsarAJj+RdtV9sJTQ/xrkIw==",
-      "peer": true,
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/o-colors": "^6.5.0"
       }
     },
     "node_modules/@financial-times/o3-button": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -362,7 +362,6 @@
         "node": "16.x || 18.x || 20.x"
       },
       "peerDependencies": {
-        "@financial-times/o-editorial-typography": "^2.3.2",
         "@financial-times/o3-foundation": "^3.1.0"
       }
     },
@@ -2621,46 +2620,6 @@
         "npm": ">7"
       }
     },
-    "node_modules/@financial-times/o-colors": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-6.6.3.tgz",
-      "integrity": "sha512-f4aAlc9BjBOQGNREakxvKmLIP9wNo9epBh7YS3wPRSNReY9gIppezhANWJ0peFIWdX6x50oNT1R7pIifHiGKJg==",
-      "peer": true,
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/math": "^1.0.0",
-        "@financial-times/o-brand": "^4.0.1"
-      }
-    },
-    "node_modules/@financial-times/o-editorial-typography": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-editorial-typography/-/o-editorial-typography-2.4.1.tgz",
-      "integrity": "sha512-nK8S4afng5B+jPtIpzwY3Ezb7g1jA73+0UwNbXakc/cbasB8qkYWWMEelnkj03cncZEJsVxfxt/K4Ytt4bHGmA==",
-      "peer": true,
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/o-colors": "^6.5.0",
-        "@financial-times/o-fonts": "^5.0.0",
-        "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-typography": "^7.4.1"
-      }
-    },
-    "node_modules/@financial-times/o-fonts": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-fonts/-/o-fonts-5.3.5.tgz",
-      "integrity": "sha512-tZsQlzBd12RdhLU+H8eDgd7qzSueeUEzHoHBgl07+7dIaI9KUR3jH2p9/P0bget05hh36sVVfwyEN1A/awburA==",
-      "peer": true,
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/o-brand": "^4.1.0"
-      }
-    },
     "node_modules/@financial-times/o-forms": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-10.0.1.tgz",
@@ -2693,15 +2652,6 @@
       "peerDependencies": {
         "@financial-times/math": "^1.0.0",
         "@financial-times/sass-mq": "^5.0.2"
-      }
-    },
-    "node_modules/@financial-times/o-icons": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.7.1.tgz",
-      "integrity": "sha512-6JiHRtPJ33DIURX6ChzIJ/a0Tii12oL3Ow2OEdGghbtWbWgnbLt71ML9laz0bfQ50bpgRrsV2d3vObgW3yM1Gg==",
-      "peer": true,
-      "engines": {
-        "npm": ">7"
       }
     },
     "node_modules/@financial-times/o-labels": {
@@ -2746,19 +2696,6 @@
         "@financial-times/math": "^1.0.0",
         "@financial-times/o-brand": "^4.1.0",
         "@financial-times/o-private-foundation": "^1.0.0"
-      }
-    },
-    "node_modules/@financial-times/o-normalise": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.3.2.tgz",
-      "integrity": "sha512-k7/kw2zVAI6lVfQqI9Md/PIroZHhCZvXWHZoiP5Zih+JHqevjqIMDA35g8utaxVcwBKtZ5g6OmKDd3GDi+AU4w==",
-      "peer": true,
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/o-colors": "^6.0.1",
-        "@financial-times/sass-mq": "^5.0.2"
       }
     },
     "node_modules/@financial-times/o-overlay": {
@@ -2810,18 +2747,6 @@
         "@financial-times/o-private-foundation": "^1.0.0"
       }
     },
-    "node_modules/@financial-times/o-spacing": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-spacing/-/o-spacing-3.2.5.tgz",
-      "integrity": "sha512-U+4i//fd3qJHXgGRVEl0TkHK6Q5WUoXPsumBLSnWDW84jpXJic7kfpYGqyVP4sJpVAyq4FyLNu2L1oXopeHuDw==",
-      "peer": true,
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/math": "^1.0.0"
-      }
-    },
     "node_modules/@financial-times/o-tooltip": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-6.0.0.tgz",
@@ -2838,27 +2763,6 @@
         "@financial-times/o-overlay": "^5.0.0",
         "@financial-times/o-private-foundation": "^1.0.0",
         "@financial-times/o-viewport": "^5.1.2"
-      }
-    },
-    "node_modules/@financial-times/o-typography": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-typography/-/o-typography-7.6.1.tgz",
-      "integrity": "sha512-rhfdWd645YnAavGfeaBrO7XtKxkfuOOOnUKiP6cmymu4ypa6/vDXRGc8l17GvfhxVbD6KVjn9Z2WFD6E5ZM7tg==",
-      "peer": true,
-      "dependencies": {
-        "fontfaceobserver": "^2.0.9"
-      },
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/math": "^1.0.0",
-        "@financial-times/o-colors": "^6.6.0",
-        "@financial-times/o-fonts": "^5.0.0",
-        "@financial-times/o-grid": "^6.1.1",
-        "@financial-times/o-icons": "^7.0.0",
-        "@financial-times/o-normalise": "^3.3.0",
-        "@financial-times/o-spacing": "^3.0.0"
       }
     },
     "node_modules/@financial-times/o-utils": {
@@ -15541,12 +15445,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/focusable/-/focusable-2.3.0.tgz",
       "integrity": "sha512-e63a4CAb5yLbn4Scn0wG9F+rEq4ZcbggRc9pD3hufAWf8y8dpZImdIES8YNUufRpKB+p0JS+BRd8RBU+sLAeIw==",
-      "peer": true
-    },
-    "node_modules/fontfaceobserver": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
-      "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
       "peer": true
     },
     "node_modules/for-each": {


### PR DESCRIPTION
This is a supplementary PR to the original CP O3 Migration PR which can be found [here](https://github.com/Financial-Times/x-dash/pull/818). 

This PR bumps the versions of `o-labels`, and `o-banner` in `x-gift-article` and removes the use of `o-editorial-typography` from `x-topic-search`, that were missed in the original PR.  
