### PR TITLE
CULT-126: Only create MetaLink elements when metadata exists

### DIFF
--- a/components/x-teaser/src/MetaLink.jsx
+++ b/components/x-teaser/src/MetaLink.jsx
@@ -17,19 +17,20 @@ export default ({ metaPrefixText, metaLink, metaAltLink, metaSuffixText, context
 	const displayLink = useAltLink ? metaAltLink : metaLink
 
 	return (
-		<div className="o-teaser__meta">
-			{showPrefixText ? <span className="o-teaser__tag-prefix">{metaPrefixText}</span> : null}
-			{displayLink?.prefLabel ? (
+		displayLink?.prefLabel && (
+			<div className="o-teaser__meta">
+				{showPrefixText ? <span className="o-teaser__tag-prefix">{metaPrefixText}</span> : null}
 				<a
 					className="o-teaser__tag"
 					data-trackable="teaser-tag"
 					data-trackable-context-story-link="teaser-tag"
 					href={displayLink.relativeUrl || displayLink.url}
-					aria-label={`Category: ${displayLink.prefLabel}`}>
+					aria-label={`Category: ${displayLink.prefLabel}`}
+				>
 					{displayLink.prefLabel}
 				</a>
-			) : null}
-			{showSuffixText ? <span className="o-teaser__tag-suffix">{metaSuffixText}</span> : null}
-		</div>
+				{showSuffixText ? <span className="o-teaser__tag-suffix">{metaSuffixText}</span> : null}
+			</div>
+		)
 	)
 }


### PR DESCRIPTION
This PR prevents the rendering of empty `<MetaLink>` elements in teasers by ensuring they are only created when the relevant metadata is available.

The issue was observed in `ft-app` homepage spotlight slice, but it could potentially occur in any teaser if the content has no metadata.

While it's rare for content to have no metadata (i.e. no annotations), it can happen, this change helps ensure the component handles it more appropriately when it does occur.

|Desktop|Mobile|
|---|---|
|<img width="720" height="331" alt="image-20241223-091132" src="https://github.com/user-attachments/assets/18fae684-f893-4571-8804-b4b7d321a2bd" />|<img width="558" height="720" alt="image-20241223-091118" src="https://github.com/user-attachments/assets/c7167ba6-e539-4162-89b1-04ad0d127dc9" />|

This issue could happen on any teaser
|Before|After|
|---|---|
|<img width="1395" height="661" alt="SCR-20251002-nlsm" src="https://github.com/user-attachments/assets/0b000ea7-98ea-4216-a3bc-0a915fd39be3" />|<img width="1339" height="704" alt="SCR-20251002-nnee" src="https://github.com/user-attachments/assets/df9fb157-e7f8-40ec-b797-b22d789fdf04" />|



[[Jira ticket](https://financialtimes.atlassian.net/browse/CULT-126)]