### PR TITLE
fix: Fix x-privacy-manager to respond to interaction

### DIFF
--- a/components/x-privacy-manager/src/components/radio-btn.jsx
+++ b/components/x-privacy-manager/src/components/radio-btn.jsx
@@ -19,7 +19,7 @@ export function RadioBtn({ name, type, checked, trackingKeys, buttonText, onChan
 	return (
 		<div className="x-privacy-manager-radio-button">
 			<input
-				className="o3-visually-hidden"
+				className="o3-visually-hidden x-privacy-manager-radio-button__input"
 				id={id}
 				type="radio"
 				name={name}


### PR DESCRIPTION
Fixed radio button component in privacy manager  by reverting the class that was removed during o3 migration for it to respond to user interaction.

This was spotted during the work of https://financialtimes.atlassian.net/browse/CPO3-39